### PR TITLE
Switch to Gradle's native test task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ version '0.1-SNAPSHOT'
 apply plugin: 'java'
 apply plugin: 'com.diffplug.gradle.spotless'
 apply plugin: 'checkstyle'
-apply plugin: 'org.junit.platform.gradle.plugin'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
@@ -45,17 +44,19 @@ buildscript {
             name "GradlePlugins"
             url 'https://plugins.gradle.org/m2/'
         }
-        maven {
-            name "MavenSnapshot"
-            url 'https://oss.sonatype.org/content/repositories/snapshots/'
-        }
     }
 
     dependencies {
         classpath group: 'com.diffplug.gradle.spotless', name: 'spotless', version: '2.2.0'
-        classpath group: 'org.junit.platform', name: 'junit-platform-gradle-plugin', version: '1.0.0-SNAPSHOT'
         classpath group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.8.1'
         classpath group: 'org.ajoberstar', name: 'grgit', version: '1.9.3'
+    }
+}
+
+test {
+    useJUnitPlatform()
+    filter {
+        includeTestsMatching "*Tests"
     }
 }
 


### PR DESCRIPTION
Instead of using the now deprecated junit-platform-gradle-plugin, this PR switches test execution to use Gradle's native JUnit Platform support.

Resolves #75.

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](../CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
