### PR TITLE
Document strategy for branching, merging, and commit messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Please make sure to give branches a meaningful name!
 
 ### Commits
 
-While it is nice to have each individual commit pass the build, this is not a requirement - it is the developer's branch to play on.
+While it is nice to have each individual commit pass the build, this is not a requirement - it is the contributor's branch to play on.
 
 As a general rule, the style and formatting of commit messages should follow the [guidelines for good Git commit messages](http://chris.beams.io/posts/git-commit/).
 Because of the noise it generates on the issue, please do _not_ mention the issue number in the message.
@@ -61,4 +61,4 @@ Ideally, this title line should not exceed 50 characters - 70 is the absolute ma
 This can usually be a summary of the issue description and commit messages.
 Markdown syntax can be used and lines should usually not exceed 72 characters (exceptions are possible, e.g. to include stack traces).
 
-Once a pull request is ready to be merged, the developer will be asked to propose an action and body for the squashed commit and the maintainer will refine them when merging.
+Once a pull request is ready to be merged, the contributor will be asked to propose an action and body for the squashed commit and the maintainer will refine them when merging.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ By default development happens in branches, which are merged via pull requests -
 Special cases, like fixing problems with the CI pipeline, are of course exempt from this guideline.
 
 Please make sure to give branches a meaningful name!
+As an example, the one creating this documentation was called `branching-merging-documentation`.
 
 ### Commits
 
@@ -58,7 +59,29 @@ It is followed by a comma-separated list of all related issues, a dash, and the 
 Ideally, this title line should not exceed 50 characters - 70 is the absolute maximum.
 
 `<Body>` should outline the problem the pull request was solving - it should focus on _why_ the code was written not on _how_ it works.
-This can usually be a summary of the issue description and commit messages.
+This can usually be a summary of the issue description and discussion as well as commit messages.
 Markdown syntax can be used and lines should usually not exceed 72 characters (exceptions are possible, e.g. to include stack traces).
 
 Once a pull request is ready to be merged, the contributor will be asked to propose an action and body for the squashed commit and the maintainer will refine them when merging.
+
+As an example, the squashed commit that created this documentation had the following message:
+
+```
+Document branching and merging (#30, #31 / #40)
+
+To make sure the project has a sensible and helpful commit history and
+interacts well with GitHub's features the strategy used for branching,
+commit messages, and merging must be chosen carefully and deliberately.
+The following aspects are particularly important:
+
+ - a history that is accessible, detailed, and of high quality
+ - backlinks from commits to isses and PRs without creating
+   "notification noise" in the web interface
+ - reduce necessity for maintainers policing contributors' commit
+   messages
+
+The chosen approach to squash and merge fulfills all of them except
+the detailed history, which will be more coarse than with merge commits
+or fast-forward merges. This was deemed acceptable in order to achieve
+the other points, particularly the last one.
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,13 +12,53 @@
 * Whatever content you contribute will be provided under the project
   license(s).
 
-## Commit Messages
+## Branching, Committing, Pull Requesting, and Merging
 
-As a general rule, the style and formatting of commit messages should follow
-the guidelines in
-[How to Write a Git Commit Message](http://chris.beams.io/posts/git-commit/).
+### Branching Strategy
 
-## Pull Requests
+By default development happens in branches, which are merged via pull requests - this also applies to core committers.
+Special cases, like fixing problems with the CI pipeline, are of course exempt from this guideline.
 
-The [pull requests template](.github/PULL_REQUEST_TEMPLATE.md) contains a
-footer that must not be edited or removed.
+Please make sure to give branches a meaningful name!
+
+### Commits
+
+While it is nice to have each individual commit pass the build, this is not a requirement - it is the developer's branch to play on.
+
+As a general rule, the style and formatting of commit messages should follow the [guidelines for good Git commit messages](http://chris.beams.io/posts/git-commit/).
+Because of the noise it generates on the issue, please do _not_ mention the issue number in the message.
+
+### Pull Requests
+
+Pull requests are used to discuss a concrete solution, not the motivation nor requirements for it.
+As such there should be at least one issue a pull request relates to.
+At the same time it should be focused so it should usually not relate to more than one issue (although that can occasionally happen).
+Please mention all issues in the request's body, possibly using [closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) like `closes`, `fixes` (for bugs only), or `resolves`.
+
+The [pull requests template](.github/PULL_REQUEST_TEMPLATE.md) contains a footer that must not be edited or removed.
+
+To enforce the [branching strategy](#branching-strategy) pull requests from `master` will be closed.
+
+### Merging
+
+A pull request is accepted by squashing the commits and fast-forwarding master, making each bug fix or feature appear atomically on master.
+This can be achieved with GitHub's [_squash and merge_](https://help.github.com/articles/about-pull-request-merges/#squash-and-merge-your-pull-request-commits) feature.
+
+To make the single commit expressive its message must be detailed and [good]((http://chris.beams.io/posts/git-commit/)) (really, read that post!).
+Furthermore, it must follow this structure:
+
+```
+<Action> (<issues> / <pull-request>)
+
+<Body>
+```
+
+`<Action>` should succinctly describe what the PR does in good Git style.
+It is followed by a comma-separated list of all related issues, a dash, and the pull request (to make all of them easy to find from a look at the log).
+Ideally, this title line should not exceed 50 characters - 70 is the absolute maximum.
+
+`<Body>` should outline the problem the pull request was solving - it should focus on _why_ the code was written not on _how_ it works.
+This can usually be a summary of the issue description and commit messages.
+Markdown syntax can be used and lines should usually not exceed 72 characters (exceptions are possible, e.g. to include stack traces).
+
+Once a pull request is ready to be merged, the developer will be asked to propose an action and body for the squashed commit and the maintainer will refine them when merging.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,10 @@
 # Contributing
 
+The following guidelines were chosen very deliberately to make sure the project benefits from contributions.
+This is true for such diverse areas as a firm legal foundation or a sensible and helpful commit history.
+
+The guidelines apply to maintainers as well as contributors!
+
 ## Io Contributor License Agreement
 
 **Project License:**  [Apache License v2.0](LICENSE.md)
@@ -16,7 +21,7 @@
 
 ### Branching Strategy
 
-By default development happens in branches, which are merged via pull requests - this also applies to core committers.
+By default development happens in branches, which are merged via pull requests.
 Special cases, like fixing problems with the CI pipeline, are of course exempt from this guideline.
 
 Please make sure to give branches a meaningful name!

--- a/README.md
+++ b/README.md
@@ -11,3 +11,8 @@ A melting pot for all kinds of extensions to
 🚧 Much of this project is still under construction. 🚧
 
 ***
+
+## Contributing
+
+We welcome contributions of all kinds and shapes!
+We are still building up infrastructure and what exactly we need help on is not easy to say, but we already settled and [what we want contributions to look like](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -6,4 +6,8 @@
 A melting pot for all kinds of extensions to
 [JUnit 5](https://github.com/junit-team/junit5), particular to its Jupiter API.
 
-:construction: UNDER CONSTRUCTION :construction:
+***
+
+🚧 Much of this project is still under construction. 🚧
+
+***


### PR DESCRIPTION
After coming to terms on [how to branch and merge](https://github.com/junit-pioneer/junit-pioneer/issues/30#issuecomment-298891508) (closes #30) and [when to mention issues](https://github.com/junit-pioneer/junit-pioneer/issues/31#issuecomment-298892406) (closes #31), I am documenting both decisions in `CONTRIBUTING.md`.

---

I hereby agree to the terms of the [Io Contributor License Agreement](../CONTRIBUTING.md#io-contributor-license-agreement).