### PR TITLE
Reactivate site build with more verbose error messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,12 +48,12 @@ deploy:
     on:
       branch: master
       jdk: oraclejdk8
-# - provider: script
-#   skip_cleanup:
-#   script: ./gradlew triggerSiteBuild -P travisApiToken=$TRAVIS_API_TOKEN --stacktrace
-#   on:
-#     branch: master
-#     jdk: oraclejdk8
+  - provider: script
+    skip_cleanup:
+    script: ./gradlew triggerSiteBuild -P travisApiToken=$TRAVIS_API_TOKEN --stacktrace
+    on:
+      branch: master
+      jdk: oraclejdk8
 
 env:
   global:

--- a/buildSrc/src/main/groovy/org/junitpioneer/gradle/TriggerTravisTask.groovy
+++ b/buildSrc/src/main/groovy/org/junitpioneer/gradle/TriggerTravisTask.groovy
@@ -50,11 +50,16 @@ class TriggerTravisTask extends DefaultTask {
 	}
 
 	private void checkConfiguration() {
-		if (travisProject == null)
+		boolean configurationInvalid = false;
+		if (travisProject == null || travisProject.allWhitespace) {
+			configurationInvalid = true;
 			logger.error "For the task '${getName()}', no Travis project name has been defined."
-		if (apiToken == null)
+		}
+		if (apiToken == null || apiToken.allWhitespace) {
+			configurationInvalid = true;
 			logger.error "For the task '${getName()}', no API token has been defined."
-		if (travisProject == null || apiToken == null)
+		}
+		if (configurationInvalid)
 			throw new GradleException("To trigger a Travis build, please define both a project name and an API token.")
 	}
 


### PR DESCRIPTION
The site build could not be triggered, apparently because [the CI setup](https://travis-ci.org/junit-pioneer/junit-pioneer/settings) didn't set the environment variable `TRAVIS_API_TOKEN`. We must have accidentally deelted it. I added it back and this commit reactivates the deployment step.

The class `TriggerTravisTask` now checks whether the token is empty and prints an informative message before exiting if it is. This is more informative than a 403 from the Travis endpoint.

Closes: #124

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
