### PR TITLE
Release to Maven Central

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
 deploy:
   skip_cleanup: true
   provider: script
-  script: ./gradlew publishCompletePublicationToMavenSnapshotRepository -P mavenUserName=$MAVEN_USER_NAME -P mavenPassword=$MAVEN_PASSWORD --stacktrace
+  script: ./gradlew publishSnapshot -P mavenUserName=$MAVEN_USER_NAME -P mavenPassword=$MAVEN_PASSWORD --stacktrace
   on:
     branch: master
     jdk: oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
 deploy:
   skip_cleanup: true
   provider: script
-  script: ./gradlew publish -P mavenUserName=$MAVEN_USER_NAME -P mavenPassword=$MAVEN_PASSWORD --stacktrace
+  script: ./gradlew publishCompletePublicationToMavenSnapshotRepository -P mavenUserName=$MAVEN_USER_NAME -P mavenPassword=$MAVEN_PASSWORD --stacktrace
   on:
     branch: master
     jdk: oraclejdk8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,9 @@ This is true for such diverse areas as a firm legal foundation or a sensible and
 	* [Unavoidable Changes](#unavoidable-changes)
 	* [Optional Changes](#optional-changes)
 * [Publishing](#publishing)
+	* [Credentials](#credentials)
 	* [Snapshots](#snapshots)
+	* [Releases](#releases)
 
 The guidelines apply to maintainers as well as contributors!
 
@@ -142,11 +144,13 @@ The final commit message should reference the upstream change (issue and pull re
 
 ## Publishing
 
-### Snapshots
+Because `gradle publish` tries to execute all publications (e.g. snapshots _and_ releases), it is deactivated.
+Instead use the more specific tasks described below.
 
-To publish snapshots to Maven Central you need to execute `gradle publish` after defining the properties `mavenUserName` and `mavenPassword`.
+### Credentials
 
-One way to do the latter are [Gradle properties](https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_properties_and_system_properties).
+For any release you need the properties `mavenUserName` and `mavenPassword` to contain your credentials for the Sonatype repositories.
+One way to define them is [a Gradle properties file](https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_properties_and_system_properties).
 For that approach, create a file `gradle.properties` in `GRADLE_USER_HOME` (which defaults to `USER_HOME/.gradle`) with the following content:
 
 ```
@@ -159,3 +163,33 @@ Another way are command line flags (but note that these add sensitive informatio
 ```
 gradle publish -PmavenUserName=... -PmavenPassword=...
 ```
+
+Furthermore, non-snapshot releases require signed artifacts, for which the following properties have to be defined:
+
+```
+signing.keyId= # last eight digits of key ID
+signing.password= # password for the key
+signing.secretKeyRingFile= # path to local secring.gpg
+```
+
+For details on these have a look at the [Gradle Signing Plugin's documentation](https://docs.gradle.org/current/userguide/signing_plugin.html#sec:signatory_credentials).
+
+### Snapshots
+
+To publish a snapshot version simply execute `gradle publishSnapshot`.
+This will fail if the current project version does not end in `-SNAPSHOT`.
+
+### Releases
+
+To publish a new release, go through the following check list:
+
+* you should be operating on the `master` branch and have no uncommitted changes
+* the version must not end in `-SNAPSHOT`
+* no dependency on snapshot versions
+
+If everything's in order, execute `gradle publishRelease`.
+
+After a successful release do the following:
+
+* tag the current HEAD as a release and upload all artifacts to GitHub
+* go to the next snapshot version and commit the change

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,10 @@ ext {
 
 repositories {
     mavenCentral()
-    maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
+    maven {
+        name "MavenSnapshot"
+        url 'https://oss.sonatype.org/content/repositories/snapshots/'
+    }
 }
 
 dependencies {
@@ -35,8 +38,14 @@ dependencies {
 buildscript {
     repositories {
         mavenLocal()
-        maven { url 'https://plugins.gradle.org/m2/' }
-        maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
+        maven {
+            name "GradlePlugins"
+            url 'https://plugins.gradle.org/m2/'
+        }
+        maven {
+            name "MavenSnapshot"
+            url 'https://oss.sonatype.org/content/repositories/snapshots/'
+        }
     }
 
     dependencies {
@@ -92,7 +101,7 @@ javadoc.shouldRunAfter test
 
 publishing {
     publications {
-        mavenJava(MavenPublication) {
+        complete(MavenPublication) {
             from components.java
 
             artifact sourceJar
@@ -144,7 +153,9 @@ publishing {
         }
     }
     repositories {
+        mavenCentral()
         maven {
+            name "MavenSnapshot"
             url 'https://oss.sonatype.org/content/repositories/snapshots/'
             credentials {
                 username mavenUserName

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ apply plugin: 'com.diffplug.gradle.spotless'
 apply plugin: 'checkstyle'
 apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: 'maven-publish'
+apply plugin: 'signing'
 
 sourceCompatibility = 1.8
 
@@ -14,6 +15,7 @@ ext {
     // missing properties when eagerly configuring the Maven credentials
     mavenUserName = project.findProperty('mavenUserName') ?: ''
     mavenPassword = project.findProperty('mavenPassword') ?: ''
+    isReleaseVersion = !version.endsWith('-SNAPSHOT')
 }
 
 repositories {
@@ -100,7 +102,7 @@ check.dependsOn javadoc
 javadoc.shouldRunAfter test
 
 // create sources and JavaDoc JARs
-task sourceJar(type: Jar, dependsOn: classes) {
+task sourcesJar(type: Jar, dependsOn: classes) {
     classifier 'sources'
     from sourceSets.main.allSource
 }
@@ -110,13 +112,83 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     from javadoc.destinationDir
 }
 
+artifacts {
+    archives javadocJar, sourcesJar
+}
+
+// sign POM and archives
+task signPom(type: Sign, dependsOn: 'generatePomFileForCompletePublication') {
+    sign file('build/publications/complete/pom-default.xml')
+}
+signing {
+    sign configurations.archives
+}
+signArchives.dependsOn signPom
+
+// make sure specific tasks are used instead of the overly encompassing `gradle publish`
+task publishSnapshot {
+    dependsOn 'publishCompletePublicationToMavenSnapshotRepository'
+}
+task publishRelease {
+    dependsOn 'publishCompletePublicationToMavenRepository'
+}
+tasks.whenTaskAdded{ task ->
+    // all publication tasks should require a successful build
+    if (task instanceof PublishToMavenRepository)
+        task.dependsOn(check)
+    // because maven-publish creates its tasks very late,
+    // this was the only way I found to add the dependency to signing
+    if (task.name == "publishCompletePublicationToMavenRepository")
+        task.dependsOn(signArchives)
+}
+gradle.taskGraph.whenReady { taskGraph ->
+    def tasks = taskGraph.getAllTasks()
+    if (tasks.find { it.name == 'publish' })
+        throw new GradleException('''
+                ---------------------------------------------------------------------------
+                DON'T USE `gradle publish`!
+
+                It will try to publish a snapshot _and_ a release, which doesn't work well.
+                Instead use either `gradle publishSnapshot` or `gradle publishRelease`.
+                ---------------------------------------------------------------------------
+               ''')
+    if (tasks.find { it.name == 'publishSnapshot' } && isReleaseVersion)
+        throw new GradleException('''
+                ------------------------------------------------------------
+                DON'T USE `gradle publishSnapshot` ON NON-SNAPSHOT VERSIONS!
+
+                Maybe you're looking for `gradle publishRelease`?
+                ------------------------------------------------------------
+               ''')
+    if (tasks.find { it.name == 'publishRelease' } && !isReleaseVersion)
+        throw new GradleException('''
+                -------------------------------------------------------
+                DON'T USE `gradle publishRelease` ON SNAPSHOT VERSIONS!
+
+                Maybe you're looking for `gradle publishSnapshot`?
+                -------------------------------------------------------
+               ''')
+}
+
 publishing {
     publications {
         complete(MavenPublication) {
             from components.java
 
-            artifact sourceJar
+            artifact sourcesJar
             artifact javadocJar
+
+            // only include signatures for releases
+            if (isReleaseVersion) {
+                artifact source: "build/libs/${rootProject.name}-${rootProject.version}.jar.asc",
+                        extension: 'jar.asc'
+                artifact source: project.tasks.signPom.signatureFiles.collect { it }[0],
+                        extension: 'pom.asc'
+                artifact source: "build/libs/${rootProject.name}-${rootProject.version}-sources.jar.asc",
+                        classifier: 'sources', extension: 'jar.asc'
+                artifact source: "build/libs/${rootProject.name}-${rootProject.version}-javadoc.jar.asc",
+                        classifier: 'javadoc', extension: 'jar.asc'
+            }
 
             tasks.withType(Jar) {
                 from(project.projectDir) {
@@ -127,7 +199,6 @@ publishing {
 
             pom.withXml {
                 asNode().with {
-                    appendNode('packaging', 'jar')
                     appendNode('name', 'JUnit Pioneer')
                     appendNode('description', 'JUnit 5 Extension Pack')
                     appendNode('url', 'https://github.com/junit-pioneer/junit-pioneer')

--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,14 @@ signing {
 }
 signArchives.dependsOn signPom
 
+// The task "assemble" and by extension "build" depends on signing, which leads to
+// problems on machines that have no signatories configured (e.g. AppVeyor). For
+// that reason we want to skip signing unless it is actually required for publication.
+// Unfortunately there seems to be no way to remove a dependency (in this case from
+// "assemble" to "signArchives"), so we disable the task and enable it when required.
+signArchives.enabled = false
+signPom.enabled = false
+
 // make sure specific tasks are used instead of the overly encompassing `gradle publish`
 task publishSnapshot {
     dependsOn 'publishCompletePublicationToMavenSnapshotRepository'
@@ -138,8 +146,12 @@ tasks.whenTaskAdded{ task ->
         task.dependsOn(check)
     // because maven-publish creates its tasks very late,
     // this was the only way I found to add the dependency to signing
-    if (task.name == "publishCompletePublicationToMavenRepository")
+    if (task.name == "publishCompletePublicationToMavenRepository") {
         task.dependsOn(signArchives)
+        // activate the signing tasks (we deactivated them above)
+        signArchives.enabled = true
+        signPom.enabled = true
+    }
 }
 gradle.taskGraph.whenReady { taskGraph ->
     def tasks = taskGraph.getAllTasks()

--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,17 @@ check.dependsOn javadoc
 // it should ran last, though
 javadoc.shouldRunAfter test
 
+// create sources and JavaDoc JARs
+task sourceJar(type: Jar, dependsOn: classes) {
+    classifier 'sources'
+    from sourceSets.main.allSource
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
 publishing {
     publications {
         complete(MavenPublication) {
@@ -153,7 +164,14 @@ publishing {
         }
     }
     repositories {
-        mavenCentral()
+        maven {
+            name "Maven"
+            url 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+            credentials {
+                username mavenUserName
+                password mavenPassword
+            }
+        }
         maven {
             name "MavenSnapshot"
             url 'https://oss.sonatype.org/content/repositories/snapshots/'
@@ -163,16 +181,6 @@ publishing {
             }
         }
     }
-}
-
-task sourceJar(type: Jar, dependsOn: classes) {
-    classifier 'sources'
-    from sourceSets.main.allSource
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
 }
 
 configure(rootProject) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'org.junit-pioneer'
-version '1.0-SNAPSHOT'
+version '0.1-SNAPSHOT'
 
 apply plugin: 'java'
 apply plugin: 'com.diffplug.gradle.spotless'


### PR DESCRIPTION
First work on using Gradle and [maven-publish](https://docs.gradle.org/3.5/userguide/publishing_maven.html) to publish to Maven Central - closes #17. ToDos:

* technical:
    * [x] stage JAR on Maven central
    * [x] stage POM, sources, and JavaDoc
    * [x] sign all artifacts and stage signatures
* other:
    * [x] document release workflow
    * [x] write commit message
    * [x] create follow-up issue to further automate release ~> #53

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](../CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
