### PR TITLE
 Introduce TempDirectory Jupiter Extension

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
 
     testCompile group: 'org.assertj', name: 'assertj-core', version: '3.5.2'
     testCompile group: 'org.mockito', name: 'mockito-core', version: '2.2.1'
+    testCompile group: 'com.google.jimfs', name: 'jimfs', version: '1.1'
 
     testRuntime group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.0'
     testRuntime group: 'org.apache.logging.log4j', name: 'log4j-jul', version: '2.11.0'

--- a/docs/docs-nav.yml
+++ b/docs/docs-nav.yml
@@ -2,3 +2,5 @@
     children:
       - title: Vintage @Test
         url: /docs/vintage-test/
+      - title: TempDirectory
+        url: /docs/temp-directory/

--- a/docs/temp-directory.adoc
+++ b/docs/temp-directory.adoc
@@ -1,0 +1,50 @@
+:page-title: TempDirectory
+:page-description: JUnit Jupiter extension to create and clean up a temporary directory.
+
+The `TempDirectory` extension can be used to create and clean up a temporary directory for an individual test or all tests in a test class.
+To use it, simply register the extension and add a parameter of type `java.nio.file.Path` to your test or lifecycle method or constructor.
+
+For example, the following test registers the extension for a single test method, creates and writes a file to the temporary directory and checks its content.
+
+[source,java]
+----
+@Test
+@ExtendWith(TempDirectory.class)
+void test(@TempDir Path tempDir) {
+    Path file = tempDir.resolve("test.txt");
+    writeFile(file);
+    assertExpectedFileContent(file);
+}
+----
+
+In addition to the default file system, the extension can be used with any `FileSystem` implementation, e.g. https://github.com/google/jimfs[Jimfs].
+In order to use a custom file system, simply register the extension programmatically and pass a provider of a custom parent directory of type `Path`.
+The following example uses the Jimfs `FileSystem` and passes a custom `tmp` parent directory to the `TempDirectory` constructor.
+
+[source,java]
+----
+class MyTests {
+    private static FileSystem fileSystem;
+
+    @BeforeAll
+    static void createFileSystem() {
+        fileSystem = Jimfs.newFileSystem();
+    }
+
+    @AfterAll
+    static void closeFileSystem() throws Exception {
+        fileSystem.close();
+    }
+
+    @RegisterExtension
+    Extension tempDirectory = new TempDirectory(() ->
+        Files.createDirectories(fileSystem.getPath("tmp")));
+
+    @Test
+    void test(@TempDir Path tempDir) {
+        Path file = tempDir.resolve("test.txt");
+        writeFile(file);
+        assertExpectedFileContent(file);
+    }
+}
+----

--- a/docs/temp-directory.adoc
+++ b/docs/temp-directory.adoc
@@ -19,7 +19,7 @@ void test(@TempDir Path tempDir) {
 
 In addition to the default file system, the extension can be used with any `FileSystem` implementation, e.g. https://github.com/google/jimfs[Jimfs].
 In order to use a custom file system, simply register the extension programmatically and pass a provider of a custom parent directory of type `Path`.
-The following example uses the Jimfs `FileSystem` and passes a custom `tmp` parent directory to the `TempDirectory` constructor.
+The following example uses the Jimfs `FileSystem` and passes a custom `tmp` parent directory to the static factory method `TempDirectory::createInCustomDirectory`.
 
 [source,java]
 ----
@@ -37,7 +37,7 @@ class MyTests {
     }
 
     @RegisterExtension
-    Extension tempDirectory = new TempDirectory(() ->
+    Extension tempDirectory = TempDirectory.createInCustomDirectory(() ->
         Files.createDirectories(fileSystem.getPath("tmp")));
 
     @Test

--- a/src/main/java/org/junit$pioneer/jupiter/TempDirectory.java
+++ b/src/main/java/org/junit$pioneer/jupiter/TempDirectory.java
@@ -235,6 +235,7 @@ public class TempDirectory implements ParameterResolver {
 		Path parentDir;
 		try {
 			parentDir = parentDirProvider.get(parameterContext, extensionContext);
+			requireNonNull(parentDir);
 		}
 		catch (Exception ex) {
 			throw new ParameterResolutionException("Failed to get parent directory from provider", ex);

--- a/src/main/java/org/junit$pioneer/jupiter/TempDirectory.java
+++ b/src/main/java/org/junit$pioneer/jupiter/TempDirectory.java
@@ -79,8 +79,6 @@ import org.junit.jupiter.api.extension.ParameterResolver;
  */
 public class TempDirectory implements ParameterResolver {
 
-	private static final String TEMP_DIR_PREFIX = "junit";
-
 	/**
 	 * {@code TempDir} can be used to annotate a test or lifecycle method or
 	 * test class constructor parameter of type {@link Path} that should be
@@ -131,6 +129,7 @@ public class TempDirectory implements ParameterResolver {
 
 	private static final Namespace NAMESPACE = Namespace.create(TempDirectory.class);
 	private static final String KEY = "temp.dir";
+	private static final String TEMP_DIR_PREFIX = "junit";
 
 	private final TempDirProvider tempDirProvider;
 
@@ -152,7 +151,7 @@ public class TempDirectory implements ParameterResolver {
 	}
 
 	/**
-	 * Returns a {@code TempDirectory} extension that uses the default
+	 * Create a new {@code TempDirectory} extension that uses the default
 	 * {@link java.nio.file.FileSystem FileSystem} and creates temporary
 	 * directories in the default location.
 	 *
@@ -168,7 +167,7 @@ public class TempDirectory implements ParameterResolver {
 	}
 
 	/**
-	 * Returns a {@code TempDirectory} extension that uses the supplied
+	 * Create a new {@code TempDirectory} extension that uses the supplied
 	 * {@link ParentDirProvider} to configure the parent directory for the
 	 * temporary directories created by this extension.
 	 *
@@ -187,7 +186,7 @@ public class TempDirectory implements ParameterResolver {
 	}
 
 	/**
-	 * Returns a {@code TempDirectory} extension that uses the supplied
+	 * Create a new {@code TempDirectory} extension that uses the supplied
 	 * {@link Callable} to configure the parent directory for the temporary
 	 * directories created by this extension.
 	 *
@@ -248,7 +247,7 @@ public class TempDirectory implements ParameterResolver {
 		}
 	}
 
-	static class CloseablePath implements CloseableResource {
+	private static class CloseablePath implements CloseableResource {
 
 		private final Path dir;
 

--- a/src/main/java/org/junit$pioneer/jupiter/TempDirectory.java
+++ b/src/main/java/org/junit$pioneer/jupiter/TempDirectory.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit$pioneer.jupiter;
+
+import static java.nio.file.FileVisitResult.CONTINUE;
+
+import java.io.IOException;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Objects;
+import java.util.concurrent.Callable;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+/**
+ * {@code TempDirectory} is a JUnit Jupiter extension to create and clean up a
+ * temporary directory.
+ *
+ * <p>The temporary directory is only created if a test or lifecycle method or
+ * test class constructor has a parameter annotated with
+ * {@link TempDir @TempDir}. If the parameter type is not {@link Path} or if the
+ * temporary directory could not be created, this extension will throw a
+ * {@link ParameterResolutionException}.
+ *
+ * <p>The scope of the temporary directory depends on where the first
+ * {@link TempDir @TempDir} annotation is encountered when executing a test
+ * class. The temporary directory will be shared by all tests in a class when
+ * the annotation is present on a parameter of a
+ * {@link org.junit.jupiter.api.BeforeAll @BeforeAll} method or the test class
+ * constructor. Otherwise, e.g. when only used on test or
+ * {@link org.junit.jupiter.api.BeforeEach @BeforeEach} or
+ * {@link org.junit.jupiter.api.AfterEach @AfterEach} methods, each test will
+ * use its own temporary directory.
+ *
+ * <p>When the end of the scope of a temporary directory is reached, i.e. when
+ * the test method or class has finished execution, this extension will attempt
+ * to recursively delete all files and directories in the temporary directory
+ * and, finally, the temporary directory itself. In case deletion of a file or
+ * directory fails, this extension will throw an {@link IOException} that will
+ * cause the test to fail.
+ *
+ * <p>By default, this extension will use the default
+ * {@link java.nio.file.FileSystem FileSystem} to create temporary directories
+ * in the default location. However, you may instantiate this extension using
+ * the {@link TempDirectory#TempDirectory(ParentDirProvider) TempDirectory(ParentDirProvider)}
+ * or {@link TempDirectory#TempDirectory(Callable)} constructor and register it
+ * via {@link org.junit.jupiter.api.extension.RegisterExtension @RegisterExtension}
+ * to pass a custom provider to configure the parent directory for all temporary
+ * directories created by this extension. This allows the use of this extension
+ * with any third-party {@code FileSystem} implementation, e.g.
+ * <a href="https://github.com/google/jimfs">Jimfs</a>.
+ *
+ * @since 0.1
+ * @see TempDir
+ * @see ParentDirProvider
+ * @see Files#createTempDirectory
+ */
+public class TempDirectory implements ParameterResolver {
+
+	/**
+	 * {@code TempDir} can be used to annotate a test or lifecycle method or
+	 * test class constructor parameter of type {@link Path} that should be
+	 * resolved into a temporary directory.
+	 *
+	 * @see TempDirectory
+	 */
+	@Target(ElementType.PARAMETER)
+	@Retention(RetentionPolicy.RUNTIME)
+	@Documented
+	public @interface TempDir {
+	}
+
+	/**
+	 * {@code ParentDirProvider} can be used to configure a custom parent
+	 * directory for all temporary directories created by the
+	 * {@link TempDirectory} extension this is used with.
+	 *
+	 * @see org.junit.jupiter.api.extension.RegisterExtension
+	 * @see TempDirectory#TempDirectory(ParentDirProvider)
+	 */
+	@FunctionalInterface
+	public interface ParentDirProvider {
+		/**
+		 * Get the parent directory for all temporary directories created by the
+		 * {@link TempDirectory} extension this is used with.
+		 *
+		 * @return the parent directory for all temporary directories; must be
+		 * {@code null} or an existing directory.
+		 */
+		Path get(ParameterContext parameterContext, ExtensionContext extensionContext) throws Exception;
+	}
+
+	private static final Namespace NAMESPACE = Namespace.create(TempDirectory.class);
+	private static final String KEY = "temp.dir";
+
+	private final ParentDirProvider parentDirProvider;
+
+	/**
+	 * Create a new {@code TempDirectory} extension that uses the default
+	 * {@link java.nio.file.FileSystem FileSystem} and creates temporary
+	 * directories in the default location.
+	 *
+	 * <p>This constructor is used by the JUnit Jupiter Engine when the
+	 * extension is registered via
+	 * {@link org.junit.jupiter.api.extension.ExtendWith @ExtendWith}.
+	 */
+	public TempDirectory() {
+		this((parameterContext, extensionContext) -> null);
+	}
+
+	/**
+	 * Create a new {@code TempDirectory} extension that uses the supplied
+	 * {@link Callable} to configure the parent directory for the temporary
+	 * directories created by this extension.
+	 *
+	 * <p>The parent directory returned by the supplied {@link Callable} must
+	 * be {@code null} or an existing directory.
+	 *
+	 * <p>You may use this constructor when registering this extension via
+	 * {@link org.junit.jupiter.api.extension.RegisterExtension @RegisterExtension}.
+	 *
+	 * @param parentDirProvider used to configure the parent directory for the
+	 * temporary directories created by this extension; never {@code null}
+	 */
+	public TempDirectory(Callable<Path> parentDirProvider) {
+		this((parameterContext, extensionContext) -> parentDirProvider.call());
+	}
+
+	/**
+	 * Create a new {@code TempDirectory} extension that uses the supplied
+	 * {@link ParentDirProvider} to configure the parent directory for the
+	 * temporary directories created by this extension.
+	 *
+	 * <p>You may use this constructor when registering this extension via
+	 * {@link org.junit.jupiter.api.extension.RegisterExtension @RegisterExtension}.
+	 *
+	 * @param parentDirProvider used to configure the parent directory for the
+	 * temporary directories created by this extension; never {@code null}
+	 */
+	public TempDirectory(ParentDirProvider parentDirProvider) {
+		this.parentDirProvider = Objects.requireNonNull(parentDirProvider);
+	}
+
+	@Override
+	public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+		return parameterContext.isAnnotated(TempDir.class);
+	}
+
+	@Override
+	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
+		Class<?> parameterType = parameterContext.getParameter().getType();
+		if (parameterType != Path.class) {
+			throw new ParameterResolutionException(
+				"Can only resolve parameter of type " + Path.class.getName() + " but was: " + parameterType.getName());
+		}
+		return extensionContext.getStore(NAMESPACE) //
+				.getOrComputeIfAbsent(KEY, key -> createCloseablePath(parameterContext, extensionContext),
+					CloseablePath.class) //
+				.get();
+	}
+
+	private CloseablePath createCloseablePath(ParameterContext parameterContext, ExtensionContext extensionContext) {
+		Path parentDir = getParentDirFromProvider(parameterContext, extensionContext);
+		try {
+			String prefix = "junit";
+			Path tempDirectory = (parentDir == null) ? Files.createTempDirectory(prefix)
+					: Files.createTempDirectory(parentDir, prefix);
+			return new CloseablePath(tempDirectory);
+		}
+		catch (Exception e) {
+			throw new ParameterResolutionException("Failed to create temp directory", e);
+		}
+	}
+
+	private Path getParentDirFromProvider(ParameterContext parameterContext, ExtensionContext extensionContext) {
+		try {
+			return parentDirProvider.get(parameterContext, extensionContext);
+		}
+		catch (Exception ex) {
+			throw new ParameterResolutionException("Failed to get parent directory from provider", ex);
+		}
+	}
+
+	static class CloseablePath implements CloseableResource {
+
+		private final Path dir;
+
+		CloseablePath(Path dir) {
+			this.dir = dir;
+		}
+
+		Path get() {
+			return dir;
+		}
+
+		@Override
+		public void close() throws IOException {
+			Files.walkFileTree(dir, new SimpleFileVisitor<Path>() {
+
+				@Override
+				public FileVisitResult visitFile(Path file, BasicFileAttributes attributes) throws IOException {
+					return deleteAndContinue(file);
+				}
+
+				@Override
+				public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+					return deleteAndContinue(dir);
+				}
+
+				private FileVisitResult deleteAndContinue(Path path) throws IOException {
+					try {
+						Files.delete(path);
+					}
+					catch (IOException ex) {
+						throw new IOException(
+							"Failed to delete temp directory " + dir.toAbsolutePath() + " at: " + path.toAbsolutePath(),
+							ex);
+					}
+					return CONTINUE;
+				}
+			});
+		}
+	}
+}

--- a/src/main/java/org/junit$pioneer/jupiter/TempDirectory.java
+++ b/src/main/java/org/junit$pioneer/jupiter/TempDirectory.java
@@ -151,7 +151,7 @@ public class TempDirectory implements ParameterResolver {
 	}
 
 	/**
-	 * Create a new {@code TempDirectory} extension that uses the default
+	 * Returns a {@code TempDirectory} extension that uses the default
 	 * {@link java.nio.file.FileSystem FileSystem} and creates temporary
 	 * directories in the default location.
 	 *
@@ -167,7 +167,7 @@ public class TempDirectory implements ParameterResolver {
 	}
 
 	/**
-	 * Create a new {@code TempDirectory} extension that uses the supplied
+	 * Returns a {@code TempDirectory} extension that uses the supplied
 	 * {@link ParentDirProvider} to configure the parent directory for the
 	 * temporary directories created by this extension.
 	 *
@@ -186,7 +186,7 @@ public class TempDirectory implements ParameterResolver {
 	}
 
 	/**
-	 * Create a new {@code TempDirectory} extension that uses the supplied
+	 * Returns a {@code TempDirectory} extension that uses the supplied
 	 * {@link Callable} to configure the parent directory for the temporary
 	 * directories created by this extension.
 	 *

--- a/src/main/java/org/junit$pioneer/jupiter/package-info.java
+++ b/src/main/java/org/junit$pioneer/jupiter/package-info.java
@@ -3,7 +3,7 @@
  *
  * <p>Check out the following types for details:
  * <ul>
- *     <li>n.a.</li>
+ *     <li>{@link org.junit$pioneer.jupiter.TempDirectory}</li>
  * </ul>
  */
 

--- a/src/test/java/org/junit$pioneer/jupiter/TempDirectoryTests.java
+++ b/src/test/java/org/junit$pioneer/jupiter/TempDirectoryTests.java
@@ -378,7 +378,7 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 		}
 
 		@RegisterExtension
-		Extension tempDirectory = new TempDirectory(
+		Extension tempDirectory = TempDirectory.createInCustomDirectory(
 			() -> Files.createDirectories(fileSystem.getPath("tmp")));
 
 	}
@@ -386,7 +386,7 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 	static class ParentDirFromProviderTestCase extends BaseSeparateTempDirsTestCase {
 
 		@RegisterExtension
-		Extension tempDirectory = new TempDirectory((parameterContext, extensionContext) -> {
+		Extension tempDirectory = TempDirectory.createInCustomDirectory((parameterContext, extensionContext) -> {
 			Store store = extensionContext.getRoot().getStore(Namespace.GLOBAL);
 			FileSystem fileSystem = store.getOrComputeIfAbsent("jimfs.fileSystem", key -> new JimfsFileSystemResource(),
 				JimfsFileSystemResource.class).get();
@@ -427,7 +427,7 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 		}
 
 		@RegisterExtension
-		Extension tempDirectory = new TempDirectory(() -> fileSystem.getPath("tmp"));
+		Extension tempDirectory = TempDirectory.createInCustomDirectory(() -> fileSystem.getPath("tmp"));
 
 		@Test
 		void test(@TempDir Path tempDir) {
@@ -457,7 +457,7 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 		}
 
 		@RegisterExtension
-		Extension tempDirectory = new TempDirectory(() -> fileSystem.getPath("tmp"));
+		Extension tempDirectory = TempDirectory.createInCustomDirectory(() -> fileSystem.getPath("tmp"));
 
 		@Test
 		void test(@TempDir Path tempDir) {
@@ -470,7 +470,7 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 		private FileSystem fileSystem = mock(FileSystem.class);
 
 		@RegisterExtension
-		Extension tempDirectory = new TempDirectory(() -> {
+		Extension tempDirectory = TempDirectory.createInCustomDirectory(() -> {
 			throw new IOException("something went horribly wrong");
 		});
 

--- a/src/test/java/org/junit$pioneer/jupiter/TempDirectoryTests.java
+++ b/src/test/java/org/junit$pioneer/jupiter/TempDirectoryTests.java
@@ -158,7 +158,7 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 
 	@Nested
 	@DisplayName("reports failure")
-	class Foo {
+	class Failures {
 
 		@Test
 		@DisplayName("when @TempDir is used on parameter of wrong type")

--- a/src/test/java/org/junit$pioneer/jupiter/TempDirectoryTests.java
+++ b/src/test/java/org/junit$pioneer/jupiter/TempDirectoryTests.java
@@ -1,0 +1,484 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junit$pioneer.jupiter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.platform.engine.TestExecutionResult.Status.FAILED;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.Optional;
+
+import com.google.common.jimfs.Jimfs;
+
+import org.junit$pioneer.AbstractPioneerTestEngineTests;
+import org.junit$pioneer.jupiter.TempDirectory.TempDir;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.test.event.ExecutionEvent;
+import org.junit.platform.engine.test.event.ExecutionEventRecorder;
+
+@DisplayName("TempDirectory extension")
+class TempDirectoryTests extends AbstractPioneerTestEngineTests {
+
+	@BeforeEach
+	@AfterEach
+	void resetStaticVariables() {
+		BaseSharedTempDirTestCase.tempDir = null;
+		BaseSeparateTempDirsTestCase.tempDirs.clear();
+	}
+
+	@Nested
+	@DisplayName("resolves shared temp dir")
+	class SharedTempDir {
+
+		@Test
+		@DisplayName("when @TempDir is used on constructor parameter")
+		void resolvesSharedTempDirWhenAnnotationIsUsedOnConstructorParameter() {
+			assertResolvesShareTempDir(AnnotationOnConstructorParameterTestCase.class);
+		}
+
+		@Test
+		@DisplayName("when @TempDir is used on @BeforeAll method parameter")
+		void resolvesSharedTempDirWhenAnnotationIsUsedOnBeforeAllMethodParameter() {
+			assertResolvesShareTempDir(AnnotationOnBeforeAllMethodParameterTestCase.class);
+		}
+
+		@Test
+		@DisplayName("when @TempDir is used on constructor parameter with @TestInstance(PER_CLASS)")
+		void resolvesSharedTempDirWhenAnnotationIsUsedOnConstructorParameterWithTestInstancePerClass() {
+			assertResolvesShareTempDir(AnnotationOnConstructorParameterWithTestInstancePerClassTestCase.class);
+		}
+
+		@Test
+		@DisplayName("when @TempDir is used on @BeforeAll method parameter with @TestInstance(PER_CLASS)")
+		void resolvesSharedTempDirWhenAnnotationIsUsedOnBeforeAllMethodParameterWithTestInstancePerClass() {
+			assertResolvesShareTempDir(AnnotationOnBeforeAllMethodParameterWithTestInstancePerClassTestCase.class);
+		}
+
+		private void assertResolvesShareTempDir(Class<? extends BaseSharedTempDirTestCase> testClass) {
+			ExecutionEventRecorder executionEventRecorder = executeTests(testClass);
+
+			assertEquals(2, executionEventRecorder.getTestStartedCount());
+			assertEquals(0, executionEventRecorder.getTestFailedCount());
+			assertEquals(2, executionEventRecorder.getTestSuccessfulCount());
+			assertThat(BaseSharedTempDirTestCase.tempDir).doesNotExist();
+		}
+	}
+
+	@Nested
+	@DisplayName("resolves separate temp dirs")
+	class SeparateTempDirs {
+
+		@Test
+		@DisplayName("for @AfterAll method parameter when @TempDir is not used on constructor or @BeforeAll method parameter")
+		void resolvesSeparateTempDirWhenAnnotationIsUsedOnAfterAllMethodParameterOnly() {
+			ExecutionEventRecorder executionEventRecorder = executeTests(
+				AnnotationOnAfterAllMethodParameterTestCase.class);
+
+			assertEquals(1, executionEventRecorder.getTestStartedCount());
+			assertEquals(0, executionEventRecorder.getTestFailedCount());
+			assertEquals(1, executionEventRecorder.getTestSuccessfulCount());
+			assertThat(AnnotationOnAfterAllMethodParameterTestCase.firstTempDir).doesNotExist();
+			assertThat(AnnotationOnAfterAllMethodParameterTestCase.secondTempDir).doesNotExist();
+		}
+
+		@Test
+		@DisplayName("when @TempDir is used on @BeforeEach/@AfterEach method parameters")
+		void resolvesSeparateTempDirsWhenUsedOnForEachLifecycleMethods() {
+			assertResolvesSeparateTempDirs(SeparateTempDirsWhenUsedOnForEachLifecycleMethodsTestCase.class);
+			assertThat(BaseSeparateTempDirsTestCase.tempDirs.getFirst()).doesNotExist();
+			assertThat(BaseSeparateTempDirsTestCase.tempDirs.getLast()).doesNotExist();
+		}
+
+		@Test
+		@DisplayName("when @TempDir is used on @BeforeEach/@AfterEach method parameters with @TestInstance(PER_CLASS)")
+		void resolvesSeparateTempDirsWhenUsedOnForEachLifecycleMethodsWithTestInstancePerClass() {
+			assertResolvesSeparateTempDirs(
+				SeparateTempDirsWhenUsedOnForEachLifecycleMethodsWithTestInstancePerClassTestCase.class);
+			assertThat(BaseSeparateTempDirsTestCase.tempDirs.getFirst()).doesNotExist();
+			assertThat(BaseSeparateTempDirsTestCase.tempDirs.getLast()).doesNotExist();
+		}
+	}
+
+	@Nested
+	@DisplayName("resolves temp dir with custom parent dir")
+	class WithCustomParentDir {
+		@Test
+		@DisplayName("from Callable<Path>")
+		void resolvesTempDirWithCustomParentDirFromCallable() {
+			assertResolvesSeparateTempDirs(ParentDirFromCallableTestCase.class);
+		}
+
+		@Test
+		@DisplayName("from ParentDirProvider")
+		void resolvesTempDirWithCustomParentDirFromProvider() {
+			assertResolvesSeparateTempDirs(ParentDirFromProviderTestCase.class);
+		}
+	}
+
+	@Nested
+	@DisplayName("reports failure")
+	class Foo {
+
+		@Test
+		@DisplayName("when @TempDir is used on parameter of wrong type")
+		void onlySupportsParametersOfTypePath() {
+			ExecutionEventRecorder executionEventRecorder = executeTests(InvalidTestCase.class);
+
+			assertSingleFailedTest(executionEventRecorder, ParameterResolutionException.class,
+				"Can only resolve parameter of type java.nio.file.Path");
+		}
+
+		@Test
+		@DisplayName("when attempt to create temp dir fails")
+		void failedCreationAttemptMakesTestFail() {
+			ExecutionEventRecorder executionEventRecorder = executeTests(FailedCreationAttemptTestCase.class);
+
+			assertSingleFailedTest(executionEventRecorder, ParameterResolutionException.class,
+				"Failed to create temp directory");
+		}
+
+		@Test
+		@DisplayName("when attempt to delete temp dir fails")
+		void failedDeletionAttemptMakesTestFail() {
+			ExecutionEventRecorder executionEventRecorder = executeTests(FailedDeletionAttemptTestCase.class);
+
+			assertSingleFailedTest(executionEventRecorder, IOException.class, "Failed to delete temp directory");
+		}
+
+		@Test
+		@DisplayName("when attempt to get parent dir from ParentDirProvider fails")
+		void erroneousParentDirProviderMakesTestFail() {
+			ExecutionEventRecorder executionEventRecorder = executeTests(ErroneousParentDirProviderTestCase.class);
+
+			assertSingleFailedTest(executionEventRecorder, ParameterResolutionException.class,
+				"Failed to get parent directory");
+		}
+
+		private void assertSingleFailedTest(ExecutionEventRecorder executionEventRecorder,
+				Class<? extends Throwable> clazz, String message) {
+			assertEquals(1, executionEventRecorder.getTestStartedCount());
+			assertEquals(1, executionEventRecorder.getTestFailedCount());
+			assertEquals(0, executionEventRecorder.getTestSuccessfulCount());
+
+			ExecutionEvent executionEvent = executionEventRecorder.getFailedTestFinishedEvents().get(0);
+			Optional<TestExecutionResult> result = executionEvent.getPayload(TestExecutionResult.class);
+			assertThat(result).isPresent();
+			assertThat(result.get().getStatus()).isEqualTo(FAILED);
+			Optional<Throwable> throwable = result.get().getThrowable();
+			assertThat(throwable).containsInstanceOf(clazz);
+			assertThat(throwable.get()).hasMessageContaining(message);
+		}
+	}
+
+	private void assertResolvesSeparateTempDirs(Class<? extends BaseSeparateTempDirsTestCase> testClass) {
+		ExecutionEventRecorder executionEventRecorder = executeTests(testClass);
+
+		assertEquals(2, executionEventRecorder.getTestStartedCount());
+		assertEquals(0, executionEventRecorder.getTestFailedCount());
+		assertEquals(2, executionEventRecorder.getTestSuccessfulCount());
+		Deque<Path> tempDirs = BaseSeparateTempDirsTestCase.tempDirs;
+		assertThat(tempDirs).hasSize(2);
+	}
+
+	@ExtendWith(TempDirectory.class)
+	static class BaseSharedTempDirTestCase {
+		static Path tempDir;
+
+		@BeforeEach
+		void beforeEach(@TempDir Path tempDir) {
+			check(tempDir);
+		}
+
+		@Test
+		void test1(@TempDir Path tempDir, TestInfo testInfo) throws Exception {
+			check(tempDir);
+			writeFile(tempDir, testInfo);
+		}
+
+		@Test
+		void test2(TestInfo testInfo, @TempDir Path tempDir) throws Exception {
+			check(tempDir);
+			writeFile(tempDir, testInfo);
+		}
+
+		@AfterEach
+		void afterEach(@TempDir Path tempDir) {
+			check(tempDir);
+		}
+
+		static void check(Path tempDir) {
+			assertSame(BaseSharedTempDirTestCase.tempDir, tempDir);
+			assertTrue(Files.exists(tempDir));
+		}
+	}
+
+	static class AnnotationOnConstructorParameterTestCase extends BaseSharedTempDirTestCase {
+		AnnotationOnConstructorParameterTestCase(@TempDir Path tempDir) {
+			if (BaseSharedTempDirTestCase.tempDir == null) {
+				BaseSharedTempDirTestCase.tempDir = tempDir;
+			}
+			else {
+				assertSame(BaseSharedTempDirTestCase.tempDir, tempDir);
+			}
+			check(tempDir);
+		}
+	}
+
+	static class AnnotationOnBeforeAllMethodParameterTestCase extends BaseSharedTempDirTestCase {
+		@BeforeAll
+		static void beforeAll(@TempDir Path tempDir) {
+			assertNull(BaseSharedTempDirTestCase.tempDir);
+			BaseSharedTempDirTestCase.tempDir = tempDir;
+			check(tempDir);
+		}
+	}
+
+	@TestInstance(PER_CLASS)
+	static class AnnotationOnConstructorParameterWithTestInstancePerClassTestCase
+			extends AnnotationOnConstructorParameterTestCase {
+		AnnotationOnConstructorParameterWithTestInstancePerClassTestCase(@TempDir Path tempDir) {
+			super(tempDir);
+		}
+	}
+
+	@TestInstance(PER_CLASS)
+	static class AnnotationOnBeforeAllMethodParameterWithTestInstancePerClassTestCase
+			extends AnnotationOnBeforeAllMethodParameterTestCase {
+	}
+
+	@ExtendWith(TempDirectory.class)
+	static class AnnotationOnAfterAllMethodParameterTestCase {
+		static Path firstTempDir;
+		static Path secondTempDir;
+
+		@Test
+		void test(@TempDir Path tempDir, TestInfo testInfo) throws Exception {
+			assertNull(firstTempDir);
+			firstTempDir = tempDir;
+			writeFile(tempDir, testInfo);
+		}
+
+		@AfterAll
+		static void afterAll(@TempDir Path tempDir) {
+			secondTempDir = tempDir;
+			assertNotNull(firstTempDir);
+			assertNotEquals(firstTempDir, tempDir);
+		}
+	}
+
+	static class BaseSeparateTempDirsTestCase {
+		static final Deque<Path> tempDirs = new LinkedList<>();
+
+		@BeforeEach
+		void beforeEach(@TempDir Path tempDir) {
+			for (Path dir : tempDirs) {
+				assertThat(dir).doesNotExist();
+			}
+			assertThat(tempDirs).doesNotContain(tempDir);
+			tempDirs.add(tempDir);
+			check(tempDir);
+		}
+
+		@Test
+		void test1(@TempDir Path tempDir, TestInfo testInfo) throws Exception {
+			check(tempDir);
+			writeFile(tempDir, testInfo);
+		}
+
+		@Test
+		void test2(TestInfo testInfo, @TempDir Path tempDir) throws Exception {
+			check(tempDir);
+			writeFile(tempDir, testInfo);
+		}
+
+		@AfterEach
+		void afterEach(@TempDir Path tempDir) {
+			check(tempDir);
+		}
+
+		void check(@TempDir Path tempDir) {
+			assertSame(tempDirs.getLast(), tempDir);
+			assertTrue(Files.exists(tempDir));
+		}
+	}
+
+	@ExtendWith(TempDirectory.class)
+	static class SeparateTempDirsWhenUsedOnForEachLifecycleMethodsTestCase extends BaseSeparateTempDirsTestCase {
+	}
+
+	@TestInstance(PER_CLASS)
+	static class SeparateTempDirsWhenUsedOnForEachLifecycleMethodsWithTestInstancePerClassTestCase
+			extends SeparateTempDirsWhenUsedOnForEachLifecycleMethodsTestCase {
+	}
+
+	@ExtendWith(TempDirectory.class)
+	static class InvalidTestCase {
+		@Test
+		void wrongParameterType(@TempDir File ignored) {
+			fail("this should never be called");
+		}
+	}
+
+	static class ParentDirFromCallableTestCase extends BaseSeparateTempDirsTestCase {
+
+		private static FileSystem fileSystem;
+
+		@BeforeAll
+		static void createFileSystem() {
+			fileSystem = Jimfs.newFileSystem();
+		}
+
+		@AfterAll
+		static void closeFileSystem() throws Exception {
+			assertThat(tempDirs.getFirst()).doesNotExist();
+			assertThat(tempDirs.getLast()).doesNotExist();
+			fileSystem.close();
+		}
+
+		@RegisterExtension
+		Extension tempDirectory = new TempDirectory(() -> Files.createDirectories(fileSystem.getPath("tmp")));
+
+	}
+
+	static class ParentDirFromProviderTestCase extends BaseSeparateTempDirsTestCase {
+
+		@RegisterExtension
+		Extension tempDirectory = new TempDirectory((parameterContext, extensionContext) -> {
+			Store store = extensionContext.getRoot().getStore(Namespace.GLOBAL);
+			FileSystem fileSystem = store.getOrComputeIfAbsent("jimfs.fileSystem", key -> new JimfsFileSystemResource(),
+				JimfsFileSystemResource.class).get();
+			return Files.createDirectories(fileSystem.getPath("tmp"));
+		});
+
+		static class JimfsFileSystemResource implements CloseableResource {
+			private final FileSystem fileSystem;
+
+			JimfsFileSystemResource() {
+				this.fileSystem = Jimfs.newFileSystem();
+			}
+
+			FileSystem get() {
+				return fileSystem;
+			}
+
+			@Override
+			public void close() throws IOException {
+				assertThat(tempDirs.getFirst()).doesNotExist();
+				assertThat(tempDirs.getLast()).doesNotExist();
+				fileSystem.close();
+			}
+		}
+	}
+
+	static class FailedCreationAttemptTestCase {
+
+		private FileSystem fileSystem = mock(FileSystem.class);
+
+		@BeforeEach
+		void prepareFileSystem() {
+			when(fileSystem.getPath(any())).thenAnswer(invocation -> {
+				Path path = mock(Path.class, Arrays.toString(invocation.getArguments()));
+				when(path.getFileSystem()).thenThrow(new RuntimeException("Simulated creation failure"));
+				return path;
+			});
+		}
+
+		@RegisterExtension
+		Extension tempDirectory = new TempDirectory(() -> fileSystem.getPath("tmp"));
+
+		@Test
+		void test(@TempDir Path tempDir) {
+			fail("this should never be called");
+		}
+	}
+
+	static class FailedDeletionAttemptTestCase {
+
+		private FileSystem fileSystem = mock(FileSystem.class);
+
+		@BeforeEach
+		@SuppressWarnings("unchecked")
+		void prepareFileSystem() throws Exception {
+			FileSystemProvider provider = mock(FileSystemProvider.class);
+			when(provider.readAttributes(any(), any(Class.class), any())) //
+					.thenAnswer(invocation -> mock(invocation.getArgument(1)));
+			doThrow(new IOException("Simulated deletion failure")).when(provider).delete(any());
+			when(fileSystem.provider()).thenReturn(provider);
+			when(fileSystem.getPath(any())).thenAnswer(invocation -> {
+				Path path = mock(Path.class, Arrays.toString(invocation.getArguments()));
+				when(path.getFileSystem()).thenReturn(fileSystem);
+				when(path.toAbsolutePath()).thenReturn(path);
+				when(path.resolve(any(Path.class))).thenAnswer(invocation1 -> invocation1.getArgument(0));
+				return path;
+			});
+		}
+
+		@RegisterExtension
+		Extension tempDirectory = new TempDirectory(() -> fileSystem.getPath("tmp"));
+
+		@Test
+		void test(@TempDir Path tempDir) {
+			assertNotNull(tempDir);
+		}
+	}
+
+	static class ErroneousParentDirProviderTestCase {
+
+		private FileSystem fileSystem = mock(FileSystem.class);
+
+		@RegisterExtension
+		Extension tempDirectory = new TempDirectory(() -> {
+			throw new IOException("something went horribly wrong");
+		});
+
+		@Test
+		void test(@TempDir Path tempDir) {
+			fail("this should never be called");
+		}
+	}
+
+	private static Path writeFile(@TempDir Path tempDir, TestInfo testInfo) throws IOException {
+		Path file = tempDir.resolve(testInfo.getTestMethod().get().getName() + ".txt");
+		Files.write(file, testInfo.getDisplayName().getBytes());
+		return file;
+	}
+}

--- a/src/test/java/org/junit$pioneer/jupiter/TempDirectoryTests.java
+++ b/src/test/java/org/junit$pioneer/jupiter/TempDirectoryTests.java
@@ -175,7 +175,7 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 			ExecutionEventRecorder executionEventRecorder = executeTests(FailedCreationAttemptTestCase.class);
 
 			assertSingleFailedTest(executionEventRecorder, ParameterResolutionException.class,
-				"Failed to create temp directory");
+				"Failed to create custom temp directory");
 		}
 
 		@Test
@@ -379,7 +379,7 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 
 		@RegisterExtension
 		Extension tempDirectory = new TempDirectory(
-			() -> Optional.of(Files.createDirectories(fileSystem.getPath("tmp"))));
+			() -> Files.createDirectories(fileSystem.getPath("tmp")));
 
 	}
 
@@ -390,8 +390,7 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 			Store store = extensionContext.getRoot().getStore(Namespace.GLOBAL);
 			FileSystem fileSystem = store.getOrComputeIfAbsent("jimfs.fileSystem", key -> new JimfsFileSystemResource(),
 				JimfsFileSystemResource.class).get();
-			Path tempDirectory = Files.createDirectories(fileSystem.getPath("tmp"));
-			return Optional.of(tempDirectory);
+			return Files.createDirectories(fileSystem.getPath("tmp"));
 		});
 
 		static class JimfsFileSystemResource implements CloseableResource {
@@ -428,7 +427,7 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 		}
 
 		@RegisterExtension
-		Extension tempDirectory = new TempDirectory(() -> Optional.of(fileSystem.getPath("tmp")));
+		Extension tempDirectory = new TempDirectory(() -> fileSystem.getPath("tmp"));
 
 		@Test
 		void test(@TempDir Path tempDir) {
@@ -458,7 +457,7 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 		}
 
 		@RegisterExtension
-		Extension tempDirectory = new TempDirectory(() -> Optional.of(fileSystem.getPath("tmp")));
+		Extension tempDirectory = new TempDirectory(() -> fileSystem.getPath("tmp"));
 
 		@Test
 		void test(@TempDir Path tempDir) {

--- a/src/test/resources/log4j2-test.xml
+++ b/src/test/resources/log4j2-test.xml
@@ -6,6 +6,8 @@
 		</Console>
 	</Appenders>
 	<Loggers>
+		<!-- Hide logged errors when closing CloseableResources -->
+		<Logger name="org.junit.jupiter.engine.execution.JupiterEngineExecutionContext" level="off" />
 		<Root level="error">
 			<AppenderRef ref="Console" />
 		</Root>


### PR DESCRIPTION
This PR introduces a Jupiter extension to create and cleanup per-test temporary directories. Resolves #39.

### Example

```java
@ExtendWith(TempDirectory.class)
class Tests {
	@Test
	void test(@TempDir Path tempDir) throws Exception {
		Path file = tempDir.resolve("my-file.txt");
		Files.write(file, "Hello World".getBytes());
	}
}
```

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](../CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
