### PR TITLE
ignore missing files when deleting TempDirectory

### DIFF
--- a/src/main/java/org/junitpioneer/jupiter/TempDirectory.java
+++ b/src/main/java/org/junitpioneer/jupiter/TempDirectory.java
@@ -307,6 +307,9 @@ public class TempDirectory implements ParameterResolver {
 
 				private FileVisitResult deleteAndContinue(Path path) {
 					try {
+						// without races by multiple threads, a call to `Files::delete` would suffice
+						// because the tree walker doesn't visit non-existing files; since race
+						// conditions can't be ruled out, `Files::deleteIfExists` is the safer approach
 						Files.deleteIfExists(path);
 					}
 					catch (IOException ex) {

--- a/src/main/java/org/junitpioneer/jupiter/TempDirectory.java
+++ b/src/main/java/org/junitpioneer/jupiter/TempDirectory.java
@@ -22,6 +22,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
@@ -292,13 +293,21 @@ public class TempDirectory implements ParameterResolver {
 				}
 
 				@Override
+				public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+					if (exc instanceof NoSuchFileException) {
+						return CONTINUE;
+					}
+					return super.visitFileFailed(file, exc);
+				}
+
+				@Override
 				public FileVisitResult postVisitDirectory(Path dir, IOException exc) {
 					return deleteAndContinue(dir);
 				}
 
 				private FileVisitResult deleteAndContinue(Path path) {
 					try {
-						Files.delete(path);
+						Files.deleteIfExists(path);
 					}
 					catch (IOException ex) {
 						failures.put(path, ex);

--- a/src/test/java/org/junitpioneer/AbstractPioneerTestEngineTests.java
+++ b/src/test/java/org/junitpioneer/AbstractPioneerTestEngineTests.java
@@ -17,6 +17,7 @@ import static org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder.r
 
 import org.junit.jupiter.engine.AbstractJupiterTestEngineTests;
 import org.junit.platform.engine.DiscoverySelector;
+import org.junit.platform.engine.discovery.MethodSelector;
 import org.junit.platform.engine.test.event.ExecutionEventRecorder;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 
@@ -34,14 +35,29 @@ public abstract class AbstractPioneerTestEngineTests extends AbstractJupiterTest
 		return executeTests(request);
 	}
 
-	private ExecutionEventRecorder executeTestMethods(Class<?> type, String[] methodNames) {
+	private ExecutionEventRecorder executeTestMethods(Class<?> type, String[] methodSignatures) {
 		//@formatter:off
-		DiscoverySelector[] selectors = stream(methodNames)
-				.map(methodName -> selectMethod(type, methodName))
+		DiscoverySelector[] selectors = stream(methodSignatures)
+				.map(methodSignature -> selectMethodWithPossibleParameters(type, methodSignature))
 				.toArray(DiscoverySelector[]::new);
 		//@formatter:on
 		LauncherDiscoveryRequest request = request().selectors(selectors).build();
 		return executeTests(request);
+	}
+
+	private MethodSelector selectMethodWithPossibleParameters(Class<?> type, String methodSignature) {
+		int open = methodSignature.indexOf('(');
+		int close = methodSignature.indexOf(')');
+		boolean hasValidParameters = 0 < open && open < close && close == methodSignature.length() - 1;
+
+		if (hasValidParameters) {
+			String methodName = methodSignature.substring(0, open);
+			String methodParameters = methodSignature.substring(open + 1, close);
+			return selectMethod(type, methodName, methodParameters);
+		}
+		else {
+			return selectMethod(type, methodSignature);
+		}
 	}
 
 }

--- a/src/test/java/org/junitpioneer/jupiter/TempDirectoryTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/TempDirectoryTests.java
@@ -11,7 +11,11 @@
 package org.junitpioneer.jupiter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.platform.engine.TestExecutionResult.Status.FAILED;
 import static org.mockito.ArgumentMatchers.any;
@@ -92,15 +96,6 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 			assertResolvesShareTempDir(AnnotationOnBeforeAllMethodParameterWithTestInstancePerClassTestCase.class);
 		}
 
-		private void assertResolvesShareTempDir(Class<? extends BaseSharedTempDirTestCase> testClass) {
-			ExecutionEventRecorder executionEventRecorder = executeTests(testClass);
-
-			assertEquals(2, executionEventRecorder.getTestStartedCount());
-			assertEquals(0, executionEventRecorder.getTestFailedCount());
-			assertEquals(2, executionEventRecorder.getTestSuccessfulCount());
-			assertThat(BaseSharedTempDirTestCase.tempDir).isPresent();
-			assertThat(BaseSharedTempDirTestCase.tempDir.get()).doesNotExist();
-		}
 	}
 
 	@Nested
@@ -143,6 +138,7 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 	@Nested
 	@DisplayName("resolves temp dir with custom parent dir")
 	class WithCustomParentDir {
+
 		@Test
 		@DisplayName("from Callable<Path>")
 		void resolvesTempDirWithCustomParentDirFromCallable() {
@@ -195,20 +191,16 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 				"Failed to get parent directory");
 		}
 
-		private void assertSingleFailedTest(ExecutionEventRecorder executionEventRecorder,
-				Class<? extends Throwable> clazz, String message) {
-			assertEquals(1, executionEventRecorder.getTestStartedCount());
-			assertEquals(1, executionEventRecorder.getTestFailedCount());
-			assertEquals(0, executionEventRecorder.getTestSuccessfulCount());
+	}
 
-			ExecutionEvent executionEvent = executionEventRecorder.getFailedTestFinishedEvents().get(0);
-			Optional<TestExecutionResult> result = executionEvent.getPayload(TestExecutionResult.class);
-			assertThat(result).isPresent();
-			assertThat(result.get().getStatus()).isEqualTo(FAILED);
-			Optional<Throwable> throwable = result.get().getThrowable();
-			assertThat(throwable).containsInstanceOf(clazz);
-			assertThat(throwable.get()).hasMessageContaining(message);
-		}
+	private void assertResolvesShareTempDir(Class<? extends BaseSharedTempDirTestCase> testClass) {
+		ExecutionEventRecorder executionEventRecorder = executeTests(testClass);
+
+		assertEquals(2, executionEventRecorder.getTestStartedCount());
+		assertEquals(0, executionEventRecorder.getTestFailedCount());
+		assertEquals(2, executionEventRecorder.getTestSuccessfulCount());
+		assertThat(BaseSharedTempDirTestCase.tempDir).isPresent();
+		assertThat(BaseSharedTempDirTestCase.tempDir.get()).doesNotExist();
 	}
 
 	private void assertResolvesSeparateTempDirs(Class<? extends BaseSeparateTempDirsTestCase> testClass) {
@@ -221,8 +213,24 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 		assertThat(tempDirs).hasSize(2);
 	}
 
+	private void assertSingleFailedTest(ExecutionEventRecorder executionEventRecorder, Class<? extends Throwable> clazz,
+			String message) {
+		assertEquals(1, executionEventRecorder.getTestStartedCount());
+		assertEquals(1, executionEventRecorder.getTestFailedCount());
+		assertEquals(0, executionEventRecorder.getTestSuccessfulCount());
+
+		ExecutionEvent executionEvent = executionEventRecorder.getFailedTestFinishedEvents().get(0);
+		Optional<TestExecutionResult> result = executionEvent.getPayload(TestExecutionResult.class);
+		assertThat(result).isPresent();
+		assertThat(result.get().getStatus()).isEqualTo(FAILED);
+		Optional<Throwable> throwable = result.get().getThrowable();
+		assertThat(throwable).containsInstanceOf(clazz);
+		assertThat(throwable.get()).hasMessageContaining(message);
+	}
+
 	@ExtendWith(TempDirectory.class)
 	static class BaseSharedTempDirTestCase {
+
 		static Optional<Path> tempDir;
 
 		@BeforeEach
@@ -249,38 +257,45 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 
 		static void check(Path tempDir) {
 			assertThat(BaseSharedTempDirTestCase.tempDir).isPresent();
-			assertSame(BaseSharedTempDirTestCase.tempDir.get(), tempDir);
-			assertTrue(Files.exists(tempDir));
+			assertThat(BaseSharedTempDirTestCase.tempDir).containsSame(tempDir);
+			assertThat(tempDir).exists();
 		}
+
 	}
 
 	static class AnnotationOnConstructorParameterTestCase extends BaseSharedTempDirTestCase {
+
 		AnnotationOnConstructorParameterTestCase(@TempDir Path tempDir) {
 			if (BaseSharedTempDirTestCase.tempDir.isPresent()) {
-				assertSame(BaseSharedTempDirTestCase.tempDir.get(), tempDir);
+				assertThat(BaseSharedTempDirTestCase.tempDir).containsSame(tempDir);
 			}
 			else {
 				BaseSharedTempDirTestCase.tempDir = Optional.of(tempDir);
 			}
 			check(tempDir);
 		}
+
 	}
 
 	static class AnnotationOnBeforeAllMethodParameterTestCase extends BaseSharedTempDirTestCase {
+
 		@BeforeAll
 		static void beforeAll(@TempDir Path tempDir) {
 			assertThat(BaseSharedTempDirTestCase.tempDir).isEmpty();
 			BaseSharedTempDirTestCase.tempDir = Optional.of(tempDir);
 			check(tempDir);
 		}
+
 	}
 
 	@TestInstance(PER_CLASS)
 	static class AnnotationOnConstructorParameterWithTestInstancePerClassTestCase
 			extends AnnotationOnConstructorParameterTestCase {
+
 		AnnotationOnConstructorParameterWithTestInstancePerClassTestCase(@TempDir Path tempDir) {
 			super(tempDir);
 		}
+
 	}
 
 	@TestInstance(PER_CLASS)
@@ -290,6 +305,7 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 
 	@ExtendWith(TempDirectory.class)
 	static class AnnotationOnAfterAllMethodParameterTestCase {
+
 		static Optional<Path> firstTempDir = Optional.empty();
 		static Optional<Path> secondTempDir = Optional.empty();
 
@@ -306,9 +322,11 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 			assertNotEquals(firstTempDir.get(), tempDir);
 			secondTempDir = Optional.of(tempDir);
 		}
+
 	}
 
 	static class BaseSeparateTempDirsTestCase {
+
 		static final Deque<Path> tempDirs = new LinkedList<>();
 
 		@BeforeEach
@@ -340,8 +358,9 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 
 		void check(@TempDir Path tempDir) {
 			assertSame(tempDirs.getLast(), tempDir);
-			assertTrue(Files.exists(tempDir));
+			assertThat(tempDir).exists();
 		}
+
 	}
 
 	@ExtendWith(TempDirectory.class)
@@ -355,10 +374,12 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 
 	@ExtendWith(TempDirectory.class)
 	static class InvalidTestCase {
+
 		@Test
 		void wrongParameterType(@TempDir File ignored) {
 			fail("this should never be called");
 		}
+
 	}
 
 	static class ParentDirFromCallableTestCase extends BaseSeparateTempDirsTestCase {
@@ -411,6 +432,7 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 				fileSystem.close();
 			}
 		}
+
 	}
 
 	static class FailedCreationAttemptTestCase {
@@ -433,6 +455,7 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 		void test(@TempDir Path tempDir) {
 			fail("this should never be called");
 		}
+
 	}
 
 	static class FailedDeletionAttemptTestCase {
@@ -465,6 +488,7 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 		void test(@TempDir Path tempDir) {
 			assertNotNull(tempDir);
 		}
+
 	}
 
 	static class ErroneousParentDirProviderTestCase {
@@ -480,6 +504,7 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 		void test(@TempDir Path tempDir) {
 			fail("this should never be called");
 		}
+
 	}
 
 	private static Path writeFile(@TempDir Path tempDir, TestInfo testInfo) throws IOException {
@@ -487,4 +512,5 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 		Files.write(file, testInfo.getDisplayName().getBytes());
 		return file;
 	}
+
 }


### PR DESCRIPTION
I've got an exception when TempDirectory was deleting its contents because one of the files has been deleted at the same time by the process started from test.
I think such disappearing files should be ignored by TempDirectory.

```
java.nio.file.NoSuchFileException: /var/folders/5p/6vn1lg4d6x3b5rmct9nkn96w0000gn/T/junit1862350231264789347/logs/foo.pid
    at sun.nio.fs.UnixException.translateToIOException(UnixException.java:86)
    at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
    at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
    at sun.nio.fs.UnixFileAttributeViews$Basic.readAttributes(UnixFileAttributeViews.java:55)
    at sun.nio.fs.UnixFileSystemProvider.readAttributes(UnixFileSystemProvider.java:144)
    at java.nio.file.Files.readAttributes(Files.java:1737)
    at java.nio.file.FileTreeWalker.getAttributes(FileTreeWalker.java:219)
    at java.nio.file.FileTreeWalker.visit(FileTreeWalker.java:276)
    at java.nio.file.FileTreeWalker.next(FileTreeWalker.java:372)
    at java.nio.file.Files.walkFileTree(Files.java:2706)
    at java.nio.file.Files.walkFileTree(Files.java:2742)
    at org.junitpioneer.jupiter.TempDirectory$CloseablePath.deleteAllFilesAndDirectories(TempDirectory.java:275)
    at org.junitpioneer.jupiter.TempDirectory$CloseablePath.close(TempDirectory.java:267)
...
```

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
