### PR TITLE
Move issue and PR numbers from commit action to body

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,8 @@ ${action}
 
 ${body}
 
-${references} ${issues} / ${pull-request}
+${references}: ${issues}
+PR: ${pull-request}
 ```
 
 `${action}` should succinctly describe what the PR does in good Git style.
@@ -87,15 +88,15 @@ Markdown syntax can be used and lines should usually not exceed 70 characters (e
 
 The message ends with a list of related issues and the PR that merges the change:
 
-* `${references}` is either _Closes_, _Fixes_, or _Resolves_.
+* `${references}` is usually _Closes_, _Fixes_, or _Resolves_, but if none of that is the case, can also be _Issue(s)_
 * `${issues}` is a comma-separated list of all related issues
-* `${pull-request}` is the pull request (don't forget to separate it from the issues with a slash)
+* `${pull-request}` is the pull request
 
 This makes the related issues and pull request easy to find from a look at the log.
 
 Once a pull request is ready to be merged, the contributor will be asked to propose an action and body for the squashed commit and the maintainer will refine them when merging.
 
-As an example, the squashed commit 22996a2, which created this documentation, had the following message:
+As an example, the squashed commit 22996a2, which created this documentation, should have had the following message:
 
 ```
 Document branching and merging
@@ -116,10 +117,11 @@ the detailed history, which will be more coarse than with merge commits
 or fast-forward merges. This was deemed acceptable in order to achieve
 the other points, particularly the last one.
 
-Closes #30, #31 / #40
+Closes: #30, #31
+PR: #40
 ```
 
-(This is not entirely true - the guideline for location of the issue and pull request numbers was later changed, so in the original message, they appear in a different place.)
+(The actual message is slightly different because the guideline for location of the issue and pull request numbers was later changed and the example above was updated to reflect that.)
 
 
 ## Adapting to Upstream Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,25 +71,34 @@ To make the single commit expressive its message must be detailed and [good]((ht
 Furthermore, it must follow this structure:
 
 ```
-${action} (${issues} / ${pull-request})
+${action}
 
 ${body}
+
+${references} ${issues} / ${pull-request}
 ```
 
 `${action}` should succinctly describe what the PR does in good Git style.
-It is followed, in parenthesis, by a comma-separated list of all related issues, a slash, and the pull request (to make all of them easy to find from a look at the log).
 Ideally, this title line should not exceed 50 characters - 70 is the absolute maximum.
 
 `${body}` should outline the problem the pull request was solving - it should focus on _why_ the code was written, not on _how_ it works.
 This can usually be a summary of the issue description and discussion as well as commit messages.
 Markdown syntax can be used and lines should usually not exceed 70 characters (exceptions are possible, e.g. to include stack traces).
 
+The message ends with a list of related issues and the PR that merges the change:
+
+* `${references}` is either _Closes_, _Fixes_, or _Resolves_.
+* `${issues}` is a comma-separated list of all related issues
+* `${pull-request}` is the pull request (don't forget to separate it from the issues with a slash)
+
+This makes the related issues and pull request easy to find from a look at the log.
+
 Once a pull request is ready to be merged, the contributor will be asked to propose an action and body for the squashed commit and the maintainer will refine them when merging.
 
-As an example, the squashed commit that created this documentation had the following message:
+As an example, the squashed commit 22996a2, which created this documentation, had the following message:
 
 ```
-Document branching and merging (#30, #31 / #40)
+Document branching and merging
 
 To make sure the project has a sensible and helpful commit history and
 interacts well with GitHub's features the strategy used for branching,
@@ -106,7 +115,11 @@ The chosen approach to squash and merge fulfills all of them except
 the detailed history, which will be more coarse than with merge commits
 or fast-forward merges. This was deemed acceptable in order to achieve
 the other points, particularly the last one.
+
+Closes #30, #31 / #40
 ```
+
+(This is not entirely true - the guideline for location of the issue and pull request numbers was later changed, so in the original message, they appear in a different place.)
 
 
 ## Adapting to Upstream Changes


### PR DESCRIPTION
In the future the merge message would look as follows:

```
${action}

${body}

${references} ${issues} / ${pull-request}
```

`${action}` should succinctly describe what the PR does in good Git style.
Ideally, this title line should not exceed 50 characters - 70 is the absolute maximum.

`${body}` should outline the problem the pull request was solving - it should focus on _why_ the code was written, not on _how_ it works.
This can usually be a summary of the issue description and discussion as well as commit messages.
Markdown syntax can be used and lines should usually not exceed 70 characters (exceptions are possible, e.g. to include stack traces).

The message ends with a list of related issues and the PR that merges the change:

* `${references}` is either _Closes_, _Fixes_, or _Resolves_.
* `${issues}` is a comma-separated list of all related issues
* `${pull-request}` is the pull request (don't forget to separate it from the issues with a slash)

Closes #79, where this was discussed. Unlike over there, `${references}` is not followed by a colon. Is that alright? Does it even matter? :smile_cat: 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
