### PR TITLE
Create blueprints for project site and documentation

### DIFF
--- a/docs/disabled.adoc
+++ b/docs/disabled.adoc
@@ -1,6 +1,4 @@
----
-title: Disabling Tests
----
+:page-title: Disabling Tests
 
 = Sample Page
 :uri-asciidoctor: http://asciidoctor.org

--- a/docs/disabled.adoc
+++ b/docs/disabled.adoc
@@ -1,0 +1,12 @@
+---
+title: Disabling Tests
+---
+
+= Sample Page
+:uri-asciidoctor: http://asciidoctor.org
+
+This is a sample page composed in AsciiDoc.
+Jekyll converts it to HTML using {uri-asciidoctor}[Asciidoctor].
+
+[source,ruby]
+puts "Hello, World!"

--- a/docs/docs-nav.yml
+++ b/docs/docs-nav.yml
@@ -1,0 +1,4 @@
+  - title: Features
+    children:
+      - title: Disabling Tests
+        url: /docs/disabled/

--- a/docs/docs-page.adoc
+++ b/docs/docs-page.adoc
@@ -1,0 +1,10 @@
+---
+layout: single
+permalink: /docs/
+header:
+  overlay_color: black
+  overlay_image: assets/site_images/type-writer.jpg
+title: Documentation
+---
+
+Once we have features, they'll be documented here. :wink:

--- a/docs/docs-page.adoc
+++ b/docs/docs-page.adoc
@@ -1,10 +1,1 @@
----
-layout: single
-permalink: /docs/
-header:
-  overlay_color: black
-  overlay_image: assets/site_images/type-writer.jpg
-title: Documentation
----
-
 Once we have features, they'll be documented here. :wink:

--- a/docs/project-page.adoc
+++ b/docs/project-page.adoc
@@ -1,12 +1,10 @@
 ---
-layout: single
-permalink: /junit-pioneer/
-header:
-  overlay_color: black
-  overlay_image: assets/site_images/pioneer-full.jpg
-title: JUnit Pioneer
 excerpt: 'JUnit 5 extension pack, pushing the frontiers on Jupiter.<br /> <small><a href="https://github.com/junit-pioneer/junit-pioneer/releases">First release coming soon!</a></small><br /><br /> {::nomarkdown}<iframe style="display: inline-block;" src="https://ghbtns.com/github-btn.html?user=junit-pioneer&repo=junit-pioneer&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160px" height="30px"></iframe> <iframe style="display: inline-block;" src="https://ghbtns.com/github-btn.html?user=junit-pioneer&repo=junit-pioneer&type=fork&count=true&size=large" frameborder="0" scrolling="0" width="158px" height="30px"></iframe>{:/nomarkdown}'
 ---
+:page-layout: single
+:page-permalink: /junit-pioneer/
+:page-header: { overlay_image: {site-images}/pioneer-full.jpg }
+:page-title: JUnit Pioneer
 
 JUnit Pioneer is an http://blog.codefx.org/design/architecture/junit-5-extension-model/[extension pack] for JUnit 5 or, to be http://blog.codefx.org/design/architecture/junit-5-architecture/[more precise], for the Jupiter engine.
 It is currently being set up, so this site as well as the repo is a little shy on content - we hope to fix that soon!
@@ -15,4 +13,4 @@ There are various ways to help us get there if you're interested:
 
 * if you have an idea for an extension you could make good use of, https://github.com/junit-pioneer/junit-pioneer/issues/new[open an issue]
 * if you already wrote some code and would like to release it as part of JUnit Pioneer, which is an awesome idea, please also https://github.com/junit-pioneer/junit-pioneer/issues/new[open an issue] (rather than a pull request)
-* if you want to contribute but aren't sure how, have a look at https://github.com/junit-pioneer/junit-pioneer/issues[the list of open issues], particularly those https://github.com/junit-pioneer/junit-pioneer/issues?q=is%3Aissue+is%3Aopen+label%3Aup-for-grabs[marked as _up fpr grabs_]
+* if you want to contribute but aren't sure how, have a look at https://github.com/junit-pioneer/junit-pioneer/issues[the list of open issues], particularly those https://github.com/junit-pioneer/junit-pioneer/issues?q=is%3Aissue+is%3Aopen+label%3Aup-for-grabs[marked as _up for grabs_]

--- a/docs/project-page.adoc
+++ b/docs/project-page.adoc
@@ -1,0 +1,18 @@
+---
+layout: single
+permalink: /junit-pioneer/
+header:
+  overlay_color: black
+  overlay_image: assets/site_images/pioneer-full.jpg
+title: JUnit Pioneer
+excerpt: 'JUnit 5 extension pack, pushing the frontiers on Jupiter.<br /> <small><a href="https://github.com/junit-pioneer/junit-pioneer/releases">First release coming soon!</a></small><br /><br /> {::nomarkdown}<iframe style="display: inline-block;" src="https://ghbtns.com/github-btn.html?user=junit-pioneer&repo=junit-pioneer&type=star&count=true&size=large" frameborder="0" scrolling="0" width="160px" height="30px"></iframe> <iframe style="display: inline-block;" src="https://ghbtns.com/github-btn.html?user=junit-pioneer&repo=junit-pioneer&type=fork&count=true&size=large" frameborder="0" scrolling="0" width="158px" height="30px"></iframe>{:/nomarkdown}'
+---
+
+JUnit Pioneer is an http://blog.codefx.org/design/architecture/junit-5-extension-model/[extension pack] for JUnit 5 or, to be http://blog.codefx.org/design/architecture/junit-5-architecture/[more precise], for the Jupiter engine.
+It is currently being set up, so this site as well as the repo is a little shy on content - we hope to fix that soon!
+
+There are various ways to help us get there if you're interested:
+
+* if you have an idea for an extension you could make good use of, https://github.com/junit-pioneer/junit-pioneer/issues/new[open an issue]
+* if you already wrote some code and would like to release it as part of JUnit Pioneer, which is an awesome idea, please also https://github.com/junit-pioneer/junit-pioneer/issues/new[open an issue] (rather than a pull request)
+* if you want to contribute but aren't sure how, have a look at https://github.com/junit-pioneer/junit-pioneer/issues[the list of open issues], particularly those https://github.com/junit-pioneer/junit-pioneer/issues?q=is%3Aissue+is%3Aopen+label%3Aup-for-grabs[marked as _up fpr grabs_]


### PR DESCRIPTION
The bulk of the work for a project site is done in [junit-pioneer.github.io](https://github.com/junit-pioneer/junit-pioneer.github.io) but it relies on project-specific files to fill the site and particularly the documentation with content. This PR shows what such files would look like:

* pages and documentation can be written in Asciidoc
* a sidebar menu for the documentation is enabled and must be maintained manually
* a project page and documentation page are required

The work in the .io repository makes sure that these files are automatically put in the right places, so the effort within this project should be fairly small. It would be nice to get feedback on whether the features provided here seem reasonable or lacking something that is needed from the start.

Relates to #11 and #19 but closes neither.

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](../CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
