### PR TITLE
Properly configure build scans

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ branches:
 script:
   - java -version
   - ./gradlew -version
-  - ./gradlew --refresh-dependencies --stacktrace -Dscan clean build
+  - ./gradlew --refresh-dependencies --stacktrace --scan clean build
 
 deploy:
   - provider: script

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,7 @@ plugins {
     id 'com.diffplug.gradle.spotless' version '3.13.0'
     id 'org.shipkit.java' version '2.0.26'
     id 'at.zierler.yamlvalidator' version '1.5.0'
+    id 'com.gradle.build-scan' version '1.16'
 }
 
 group 'org.junit-pioneer'
@@ -40,6 +41,11 @@ dependencies {
 
     testRuntime group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.11.0'
     testRuntime group: 'org.apache.logging.log4j', name: 'log4j-jul', version: '2.11.0'
+}
+
+buildScan {
+    licenseAgreementUrl = 'https://gradle.com/terms-of-service'
+    licenseAgree = 'yes'
 }
 
 test {


### PR DESCRIPTION
The build option `-Dscan` leads to the following message by Gradle:

> Build scan cannot be created because the build scan plugin was not applied.
> For more information on how to apply the build scan plugin, please visit https://gradle.com/scans/help/gradle-cli.

This is fixed by changing it to --scan. It is also necessary to
further configure the scan to accept the license agreement; otherwise
the build requires manual confirmation.

Fixes: #118
PR: #122


---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
