### PR TITLE
Nicolai/issues/64 junit 5 version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,38 +123,24 @@ PR: #40
 
 (The actual message is slightly different because the guideline for location of the issue and pull request numbers was later changed and the example above was updated to reflect that.)
 
-
-## Adapting to Upstream Changes
+## Updating Dependency on JUnit 5
 
 JUnit Pioneer has an uncharacteristically strong relationship to the JUnit 5 project (often called _upstream_).
 It not only depends on it, it also uses its internal APIs, copies source code that is not released in any artifact, mimics code style, unit testing, build and CI setup, and more.
 As such it will frequently have to adapt to upstream changes, so it makes sense to provision for that in the development strategy.
 
-### Small, Unavoidable Changes
+As [documented](README.md#dependencies) Pioneer aims to use the lowest JUnit 5 version that supports Pioneer's feature set.
+At the same time, there is no general reason to hesitate with updating the dependency if a new feature requires a newer version or the old version has a severe bug.
+Follow these steps when updating JUnit 5:
 
-Some upstream changes (like [this one](https://github.com/junit-team/junit5/issues/793#issuecomment-294377755)) can cause compile or other blatantly obvious errors, for which only one fix exists and no discussion is required.
-In such cases:
-
-* no issue needs to be created
-* pull requests are optional and the maintainer might opt to commit directly on `master` (please make sure it builds!)
-* commit messages must be stellar:
-	* structured and worded as defined above
-	* reference to the upstream change (issue and pull request)
-
-### Unavoidable Changes
-
-Some breaking upstream changes might require solutions that are not as obvious as above.
-In such cases:
-
-* no issue needs to be created
-* a pull request should be opened for review, in which case everything said earlier about commits, PRs, and merges in regular development holds
-* the final commit message should reference the upstream change (issue and pull request)
-
-### Optional Changes
-
-In case an upstream change does not _require_ a fix, a discussion is warranted.
-An issue should be opened and the procedure follows regular development as described earlier.
-The final commit message should reference the upstream change (issue and pull request).
+* create a separate issue just for the update
+	* explain which feature (i.e. other Pioneer issue) requires it
+	* explain which changes in the Pioneer code base could result from that if you know about any; mention the upstream issue and PR that caused them
+	* if changes are optional or not straightforward, allow for a discussion
+* create a pull request for the update with just the changes caused by it
+* the commit message...
+	* ... should be structured and worded as defined above
+	* ... should reference the upstream issue and pull request (if any)
 
 
 ## Publishing

--- a/README.md
+++ b/README.md
@@ -58,11 +58,15 @@ Before contributing, please read the [contribution guide](CONTRIBUTING.md).
 ### Dependencies
 
 To not add to user's [JAR hell](https://blog.codefx.org/java/jar-hell/), JUnit Pioneer is not taking on any runtime dependencies besides JUnit 5.
+Pioneer always depends on the lowest JUnit 5 version that supports its feature set, but that should not keep you from using 5's latest and greatest.
+
 For our own infrastructure, we rely on the following compile and test dependencies:
 
 * JSR-305 (for static analysis)
-* AssertJ (for our tests)
-* Mockito (for our tests)
+* AssertJ (assertions for our tests)
+* Mockito (mocking for our tests)
+* Log4J (to configure logging during test runs)
+* Jimfs (as an in-memory file system for our test)
 
 ### Code Style
 


### PR DESCRIPTION
Proposed commit message:

```
Define JUnit 5 dependency and update strategy

So far, the project depended on JUnit 5's SNAPSHOT versions, which
allowed for care-free development (particularly before JUnit 5's GA)
but releases obviously have to depend on released JUnit 5 versions.
This made it necessary to define a general strategy for handling the
dependency on JUnit 5.

Developing against SNAPSHOT versions and only picking a released
version when Pioneer gets released has some appeal. It leads to an
unreleasable `master`, though, because code may depend on unreleased
JUnit 5 APIs. Then, how do we ship bug fixes or smaller improvements?
Cutting release branches or merging features based on unreleased APIs
into a "shadow master" adds a lot of complexity.

In the end, the benefits of depending on SNAPSHOTs do not outweigh
the cost. It is easier to limit ourselves to developing against
released versions only. If push comes to shove, a "shadow master" can
still be created, and if more immediate feedback regarding
JUnit-5-internal changes is desired, it would be easy to add another
build job that builds against SNAPSHOTs.

Issue: #64
PR: #89
```

Closes #64 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
