### PR TITLE
Prepare Shipkit-based continuous delivery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,15 +30,21 @@ cache:
 # Display Gradle version instead of letting Travis execute './gradlew assemble' by default
 install: ./gradlew -version
 
+#Don't build tags
+branches:
+  except:
+  - /^v\d/
+
+#Build and perform release (if needed)
 script:
   - java -version
   - ./gradlew -version
-  - ./gradlew --refresh-dependencies clean check -Dscan
+  - ./gradlew --refresh-dependencies --stacktrace -Dscan clean build
 
 deploy:
   - provider: script
     skip_cleanup: true
-    script: ./gradlew publish -P mavenUserName=$MAVEN_USER_NAME -P mavenPassword=$MAVEN_PASSWORD --stacktrace
+    script: ./gradlew ciPerformRelease
     on:
       branch: master
       jdk: oraclejdk8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,52 +159,10 @@ The final commit message should reference the upstream change (issue and pull re
 
 ## Publishing
 
-Because `gradle publish` tries to execute all publications (e.g. snapshots _and_ releases), it is deactivated.
-Instead use the more specific tasks described below.
+Like [Mockito](http://mockito.org/), JUnit Pioneer implements a continuous delivery model using [Shipkit](http://shipkit.org/) and [Travis CI](https://travis-ci.org/).
+Every change on the `master` branch (for example when merging a pull request) triggers a release build that publishes a new version if the following criteria are met:
 
-### Credentials
+- all checks (e.g. tests) are successful
+- no `ci skip release` is used in the commit message (see the build log for more information)
 
-For any release you need the properties `mavenUserName` and `mavenPassword` to contain your credentials for the Sonatype repositories.
-One way to define them is [a Gradle properties file](https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_properties_and_system_properties).
-For that approach, create a file `gradle.properties` in `GRADLE_USER_HOME` (which defaults to `USER_HOME/.gradle`) with the following content:
-
-```
-mavenUserName=...
-mavenPassword=...
-```
-
-Another way are command line flags (but note that these add sensitive information to your terminal history):
-
-```
-gradle publishSnapshot -PmavenUserName=... -PmavenPassword=...
-```
-
-Furthermore, non-snapshot releases require signed artifacts, for which the following properties have to be defined:
-
-```
-signing.keyId= # last eight digits of key ID
-signing.password= # password for the key
-signing.secretKeyRingFile= # path to local secring.gpg
-```
-
-For details on these have a look at the [Gradle Signing Plugin's documentation](https://docs.gradle.org/current/userguide/signing_plugin.html#sec:signatory_credentials).
-
-### Snapshots
-
-To publish a snapshot version simply execute `gradle publishSnapshot`.
-This will fail if the current project version does not end in `-SNAPSHOT`.
-
-### Releases
-
-To publish a new release, go through the following check list:
-
-* you should be operating on the `master` branch and have no uncommitted changes
-* the version must not end in `-SNAPSHOT`
-* no dependency on snapshot versions
-
-If everything's in order, execute `gradle publishRelease`.
-
-After a successful release do the following:
-
-* tag the current HEAD as a release and upload all artifacts to GitHub
-* go to the next snapshot version and commit the change
+Every new version is published to the `junit-pioneer/maven` Bintray repository as well as to Maven Central and JCenter.

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'checkstyle'
     id 'maven-publish'
     id 'com.diffplug.gradle.spotless' version '3.13.0'
-    id 'org.shipkit.java' version '2.0.25'
+    id 'org.shipkit.java' version '2.0.26'
 }
 
 group 'org.junit-pioneer'

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,12 @@
-group 'org.junit-pioneer'
-version '0.1-SNAPSHOT'
+plugins {
+    id 'java'
+    id 'checkstyle'
+    id 'maven-publish'
+    id 'com.diffplug.gradle.spotless' version '3.13.0'
+    id 'org.shipkit.java' version '2.0.25'
+}
 
-apply plugin: 'java'
-apply plugin: 'com.diffplug.gradle.spotless'
-apply plugin: 'checkstyle'
-apply plugin: 'maven-publish'
-apply plugin: 'signing'
+group 'org.junit-pioneer'
 
 sourceCompatibility = 1.8
 
@@ -38,20 +39,6 @@ dependencies {
 
     testRuntime group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.0'
     testRuntime group: 'org.apache.logging.log4j', name: 'log4j-jul', version: '2.11.0'
-}
-
-buildscript {
-    repositories {
-        mavenLocal()
-        maven {
-            name "GradlePlugins"
-            url 'https://plugins.gradle.org/m2/'
-        }
-    }
-
-    dependencies {
-        classpath group: 'com.diffplug.spotless', name: 'spotless-plugin-gradle', version: '3.12.0'
-    }
 }
 
 test {
@@ -114,17 +101,6 @@ jar {
     }
 }
 
-// create sources and JavaDoc JARs
-task sourcesJar(type: Jar) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
-}
-
-task javadocJar(type: Jar) {
-    classifier = 'javadoc'
-    from javadoc
-}
-
 tasks.withType(Jar) {
     from(projectDir) {
         include 'LICENSE.md'
@@ -134,14 +110,6 @@ tasks.withType(Jar) {
 
 artifacts {
     archives javadocJar, sourcesJar
-}
-
-signing {
-    sign publishing.publications
-}
-
-tasks.withType(Sign) {
-    onlyIf { isReleaseVersion }
 }
 
 publishing {

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -4,8 +4,8 @@
 //
 shipkit {
    gitHub.repository = "junit-pioneer/junit-pioneer"
-   gitHub.readOnlyAuthToken = "2ce24ae6df26d6878d363a8f4e4073c691460657"
-   gitHub.writeAuthToken = System.getenv("GH_WRITE_TOKEN")
+   gitHub.readOnlyAuthToken = "584daca204258e2a397d0c029010732a994382dd"
+   gitHub.writeAuthToken = System.getenv("GITHUB_WRITE_TOKEN")
 }
 
 allprojects {
@@ -14,6 +14,7 @@ allprojects {
        //Bintray configuration is handled by JFrog Bintray Gradle Plugin
        //For reference see the official documentation: https://github.com/bintray/gradle-bintray-plugin
        bintray {
+           user = System.getenv("BINTRAY_USER_NAME")
            key = System.getenv("BINTRAY_API_KEY")
 
            pkg {
@@ -22,6 +23,14 @@ allprojects {
                licenses = ['EPL-2.0']
                vcsUrl = 'https://github.com/junit-pioneer/junit-pioneer.git'
                labels = ['testing', 'junit', 'extensions']
+
+               version {
+                   mavenCentralSync {
+                       sync = false
+                       user = System.getenv('NEXUS_USERNAME')
+                       password = System.getenv('NEXUS_PASSWORD')
+                   }
+               }
            }
        }
    }

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -1,17 +1,10 @@
-//This default Shipkit configuration file was created automatically and is intended to be checked-in.
-//Default configuration is sufficient for local testing and trying out Shipkit.
-//To leverage Shipkit fully, please fix the TODO items, refer to our Getting Started Guide for help:
+//To leverage Shipkit fully, refer to our Getting Started Guide for help:
 //
 //     https://github.com/mockito/shipkit/blob/master/docs/getting-started.md
 //
 shipkit {
-   //TODO is the repository correct?
    gitHub.repository = "junit-pioneer/junit-pioneer"
-
-   //TODO generate and use your own read-only GitHub personal access token
-   gitHub.readOnlyAuthToken = "76826c9ec886612f504d12fd4268b16721c4f85d"
-
-   //TODO generate GitHub write token, and ensure your Travis CI has this env variable exported
+   gitHub.readOnlyAuthToken = "2ce24ae6df26d6878d363a8f4e4073c691460657"
    gitHub.writeAuthToken = System.getenv("GH_WRITE_TOKEN")
 }
 
@@ -21,20 +14,14 @@ allprojects {
        //Bintray configuration is handled by JFrog Bintray Gradle Plugin
        //For reference see the official documentation: https://github.com/bintray/gradle-bintray-plugin
        bintray {
-
-           //TODO sign up for free open source account with https://bintray.com, then look up your API key on your profile page in Bintray
-           key = '7ea297848ca948adb7d3ee92a83292112d7ae989'
-           //TODO don't check in the key, remove above line and use env variable exported on CI:
-           //key = System.getenv("BINTRAY_API_KEY")
+           key = System.getenv("BINTRAY_API_KEY")
 
            pkg {
-               //TODO configure Bintray settings per your project (https://github.com/bintray/gradle-bintray-plugin)
-               repo = 'bootstrap'
-               user = 'shipkit-bootstrap-bot'
-               userOrg = 'shipkit-bootstrap'
-               name = 'maven'
-               licenses = ['MIT']
-               labels = ['continuous delivery', 'release automation', 'shipkit']
+               repo = 'maven'
+               name = 'junit-pioneer'
+               licenses = ['EPL-2.0']
+               vcsUrl = 'https://github.com/junit-pioneer/junit-pioneer.git'
+               labels = ['testing', 'junit', 'extensions']
            }
        }
    }

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -1,0 +1,41 @@
+//This default Shipkit configuration file was created automatically and is intended to be checked-in.
+//Default configuration is sufficient for local testing and trying out Shipkit.
+//To leverage Shipkit fully, please fix the TODO items, refer to our Getting Started Guide for help:
+//
+//     https://github.com/mockito/shipkit/blob/master/docs/getting-started.md
+//
+shipkit {
+   //TODO is the repository correct?
+   gitHub.repository = "junit-pioneer/junit-pioneer"
+
+   //TODO generate and use your own read-only GitHub personal access token
+   gitHub.readOnlyAuthToken = "76826c9ec886612f504d12fd4268b16721c4f85d"
+
+   //TODO generate GitHub write token, and ensure your Travis CI has this env variable exported
+   gitHub.writeAuthToken = System.getenv("GH_WRITE_TOKEN")
+}
+
+allprojects {
+   plugins.withId("org.shipkit.bintray") {
+
+       //Bintray configuration is handled by JFrog Bintray Gradle Plugin
+       //For reference see the official documentation: https://github.com/bintray/gradle-bintray-plugin
+       bintray {
+
+           //TODO sign up for free open source account with https://bintray.com, then look up your API key on your profile page in Bintray
+           key = '7ea297848ca948adb7d3ee92a83292112d7ae989'
+           //TODO don't check in the key, remove above line and use env variable exported on CI:
+           //key = System.getenv("BINTRAY_API_KEY")
+
+           pkg {
+               //TODO configure Bintray settings per your project (https://github.com/bintray/gradle-bintray-plugin)
+               repo = 'bootstrap'
+               user = 'shipkit-bootstrap-bot'
+               userOrg = 'shipkit-bootstrap'
+               name = 'maven'
+               licenses = ['MIT']
+               labels = ['continuous delivery', 'release automation', 'shipkit']
+           }
+       }
+   }
+}

--- a/version.properties
+++ b/version.properties
@@ -1,0 +1,3 @@
+#Version of the produced binaries. This file is intended to be checked-in.
+#It will be automatically bumped by release automation.
+version=0.1.0


### PR DESCRIPTION
About to squash and rebase onto `master` soon, to get Shipkit working.

1. step: deploy to Bintray
2. step: sync to Central Maven

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
