### PR TITLE
Make DefaultLocale configurable via language tag

### DIFF
--- a/docs/default-locale-timezone.adoc
+++ b/docs/default-locale-timezone.adoc
@@ -45,10 +45,9 @@ void test_with_lanuage_and_country_and_vairant() {
 }
 ----
 
-Note that mixing language tag configuration and constructor based configuration will cause an
-`ExtensionConfigurationException` to be thrown. Furthermore a `variant` can only be specified
-if `country` is also specified. If `variant` is specified without `country`, an
-`ExtensionConfigurationException` will be thrown.
+Note that mixing language tag configuration and constructor based configuration will cause an `ExtensionConfigurationException` to be thrown.
+Furthermore a `variant` can only be specified if `country` is also specified.
+If `variant` is specified without `country`, an `ExtensionConfigurationException` will be thrown.
 
 Any method level `@DefaultLocale` configurations will override class level configurations.
 

--- a/docs/default-locale-timezone.adoc
+++ b/docs/default-locale-timezone.adoc
@@ -46,7 +46,7 @@ void test_with_lanuage_and_country_and_vairant() {
 ----
 
 Note that mixing language tag configuration and constructor based configuration will cause an
-`ExtentionConfigurationException` to be thrown. Furthermore a `variant` can only be specified
+`ExtensionConfigurationException` to be thrown. Furthermore a `variant` can only be specified
 if `country` is also specified. If `variant` is specified without `country`, an
 `ExtensionConfigurationException` will be thrown.
 

--- a/docs/default-locale-timezone.adoc
+++ b/docs/default-locale-timezone.adoc
@@ -48,7 +48,7 @@ void test_with_lanuage_and_country_and_vairant() {
 Note that mixing language tag configuration and constructor based configuration will cause an
 `ExtentionConfigurationException` to be thrown. Furthermore a `variant` can only be specified
 if `country` is also specified. If `variant` is specified without `country`, an
-`ExtentionConfigurationException` will be thrown.
+`ExtensionConfigurationException` will be thrown.
 
 Any method level `@DefaultLocale` configurations will override class level configurations.
 

--- a/docs/default-locale-timezone.adoc
+++ b/docs/default-locale-timezone.adoc
@@ -7,7 +7,18 @@ After the annotated element has been executed the initial default value is resto
 
 == `@DefaultLocale`
 
-The default `Locale` is specified according to https://docs.oracle.com/javase/8/docs/api/java/util/Locale.html#constructor.summary[its constructors] - it needs either:
+The default `Locale` can be specified using an https://docs.oracle.com/javase/8/docs/api/java/util/Locale.html#forLanguageTag-java.lang.String-[IETF BCP 47 language tag string]
+
+[source,java]
+----
+@Test
+@DefaultLocale("zh-Hant-TW")
+void test_with_lanuage() {
+    assertEquals(Locale.forLanguageTag("zh-Hant-TW"), Locale.getDefault());
+}
+----
+
+Alternatively the default `Locale` can be specified according to https://docs.oracle.com/javase/8/docs/api/java/util/Locale.html#constructor.summary[its constructors] - it needs either:
 
 * `language` or
 * `language` and `country` or
@@ -34,8 +45,10 @@ void test_with_lanuage_and_country_and_vairant() {
 }
 ----
 
-Note that `variant` can only be specified if `country` is also specified.
-If `variant` is specified without `country`, an `ExtentionConfigurationException` will be thrown.
+Note that mixing language tag configuration and constructor based configuration will cause an
+`ExtentionConfigurationException` to be thrown. Furthermore a `variant` can only be specified
+if `country` is also specified. If `variant` is specified without `country`, an
+`ExtentionConfigurationException` will be thrown.
 
 Any method level `@DefaultLocale` configurations will override class level configurations.
 

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *   <li>using a {@link java.util.Locale#forLanguageTag(String) language tag}</li>
  *   <li>using a {@link java.util.Locale#Locale(String) language}</li>
  *   <li>using a {@link java.util.Locale#Locale(String, String) language and a county}</li>
- *   <li>using a {@link java.util.Locale#Locale(String, String, String) language, a county and a variant}</li>
+ *   <li>using a {@link java.util.Locale#Locale(String, String, String) language, a county, and a variant}</li>
  * </ul>
  *
  * If a language tag is set, none of the other fields must be set. Otherwise an

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
@@ -44,11 +44,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public @interface DefaultLocale {
 
 	/**
+	 * An language tag string as specified by IETF BCP 47. See
+	 * {@link java.util.Locale#forLanguageTag(String)} for more information
+	 * about valid language tag values.
+	 *
+	 * @since 0.3
+	 */
+	String value() default "";
+
+	/**
 	 * An ISO 639 alpha-2 or alpha-3 language code, or a language subtag up to
 	 * 8 characters in length. See the {@link java.util.Locale} class
 	 * description about valid language values.
 	 */
-	String language();
+	String language() default "";
 
 	/**
 	 * An ISO 3166 alpha-2 country code or a UN M.49 numeric-3 area code. See

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
@@ -32,10 +32,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * </ul>
  *
  * If a language tag is set, none of the other fields must be set. Otherwise an
- * {@link org.junit.jupiter.api.extension.ExtensionConfigurationException} will be thrown.
- * Specifying a {@link #variant()} but no {@link #country()} will also cause an
- * {@code ExtensionConfigurationException}. After the annotated element has been
- * executed, the default {@code Locale} will be restored to its original value.</p>
+ * {@link org.junit.jupiter.api.extension.ExtensionConfigurationException} will
+ * be thrown. Specifying a {@link #country()} but no {@link #language()}, or a
+ * {@link #variant()} but no {@link #country()} and {@link #language()} will
+ * also cause an {@code ExtensionConfigurationException}. After the annotated
+ * element has been executed, the default {@code Locale} will be restored to
+ * its original value.</p>
  *
  * <p>{@code @DefaultLocale} can be used on the method and on the class level.
  * If a class is annotated, the configured {@code Locale} will be the default

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *   <li>using a {@link java.util.Locale#Locale(String, String, String) language, a county, and a variant}</li>
  * </ul>
  *
- * If a language tag is set, none of the other fields must be set. Otherwise an
+ * <p>If a language tag is set, none of the other fields must be set. Otherwise an
  * {@link org.junit.jupiter.api.extension.ExtensionConfigurationException} will
  * be thrown. Specifying a {@link #country()} but no {@link #language()}, or a
  * {@link #variant()} but no {@link #country()} and {@link #language()} will

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
@@ -22,12 +22,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * returned by {@link java.util.Locale#getDefault()} for a test execution.
  *
  * <p>The {@link java.util.Locale} to set as the default locale can be
- * configured using only a language, a language and a country, or a language, a
- * country and a variant. If {@link #variant()} is set, but {@link #country()}
- * is not, a
- * {@link org.junit.jupiter.api.extension.ExtensionConfigurationException} will
- * be thrown. After the annotated element has been executed, the default
- * {@code Locale} will be restored to its original value.</p>
+ * configured in several ways:
+ *
+ * <ul>
+ *   <li>using a {@link java.util.Locale#forLanguageTag(String) language tag}</li>
+ *   <li>using a {@link java.util.Locale#Locale(String) language}</li>
+ *   <li>using a {@link java.util.Locale#Locale(String, String) language and a county}</li>
+ *   <li>using a {@link java.util.Locale#Locale(String, String, String) language, a county and a variant}</li>
+ * </ul>
+ *
+ * If a language tag is set, none of the other fields must be set. Otherwise an
+ * {@link org.junit.jupiter.api.extension.ExtensionConfigurationException} will be thrown.
+ * Specifying a {@link #variant()} but no {@link #country()} will also cause an
+ * {@code ExtensionConfigurationException}. After the annotated element has been
+ * executed, the default {@code Locale} will be restored to its original value.</p>
  *
  * <p>{@code @DefaultLocale} can be used on the method and on the class level.
  * If a class is annotated, the configured {@code Locale} will be the default

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocaleExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocaleExtension.java
@@ -67,18 +67,37 @@ class DefaultLocaleExtension implements BeforeAllCallback, BeforeEachCallback, A
 	}
 
 	private static Locale createLocale(DefaultLocale annotation) {
-		if (!annotation.country().isEmpty() && !annotation.variant().isEmpty()) {
-			return new Locale(annotation.language(), annotation.country(), annotation.variant());
-		}
-		else if (!annotation.country().isEmpty()) {
-			return new Locale(annotation.language(), annotation.country());
-		}
-		else if (!annotation.variant().isEmpty()) {
-			throw new ExtensionConfigurationException(
-				"@DefaultLocale.country must not be empty when @DefaultLocale.variant is set!");
+		if (!annotation.value().isEmpty()) {
+			return createFromLanguageTag(annotation);
 		}
 		else {
-			return new Locale(annotation.language());
+			return createFromParts(annotation);
+		}
+	}
+
+	private static Locale createFromLanguageTag(DefaultLocale annotation) {
+		if (!annotation.language().isEmpty() || !annotation.country().isEmpty() || !annotation.variant().isEmpty()) {
+			throw new ExtensionConfigurationException(
+				"@DefaultLocale can only be used with language tag if language, country and variant are not set!");
+		}
+		return Locale.forLanguageTag(annotation.value());
+	}
+
+	private static Locale createFromParts(DefaultLocale annotation) {
+		String language = annotation.language();
+		String country = annotation.country();
+		String variant = annotation.variant();
+		if (!language.isEmpty() && !country.isEmpty() && !variant.isEmpty()) {
+			return new Locale(language, country, variant);
+		}
+		else if (!language.isEmpty() && !country.isEmpty()) {
+			return new Locale(language, country);
+		}
+		else if (!language.isEmpty() && variant.isEmpty()) {
+			return new Locale(language);
+		}
+		else {
+			throw new ExtensionConfigurationException("@DefaultLocale not configured correctly!");
 		}
 	}
 

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocaleExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocaleExtension.java
@@ -97,7 +97,9 @@ class DefaultLocaleExtension implements BeforeAllCallback, BeforeEachCallback, A
 			return new Locale(language);
 		}
 		else {
-			throw new ExtensionConfigurationException("@DefaultLocale not configured correctly");
+			throw new ExtensionConfigurationException(
+					"@DefaultLocale not configured correctly. When not using a language tag, specify either"
+							+ "language, or language and country, or language and country and variant.");
 		}
 	}
 

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocaleExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocaleExtension.java
@@ -98,8 +98,8 @@ class DefaultLocaleExtension implements BeforeAllCallback, BeforeEachCallback, A
 		}
 		else {
 			throw new ExtensionConfigurationException(
-					"@DefaultLocale not configured correctly. When not using a language tag, specify either"
-							+ "language, or language and country, or language and country and variant.");
+				"@DefaultLocale not configured correctly. When not using a language tag, specify either"
+						+ "language, or language and country, or language and country and variant.");
 		}
 	}
 

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocaleExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocaleExtension.java
@@ -97,7 +97,7 @@ class DefaultLocaleExtension implements BeforeAllCallback, BeforeEachCallback, A
 			return new Locale(language);
 		}
 		else {
-			throw new ExtensionConfigurationException("@DefaultLocale not configured correctly!");
+			throw new ExtensionConfigurationException("@DefaultLocale not configured correctly");
 		}
 	}
 

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocaleExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocaleExtension.java
@@ -78,7 +78,7 @@ class DefaultLocaleExtension implements BeforeAllCallback, BeforeEachCallback, A
 	private static Locale createFromLanguageTag(DefaultLocale annotation) {
 		if (!annotation.language().isEmpty() || !annotation.country().isEmpty() || !annotation.variant().isEmpty()) {
 			throw new ExtensionConfigurationException(
-				"@DefaultLocale can only be used with language tag if language, country and variant are not set!");
+				"@DefaultLocale can only be used with language tag if language, country, and variant are not set");
 		}
 		return Locale.forLanguageTag(annotation.value());
 	}

--- a/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
@@ -10,13 +10,19 @@
 
 package org.junitpioneer.jupiter;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Locale;
 
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.test.event.ExecutionEvent;

--- a/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
@@ -232,6 +232,6 @@ class DefaultLocaleTests extends AbstractPioneerTestEngineTests {
 				.flatMap(TestExecutionResult::getThrowable)
 				.orElseThrow(AssertionError::new);
 		//@formatter:on
-		assertTrue(thrown instanceof ExtensionConfigurationException);
+		assertThat(thrown).isInstanceOf(ExtensionConfigurationException.class);
 	}
 }

--- a/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
@@ -13,17 +13,13 @@ package org.junitpioneer.jupiter;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.List;
 import java.util.Locale;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.test.event.ExecutionEvent;
 import org.junit.platform.engine.test.event.ExecutionEventRecorder;
 import org.junitpioneer.AbstractPioneerTestEngineTests;
 
@@ -53,6 +49,13 @@ class DefaultLocaleTests extends AbstractPioneerTestEngineTests {
 		@DisplayName("does nothing when annotation is not present")
 		void testDefaultLocaleNoAnnotation() {
 			assertEquals(TEST_DEFAULT_LOCALE, Locale.getDefault());
+		}
+
+		@DefaultLocale("zh-Hant-TW")
+		@Test
+		@DisplayName("sets the default locale using a language tag")
+		void setsLocaleViaLanguageTag() {
+			assertEquals(Locale.forLanguageTag("zh-Hant-TW"), Locale.getDefault());
 		}
 
 		@DefaultLocale(language = "en_EN")
@@ -119,51 +122,116 @@ class DefaultLocaleTests extends AbstractPioneerTestEngineTests {
 	@DisplayName("when configured incorrect")
 	class ConfigurationFailureTests {
 
-		@Test
-		@DisplayName("should fail when variant is set but country is not on method level")
-		void shouldFailWhenVariantIsSetButCountryIsNotOnMethodLevel() {
-			ExecutionEventRecorder eventRecorder = executeTestsForClass(MethodLevelInitializationFailureTestCase.class);
+		@Nested
+		@DisplayName("on the method level")
+		class MethodLevel {
 
-			assertEquals(1, eventRecorder.getTestFailedCount());
-			//@formatter:off
-			Throwable thrown = eventRecorder.getFailedTestFinishedEvents().get(0)
-					.getPayload(TestExecutionResult.class)
-					.flatMap(TestExecutionResult::getThrowable)
-					.orElseThrow(AssertionError::new);
-			//@formatter:on
-			assertTrue(thrown instanceof ExtensionConfigurationException);
+			@Test
+			@DisplayName("should fail when nothing is configured")
+			void shouldFailWhenNothingIsConfigured() {
+				ExecutionEventRecorder eventRecorder = executeTests(MethodLevelInitializationFailureTestCase.class,
+					"shouldFailMissingConfiguration");
+
+				assertExtensionConfigurationFailure(eventRecorder.getFailedTestFinishedEvents());
+			}
+
+			@Test
+			@DisplayName("should fail when variant is set but country is not")
+			void shouldFailWhenVariantIsSetButCountryIsNot() {
+				ExecutionEventRecorder eventRecorder = executeTests(MethodLevelInitializationFailureTestCase.class,
+					"shouldFailMissingCountry");
+
+				assertExtensionConfigurationFailure(eventRecorder.getFailedTestFinishedEvents());
+			}
+
+			@Test
+			@DisplayName("should fail when languageTag and language is set")
+			void shouldFailWhenLanguageTagAndLanguageIsSet() {
+				ExecutionEventRecorder eventRecorder = executeTests(MethodLevelInitializationFailureTestCase.class,
+					"shouldFailLanguageTagAndLanguage");
+
+				assertExtensionConfigurationFailure(eventRecorder.getFailedTestFinishedEvents());
+			}
+
+			@Test
+			@DisplayName("should fail when languageTag and country is set")
+			void shouldFailWhenLanguageTagAndCountryIsSet() {
+				ExecutionEventRecorder eventRecorder = executeTests(MethodLevelInitializationFailureTestCase.class,
+					"shouldFailLanguageTagAndCountry");
+
+				assertExtensionConfigurationFailure(eventRecorder.getFailedTestFinishedEvents());
+			}
+
+			@Test
+			@DisplayName("should fail when languageTag and variant is set")
+			void shouldFailWhenLanguageTagAndVariantIsSet() {
+				ExecutionEventRecorder eventRecorder = executeTests(MethodLevelInitializationFailureTestCase.class,
+					"shouldFailLanguageTagAndVariant");
+
+				assertExtensionConfigurationFailure(eventRecorder.getFailedTestFinishedEvents());
+			}
 		}
 
-		@Test
-		@DisplayName("should fail when variant is set but country is not on class level")
-		void shouldFailWhenVariantIsSetButCountryIsNotOnClassLevel() {
-			ExecutionEventRecorder eventRecorder = executeTestsForClass(ClassLevelInitializationFailureTestCase.class);
+		@Nested
+		@DisplayName("on the class level")
+		class ClassLevel {
 
-			assertEquals(1, eventRecorder.getContainerFailedCount());
-			//@formatter:off
-			Throwable thrown = eventRecorder.getFailedContainerEvents().get(0)
-					.getPayload(TestExecutionResult.class)
-					.flatMap(TestExecutionResult::getThrowable)
-					.orElseThrow(AssertionError::new);
-			//@formatter:on
-			assertTrue(thrown instanceof ExtensionConfigurationException);
+			@Test
+			@DisplayName("should fail when variant is set but country is not")
+			void shouldFailWhenVariantIsSetButCountryIsNot() {
+				ExecutionEventRecorder eventRecorder = executeTestsForClass(
+					ClassLevelInitializationFailureTestCase.class);
+
+				assertExtensionConfigurationFailure(eventRecorder.getFailedContainerEvents());
+			}
 		}
 	}
 
 	static class MethodLevelInitializationFailureTestCase {
 
 		@Test
-		@DefaultLocale(language = "de", variant = "ch")
-		void shouldFail() {
+		@DefaultLocale
+		void shouldFailMissingConfiguration() {
 		}
-	}
 
+		@Test
+		@DefaultLocale(language = "de", variant = "ch")
+		void shouldFailMissingCountry() {
+		}
+
+		@Test
+		@DefaultLocale(value = "Something", language = "de")
+		void shouldFailLanguageTagAndLanguage() {
+		}
+
+		@Test
+		@DefaultLocale(value = "Something", country = "DE")
+		void shouldFailLanguageTagAndCountry() {
+		}
+
+		@Test
+		@DefaultLocale(value = "Something", variant = "ch")
+		void shouldFailLanguageTagAndVariant() {
+		}
+
+	}
 	@DefaultLocale(language = "de", variant = "ch")
 	static class ClassLevelInitializationFailureTestCase {
 
 		@Test
 		void shouldFail() {
 		}
+
 	}
 
+	private static void assertExtensionConfigurationFailure(List<ExecutionEvent> failedTestFinishedEvents) {
+		assertEquals(1, failedTestFinishedEvents.size());
+		//@formatter:off
+		Throwable thrown = failedTestFinishedEvents.get(0)
+				.getPayload(TestExecutionResult.class)
+				.flatMap(TestExecutionResult::getThrowable)
+				.orElseThrow(AssertionError::new);
+		//@formatter:on
+		assertTrue(thrown instanceof ExtensionConfigurationException);
+	}
 }

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 #Version of the produced binaries. This file is intended to be checked-in.
 #It will be automatically bumped by release automation.
-version=0.2.3
+version=0.3
 previousVersion=0.2.2


### PR DESCRIPTION
This adds a `value()` setting to the `@DefaultLocale` annotation. If the value is set it will be used
to create the default locale via the `Locale.forLanguageTag(String)` method. To make this 
possible, the `language()` setting is no longer mandatory. The language tag based configuration and
the old configuration can't be mixed: If `value()` is set, any other setting will cause an exception to be
thrown. Existing code will still compile and work the same as before.

Closes: #114
PR: #128

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
