### PR TITLE
Move TriggerTravisTask to buildSrc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,8 +48,6 @@ buildscript {
 
     dependencies {
         classpath group: 'com.diffplug.gradle.spotless', name: 'spotless', version: '2.2.0'
-        classpath group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.8.1'
-        classpath group: 'org.ajoberstar', name: 'grgit', version: '1.9.3'
     }
 }
 
@@ -285,82 +283,9 @@ wrapper {
     jarFile = "${project.projectDir}/.infra/gradle/gradle-wrapper.jar"
 }
 
-task triggerSiteBuild(type: TriggerTravisTask) {
+task triggerSiteBuild(type: org.junit$pioneer.gradle.TriggerTravisTask) {
     travisProject = "junit-pioneer/junit-pioneer.github.io"
     branch = "grandmaster"
     apiToken = travisApiToken
     message = "Triggered by successful JUnit Pioneer build for %COMMIT"
-}
-
-import okhttp3.Headers
-import okhttp3.MediaType
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.RequestBody
-import okhttp3.Response
-
-import org.ajoberstar.grgit.Grgit
-import org.ajoberstar.grgit.service.ResolveService
-
-class TriggerTravisTask extends DefaultTask {
-
-    private static final Headers TRAVIS_API_VERSION = Headers.of "Travis-API-Version": "3"
-    private static final MediaType JSON = MediaType.parse "application/json; charset=utf-8"
-    private static final int OK = 200
-    private static final int ACCEPTED = 202
-    private static final Set<Integer> OK_CODES = [ OK, ACCEPTED ]
-
-    private final OkHttpClient client = new OkHttpClient()
-
-    String travisProject
-    String branch = "master"
-    String apiToken
-    String message = "Triggering build of %PROJECT"
-
-    @TaskAction
-    def trigger() {
-        checkConfiguration()
-        def message = createMessage()
-        println message
-        def response = postToTravis(travisProject, branch, message)
-        if (OK_CODES.contains(response.code()))
-            logger.lifecycle("Successfully triggered Travis build. $response ")
-        else
-            throw new GradleException("Triggering Travis build failed. $response ")
-    }
-
-    private void checkConfiguration() {
-        if (travisProject == null)
-            logger.error "For the task '${getName()}', no Travis project name has been defined."
-        if (apiToken == null)
-            logger.error "For the task '${getName()}', no API token has been defined."
-        if (travisProject == null || apiToken == null)
-            throw new GradleException("To trigger a Travis build, please define both a project name and an API token.")
-    }
-
-    String createMessage() {
-        def msg = message.replaceAll("%PROJECT", travisProject)
-        if (message.contains("%COMMIT"))
-            msg = msg.replaceAll("%COMMIT", determineCommit())
-        return msg
-    }
-
-    String determineCommit() {
-        def repo = Grgit.open().repository
-        return new ResolveService(repo).toCommit("HEAD").getAbbreviatedId()
-    }
-
-    Response postToTravis(String project, String branch, String message) throws IOException {
-        def url = "https://api.travis-ci.org/repo/${project.replaceAll("/", "%2F")}/requests"
-        def requestBody = """{ "request": { "message": "$message", "branch": "$branch" } }"""
-
-        def request = new Request.Builder()
-                .url(url)
-                .headers(TRAVIS_API_VERSION)
-                .header("Authorization", "token $apiToken")
-                .post(RequestBody.create(JSON, requestBody))
-                .build()
-        return client.newCall(request).execute()
-    }
-
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,17 @@
+plugins {
+    id 'groovy'
+}
+
+repositories {
+    maven {
+        name "GradlePlugins"
+        url 'https://plugins.gradle.org/m2/'
+    }
+}
+
+dependencies {
+    implementation gradleApi()
+    implementation localGroovy()
+    implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '3.8.1'
+    implementation group: 'org.ajoberstar', name: 'grgit', version: '1.9.3'
+}

--- a/buildSrc/src/main/groovy/org/junit$pioneer/gradle/TriggerTravisTask.groovy
+++ b/buildSrc/src/main/groovy/org/junit$pioneer/gradle/TriggerTravisTask.groovy
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2015-2017 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v1.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.junit$pioneer.gradle
+
+import okhttp3.Headers
+import okhttp3.MediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
+import okhttp3.Response
+
+import org.ajoberstar.grgit.Grgit
+import org.ajoberstar.grgit.service.ResolveService
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.TaskAction
+
+class TriggerTravisTask extends DefaultTask {
+
+	private static final Headers TRAVIS_API_VERSION = Headers.of "Travis-API-Version": "3"
+	private static final MediaType JSON = MediaType.parse "application/json; charset=utf-8"
+	private static final int OK = 200
+	private static final int ACCEPTED = 202
+	private static final Set<Integer> OK_CODES = [ OK, ACCEPTED ]
+
+	private final OkHttpClient client = new OkHttpClient()
+
+	String travisProject
+	String branch = "master"
+	String apiToken
+	String message = "Triggering build of %PROJECT"
+
+	@TaskAction
+	def trigger() {
+		checkConfiguration()
+		def message = createMessage()
+		println message
+		def response = postToTravis(travisProject, branch, message)
+		if (OK_CODES.contains(response.code()))
+			logger.lifecycle("Successfully triggered Travis build. $response ")
+		else
+			throw new GradleException("Triggering Travis build failed. $response ")
+	}
+
+	private void checkConfiguration() {
+		if (travisProject == null)
+			logger.error "For the task '${getName()}', no Travis project name has been defined."
+		if (apiToken == null)
+			logger.error "For the task '${getName()}', no API token has been defined."
+		if (travisProject == null || apiToken == null)
+			throw new GradleException("To trigger a Travis build, please define both a project name and an API token.")
+	}
+
+	String createMessage() {
+		def msg = message.replaceAll("%PROJECT", travisProject)
+		if (message.contains("%COMMIT"))
+			msg = msg.replaceAll("%COMMIT", determineCommit())
+		return msg
+	}
+
+	String determineCommit() {
+		def repo = Grgit.open().repository
+		return new ResolveService(repo).toCommit("HEAD").getAbbreviatedId()
+	}
+
+	Response postToTravis(String project, String branch, String message) throws IOException {
+		def url = "https://api.travis-ci.org/repo/${project.replaceAll("/", "%2F")}/requests"
+		def requestBody = """{ "request": { "message": "$message", "branch": "$branch" } }"""
+
+		def request = new Request.Builder()
+				.url(url)
+				.headers(TRAVIS_API_VERSION)
+				.header("Authorization", "token $apiToken")
+				.post(RequestBody.create(JSON, requestBody))
+				.build()
+		return client.newCall(request).execute()
+	}
+
+}


### PR DESCRIPTION
It's a recommended practice to separate task declaration in the build script from task implementation. Gradle provides a convention based mechanism for this purpose: the [`buildSrc` project](https://docs.gradle.org/current/userguide/organizing_build_logic.html#sec:build_sources). Thus, this PR moves task implementation to the `buildSrc` project to simplify the build script and ease a possible future transition to Gradle's Kotlin DSL.

Resolves #77.

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](../CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
