### PR TITLE
Add handled exception as cause to final `AssertionError`

### DIFF
--- a/src/main/java/org/junitpioneer/jupiter/RepeatFailedTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/RepeatFailedTestExtension.java
@@ -97,7 +97,9 @@ public class RepeatFailedTestExtension implements TestTemplateInvocationContextP
 			boolean allRepetitionsFailed = exceptionsSoFar == maxRepetitions;
 			if (allRepetitionsFailed)
 				throw new AssertionError(
-					format("Test execution #%d (of up to %d) failed ~> test fails", exceptionsSoFar, maxRepetitions));
+					format("Test execution #%d (of up to %d) failed ~> test fails - see cause for details",
+						exceptionsSoFar, maxRepetitions),
+					exception);
 			else
 				throw new TestAbortedException(
 					format("Test execution #%d (of up to %d) failed ~> will retry...", exceptionsSoFar, maxRepetitions),


### PR DESCRIPTION
Addresses #160. It looks like I simply overlooked to pass on the inner exception - there seems to be absolutely no reason not to do that. Or did I miss something? Please someone have a look. :)

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
