### PR TITLE
Remove $ from package name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ javadoc.shouldRunAfter test
 jar {
     manifest {
         attributes(
-            'Automatic-Module-Name': 'org.junit$pioneer'
+            'Automatic-Module-Name': 'org.junitpioneer'
         )
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -205,7 +205,7 @@ wrapper {
     jarFile = file('.infra/gradle/gradle-wrapper.jar')
 }
 
-task triggerSiteBuild(type: org.junit$pioneer.gradle.TriggerTravisTask) {
+task triggerSiteBuild(type: org.junitpioneer.gradle.TriggerTravisTask) {
     travisProject = "junit-pioneer/junit-pioneer.github.io"
     branch = "grandmaster"
     apiToken = travisApiToken

--- a/buildSrc/src/main/groovy/org/junitpioneer/gradle/TriggerTravisTask.groovy
+++ b/buildSrc/src/main/groovy/org/junitpioneer/gradle/TriggerTravisTask.groovy
@@ -7,7 +7,7 @@
  *
  * http://www.eclipse.org/legal/epl-v20.html
  */
-package org.junit$pioneer.gradle
+package org.junitpioneer.gradle
 
 import okhttp3.Headers
 import okhttp3.MediaType

--- a/docs/vintage-test.adoc
+++ b/docs/vintage-test.adoc
@@ -1,7 +1,7 @@
 :page-title: Vintage @Test
 :page-description: A drop-in replacement for JUnit 4's @Test annotation, including expected and timeout
 
-The annotation `org.junit$pioneer.vintage.@Test` acts as a drop-in replacement for https://junit.org/junit4/javadoc/4.12/org/junit/Test.html[JUnit 4`s `org.junit.@Test` annotation], but marks the method as a regular JUnit Jupiter test.
+The annotation `org.junitpioneer.vintage.@Test` acts as a drop-in replacement for https://junit.org/junit4/javadoc/4.12/org/junit/Test.html[JUnit 4`s `org.junit.@Test` annotation], but marks the method as a regular JUnit Jupiter test.
 That means you do not need to run JUnit 5's Vintage engine to execute this test--Jupiter suffices.
 
 Since the test is run by Jupiter, *JUnit 4 runners and rules will have no effect* and you will still have to replace them with JUnit 5 extensions.

--- a/src/main/java/org/junitpioneer/jupiter/TempDirectory.java
+++ b/src/main/java/org/junitpioneer/jupiter/TempDirectory.java
@@ -8,7 +8,7 @@
  * http://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit$pioneer.jupiter;
+package org.junitpioneer.jupiter;
 
 import static java.nio.file.FileVisitResult.CONTINUE;
 import static java.util.Objects.requireNonNull;

--- a/src/main/java/org/junitpioneer/jupiter/package-info.java
+++ b/src/main/java/org/junitpioneer/jupiter/package-info.java
@@ -3,8 +3,8 @@
  *
  * <p>Check out the following types for details:
  * <ul>
- *     <li>{@link org.junit$pioneer.jupiter.TempDirectory}</li>
+ *     <li>{@link org.junitpioneer.jupiter.TempDirectory}</li>
  * </ul>
  */
 
-package org.junit$pioneer.jupiter;
+package org.junitpioneer.jupiter;

--- a/src/main/java/org/junitpioneer/vintage/ExpectedExceptionExtension.java
+++ b/src/main/java/org/junitpioneer/vintage/ExpectedExceptionExtension.java
@@ -8,7 +8,7 @@
  * http://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit$pioneer.vintage;
+package org.junitpioneer.vintage;
 
 import static java.lang.String.format;
 import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;

--- a/src/main/java/org/junitpioneer/vintage/Test.java
+++ b/src/main/java/org/junitpioneer/vintage/Test.java
@@ -8,7 +8,7 @@
  * http://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit$pioneer.vintage;
+package org.junitpioneer.vintage;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/org/junitpioneer/vintage/TimeoutExtension.java
+++ b/src/main/java/org/junitpioneer/vintage/TimeoutExtension.java
@@ -8,7 +8,7 @@
  * http://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit$pioneer.vintage;
+package org.junitpioneer.vintage;
 
 import static java.lang.String.format;
 import static java.lang.System.currentTimeMillis;

--- a/src/main/java/org/junitpioneer/vintage/package-info.java
+++ b/src/main/java/org/junitpioneer/vintage/package-info.java
@@ -2,4 +2,4 @@
  * Contains extensions to JUnit Vintage, i.e. functionality that is concerned with older JUnit versions.
  */
 
-package org.junit$pioneer.vintage;
+package org.junitpioneer.vintage;

--- a/src/test/java/org/junitpioneer/AbstractPioneerTestEngineTests.java
+++ b/src/test/java/org/junitpioneer/AbstractPioneerTestEngineTests.java
@@ -8,7 +8,7 @@
  * http://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit$pioneer;
+package org.junitpioneer;
 
 import static java.util.Arrays.stream;
 import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;

--- a/src/test/java/org/junitpioneer/jupiter/TempDirectoryTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/TempDirectoryTests.java
@@ -8,7 +8,7 @@
  * http://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit$pioneer.jupiter;
+package org.junitpioneer.jupiter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -32,8 +32,6 @@ import java.util.Optional;
 
 import com.google.common.jimfs.Jimfs;
 
-import org.junit$pioneer.AbstractPioneerTestEngineTests;
-import org.junit$pioneer.jupiter.TempDirectory.TempDir;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -53,6 +51,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.test.event.ExecutionEvent;
 import org.junit.platform.engine.test.event.ExecutionEventRecorder;
+import org.junitpioneer.AbstractPioneerTestEngineTests;
+import org.junitpioneer.jupiter.TempDirectory.TempDir;
 
 @DisplayName("TempDirectory extension")
 class TempDirectoryTests extends AbstractPioneerTestEngineTests {

--- a/src/test/java/org/junitpioneer/vintage/TestIntegrationTests.java
+++ b/src/test/java/org/junitpioneer/vintage/TestIntegrationTests.java
@@ -8,19 +8,19 @@
  * http://www.eclipse.org/legal/epl-v20.html
  */
 
-package org.junit$pioneer.vintage;
+package org.junitpioneer.vintage;
 
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit$pioneer.vintage.ExpectedExceptionExtension.EXPECTED_EXCEPTION_WAS_NOT_THROWN;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junitpioneer.vintage.ExpectedExceptionExtension.EXPECTED_EXCEPTION_WAS_NOT_THROWN;
 
 import java.nio.file.InvalidPathException;
 import java.util.Optional;
 
-import org.junit$pioneer.AbstractPioneerTestEngineTests;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.test.event.ExecutionEventRecorder;
+import org.junitpioneer.AbstractPioneerTestEngineTests;
 
 /**
  * Tests the vintage {@link Test @Test} annotation by running the entire test engine.


### PR DESCRIPTION
With a heavy heart... 😢

```
Remove '$' from package and automatic module name

JUnit Pioneer owns the domain junit-pioneer.org, so the default for
package and (automatic) module names is org.junit-pioneer.
Unfortunately, neither package nor module names can contain a dash.
The only half-way sensible ways to separate two words are:

* not at all
* underscore
* dollar sign

I initially went with `$` (see 3e84191 / #45), but soon concerns were
voiced:

* The JLS states:

    > The $ character should be used only in mechanically generated
    > source code or, rarely, to access pre-existing names on legacy
    > systems.

* Vague worries about `$`, a placeholder in many scripting languages
  and terminals, causing problems down the road; either for us or
  downstream projects and users.
* Many people dislike the dollar sign in the package name (see [1])
  and nobody except for me really liked it (see #24).

In the end, I didn't want to insist and since everybody agrees that
`org.junit_pioneer` is ugly (again, see #24), we settled on
`org.junitpioneer`.

Issue: #24
PR: #91
[1]: https://twitter.com/nipafx/status/1003547161248845824
```

Closes #24 (again)

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
