### PR TITLE
Make TempDirectory clean up more thoroughly

### DIFF
--- a/src/test/java/org/junitpioneer/jupiter/TempDirectoryTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/TempDirectoryTests.java
@@ -452,6 +452,8 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 				when(path.getFileSystem()).thenReturn(fileSystem);
 				when(path.toAbsolutePath()).thenReturn(path);
 				when(path.resolve(any(Path.class))).thenAnswer(invocation1 -> invocation1.getArgument(0));
+				when(path.toFile()).thenThrow(UnsupportedOperationException.class);
+				when(path.relativize(any(Path.class))).thenAnswer(invocation1 -> invocation1.getArgument(0));
 				return path;
 			});
 		}


### PR DESCRIPTION
 - Continue deleting files even after failures
 - Include all exceptions and failed paths in the exception that is
   thrown in the end in case of failures
 - In case of the default `FileSystem`, use `File.deleteOnExit()` to
   make the VM clean up the files on exit

Fixes: #100

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
