### PR TITLE
Use Gradle properties

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
 deploy:
   skip_cleanup: true
   provider: script
-  script: ./gradlew publish -P snapshotRepoPass=$SNAPSHOT_REPO_PASS --stacktrace
+  script: ./gradlew publish -P mavenUserName=$MAVEN_USER_NAME -P mavenPassword=$MAVEN_PASSWORD --stacktrace
   on:
     branch: master
     jdk: oraclejdk8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,3 +87,24 @@ the detailed history, which will be more coarse than with merge commits
 or fast-forward merges. This was deemed acceptable in order to achieve
 the other points, particularly the last one.
 ```
+
+
+## Publishing
+
+### Snapshots
+
+To publish snapshots to Maven Central you need to execute `gradle publish` after defining the properties `mavenUserName` and `mavenPassword`.
+
+One way to do the latter are [Gradle properties](https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_properties_and_system_properties).
+For that approach, create a file `gradle.properties` in `GRADLE_USER_HOME` (which defaults to `USER_HOME/.gradle`) with the following content:
+
+```
+mavenUserName=...
+mavenPassword=...
+```
+
+Another way are command line flags (but note that these add sensitive information to your terminal history):
+
+```
+gradle publish -PmavenUserName=... -PmavenPassword=...
+```

--- a/README.md
+++ b/README.md
@@ -15,4 +15,24 @@ A melting pot for all kinds of extensions to
 ## Contributing
 
 We welcome contributions of all kinds and shapes!
-We are still building up infrastructure and what exactly we need help on is not easy to say, but we already settled and [what we want contributions to look like](CONTRIBUTING.md).
+We are still building up infrastructure and what exactly we need help on is not easy to say, but we already settled on [what we want contributions to look like](CONTRIBUTING.md).
+
+## Setup
+
+### Publishing Snapshots
+
+To publish snapshots to Maven Central you need to execute `gradle publish` after defining the properties `mavenUserName` and `mavenPassword`.
+
+One way to do the latter are [Gradle properties](https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_properties_and_system_properties).
+For that approach, create a file `gradle.properties` in `GRADLE_USER_HOME` (which defaults to `USER_HOME/.gradle`) with the following content:
+
+```
+mavenUserName=...
+mavenPassword=...
+```
+
+Another way are command line flags (but note that these add sensitive information to your terminal history):
+
+```
+gradle publish -PmavenUserName=--- -PmavenPassword=---
+```

--- a/README.md
+++ b/README.md
@@ -16,23 +16,3 @@ A melting pot for all kinds of extensions to
 
 We welcome contributions of all kinds and shapes!
 We are still building up infrastructure and what exactly we need help on is not easy to say, but we already settled on [what we want contributions to look like](CONTRIBUTING.md).
-
-## Setup
-
-### Publishing Snapshots
-
-To publish snapshots to Maven Central you need to execute `gradle publish` after defining the properties `mavenUserName` and `mavenPassword`.
-
-One way to do the latter are [Gradle properties](https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_properties_and_system_properties).
-For that approach, create a file `gradle.properties` in `GRADLE_USER_HOME` (which defaults to `USER_HOME/.gradle`) with the following content:
-
-```
-mavenUserName=...
-mavenPassword=...
-```
-
-Another way are command line flags (but note that these add sensitive information to your terminal history):
-
-```
-gradle publish -PmavenUserName=--- -PmavenPassword=---
-```

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,13 @@ apply plugin: 'maven-publish'
 
 sourceCompatibility = 1.8
 
+ext {
+    // assign empty user name and password, so Gradle does not fail due to
+    // missing properties when eagerly configuring the Maven credentials
+    mavenUserName = project.findProperty('mavenUserName') ?: ''
+    mavenPassword = project.findProperty('mavenPassword') ?: ''
+}
+
 repositories {
     mavenCentral()
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }

--- a/build.gradle
+++ b/build.gradle
@@ -9,11 +9,6 @@ apply plugin: 'maven-publish'
 
 sourceCompatibility = 1.8
 
-ext {
-    // the password needs to be specified via command line
-    snapshotRepoPass = project.hasProperty('snapshotRepoPass') ? project.getProperty('snapshotRepoPass') : ''
-}
-
 repositories {
     mavenCentral()
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
@@ -145,8 +140,8 @@ publishing {
         maven {
             url 'https://oss.sonatype.org/content/repositories/snapshots/'
             credentials {
-                username "nipa"
-                password project.snapshotRepoPass
+                username mavenUserName
+                password mavenPassword
             }
         }
     }


### PR DESCRIPTION
Maven user name and password can now be defined as `gradle.properties` _or_ as command line properties.

Closes #46.

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](../CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
