### PR TITLE
Fix distinct set collector

### DIFF
--- a/src/main/java/org/junitpioneer/jupiter/Utils.java
+++ b/src/main/java/org/junitpioneer/jupiter/Utils.java
@@ -50,10 +50,8 @@ class Utils {
 	 * on duplicate elements (according to {@link Object#equals(Object) equals}).
 	 */
 	public static <T> Collector<T, Set<T>, Set<T>> distinctToSet() {
-		return Collector.of(HashSet::new, (set, element) -> addButThrowIfDuplicate(set, element), (left, right) -> {
-			right.forEach(element -> {
-				addButThrowIfDuplicate(left, element);
-			});
+		return Collector.of(HashSet::new, Utils::addButThrowIfDuplicate, (left, right) -> {
+			right.forEach(element -> addButThrowIfDuplicate(left, element));
 			return left;
 		});
 	}

--- a/src/main/java/org/junitpioneer/jupiter/Utils.java
+++ b/src/main/java/org/junitpioneer/jupiter/Utils.java
@@ -56,8 +56,8 @@ class Utils {
 		});
 	}
 
-	private static <T> void addButThrowIfDuplicate(Set<T> right, T element) {
-		boolean newElement = right.add(element);
+	private static <T> void addButThrowIfDuplicate(Set<T> set, T element) {
+		boolean newElement = set.add(element);
 		if (!newElement) {
 			throw new IllegalStateException("Duplicate element '" + element + "'.");
 		}

--- a/src/main/java/org/junitpioneer/jupiter/Utils.java
+++ b/src/main/java/org/junitpioneer/jupiter/Utils.java
@@ -52,7 +52,7 @@ class Utils {
 	public static <T> Collector<T, Set<T>, Set<T>> distinctToSet() {
 		return Collector.of(HashSet::new, (set, element) -> addButThrowIfDuplicate(set, element), (left, right) -> {
 			right.forEach(element -> {
-				addButThrowIfDuplicate(right, element);
+				addButThrowIfDuplicate(left, element);
 			});
 			return left;
 		});

--- a/src/test/java/org/junitpioneer/jupiter/UtilsTest.java
+++ b/src/test/java/org/junitpioneer/jupiter/UtilsTest.java
@@ -85,7 +85,7 @@ class UtilsTest {
 
 			BinaryOperator<Set<Object>> combiner = collector.combiner();
 
-			assertThat(combiner.apply(left, right)).containsExactly(leftElement, rightElement);
+			assertThat(combiner.apply(left, right)).containsExactlyInAnyOrder(leftElement, rightElement);
 		}
 
 		@Test

--- a/src/test/java/org/junitpioneer/jupiter/UtilsTest.java
+++ b/src/test/java/org/junitpioneer/jupiter/UtilsTest.java
@@ -1,3 +1,12 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
 
 package org.junitpioneer.jupiter;
 

--- a/src/test/java/org/junitpioneer/jupiter/UtilsTest.java
+++ b/src/test/java/org/junitpioneer/jupiter/UtilsTest.java
@@ -1,0 +1,100 @@
+
+package org.junitpioneer.jupiter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Utils")
+class UtilsTest {
+
+	@Nested
+	@DisplayName("to distinct set")
+	class ToDistinctSetTests {
+
+		Collector<Object, Set<Object>, Set<Object>> collector;
+
+		@BeforeEach
+		void setUp() throws Exception {
+			collector = Utils.distinctToSet();
+		}
+
+		@Test
+		@DisplayName("should use hash set")
+		void supplierShouldUseHashSet() throws Exception {
+			Supplier<Set<Object>> supplier = collector.supplier();
+
+			assertThat(supplier.get()).isInstanceOf(HashSet.class);
+		}
+
+		@Test
+		@DisplayName("should add new elements")
+		void accumulatorShouldAddNewElements() throws Exception {
+			Set<Object> set = new HashSet<>();
+			Object element = new Object();
+
+			BiConsumer<Set<Object>, Object> accumulator = collector.accumulator();
+
+			accumulator.accept(set, element);
+
+			assertThat(set).containsExactly(element);
+		}
+
+		@Test
+		@DisplayName("should not add duplicate elements")
+		void accumulatorShouldNotAddDuplicateElements() throws Exception {
+			Set<Object> set = new HashSet<>();
+			Object element = new Object();
+			set.add(element);
+
+			BiConsumer<Set<Object>, Object> accumulator = collector.accumulator();
+
+			assertThatThrownBy(() -> accumulator.accept(set, element)).isInstanceOf(IllegalStateException.class);
+		}
+
+		@Test
+		@DisplayName("should should combine sets with new elements")
+		void combinerShouldCombineSetsWithNewElements() throws Exception {
+			Set<Object> left = new HashSet<>();
+			Object leftElement = new Object();
+			left.add(leftElement);
+
+			Set<Object> right = new HashSet<>();
+			Object rightElement = new Object();
+			right.add(rightElement);
+
+			BinaryOperator<Set<Object>> combiner = collector.combiner();
+
+			assertThat(combiner.apply(left, right)).containsExactly(leftElement, rightElement);
+		}
+
+		@Test
+		@DisplayName("should should not combine sets with duplicates")
+		void combinerShouldNotCombineSetsWithDuplicates() throws Exception {
+			Object element = new Object();
+
+			Set<Object> left = new HashSet<>();
+			left.add(element);
+
+			Set<Object> right = new HashSet<>();
+			right.add(element);
+
+			BinaryOperator<Set<Object>> combiner = collector.combiner();
+
+			assertThatThrownBy(() -> combiner.apply(left, right)).isInstanceOf(IllegalStateException.class);
+		}
+
+	}
+
+}

--- a/src/test/java/org/junitpioneer/jupiter/UtilsTest.java
+++ b/src/test/java/org/junitpioneer/jupiter/UtilsTest.java
@@ -73,7 +73,7 @@ class UtilsTest {
 		}
 
 		@Test
-		@DisplayName("should should combine sets with new elements")
+		@DisplayName("should combine sets with new elements")
 		void combinerShouldCombineSetsWithNewElements() throws Exception {
 			Set<Object> left = new HashSet<>();
 			Object leftElement = new Object();
@@ -89,7 +89,7 @@ class UtilsTest {
 		}
 
 		@Test
-		@DisplayName("should should not combine sets with duplicates")
+		@DisplayName("should not combine sets with duplicate elements")
 		void combinerShouldNotCombineSetsWithDuplicates() throws Exception {
 			Object element = new Object();
 

--- a/src/test/java/org/junitpioneer/jupiter/UtilsTest.java
+++ b/src/test/java/org/junitpioneer/jupiter/UtilsTest.java
@@ -17,7 +17,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.BinaryOperator;
-import java.util.function.Supplier;
 import java.util.stream.Collector;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -37,14 +36,6 @@ class UtilsTest {
 		@BeforeEach
 		void setUp() throws Exception {
 			collector = Utils.distinctToSet();
-		}
-
-		@Test
-		@DisplayName("should use hash set")
-		void supplierShouldUseHashSet() throws Exception {
-			Supplier<Set<Object>> supplier = collector.supplier();
-
-			assertThat(supplier.get()).isInstanceOf(HashSet.class);
 		}
 
 		@Test


### PR DESCRIPTION
A typo was introduced during refactoring (73d1d26) that caused the combiner to not work properly.

This PR adds a bunch of tests (ff16e46), fixes the aforementioned issue (6a90863) and does some refactoring (c30ae03 and 400983e).

Proposed commit message:

```
Fix distinct set collector

[As above, but without commit references.]

PR: 162
```

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
