### PR TITLE
Always use AssertJ assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,18 @@ For our own infrastructure, we rely on the following compile and test dependenci
 
 ### Code Style
 
+#### `Optional`
+
 [There shall be no null - use `Optional` instead.](https://blog.codefx.org/techniques/intention-revealing-code-java-8-optional/):
 
 * design code to avoid optionality wherever feasibly possible
-* in all remaining cases, prefer `Optional` over `null`.
+* in all remaining cases, prefer `Optional` over `null`
+
+#### Assertions
+
+All tests shall use [AssertJ](https://joel-costigliola.github.io/assertj/)'s assertions and not the ones build into Jupiter:
+
+* more easily discoverable API
+* more detailed assertion failures
+
+Yes, use it even if Jupiter's assertions are as good or better (c.f. `assertTrue(bool)` vs `assertThat(bool).isTrue()`) - that will spare us the discussion which assertion to use in a specific case.

--- a/docs/default-locale-timezone.adoc
+++ b/docs/default-locale-timezone.adoc
@@ -14,7 +14,7 @@ The default `Locale` can be specified using an https://docs.oracle.com/javase/8/
 @Test
 @DefaultLocale("zh-Hant-TW")
 void test_with_lanuage() {
-	assertEquals(Locale.forLanguageTag("zh-Hant-TW"), Locale.getDefault());
+	assertThat(Locale.getDefault()).isEqualsTo(Locale.forLanguageTag("zh-Hant-TW"));
 }
 ----
 
@@ -29,19 +29,19 @@ Alternatively the default `Locale` can be specified according to https://docs.or
 @Test
 @DefaultLocale(language = "en")
 void test_with_lanuage() {
-	assertEquals(new Locale("en"), Locale.getDefault());
+	assertThat(Locale.getDefault()).isEqualsTo(new Locale("en"));
 }
 
 @Test
 @DefaultLocale(language = "en", country = "EN")
 void test_with_lanuage_and_country() {
-	assertEquals(new Locale("en", "EN"), Locale.getDefault());
+	assertThat(Locale.getDefault()).isEqualsTo(new Locale("en", "EN"));
 }
 
 @Test
 @DefaultLocale(language = "en", country = "EN", variant = "gb")
 void test_with_lanuage_and_country_and_vairant() {
-	assertEquals(new Locale("en", "EN", "gb"), Locale.getDefault());
+	assertThat(Locale.getDefault()).isEqualsTo(new Locale("en", "EN", "gb"));
 }
 ----
 
@@ -58,13 +58,13 @@ class MyLocaleTests {
 
 	@Test
 	void test_with_class_level_configuration() {
-		assertEquals(new Locale("fr"), Locale.getDefault());
+		assertThat(Locale.getDefault()).isEqualsTo(new Locale("fr"));
 	}
 
 	@Test
 	@DefaultLocale(language = "en")
 	void test_with_method_level_configuration() {
-		assertEquals(new Locale("en"), Locale.getDefault());
+		aassertThat(Locale.getDefault()).isEqualsTo(new Locale("en"));
 	}
 }
 ----
@@ -78,13 +78,13 @@ The default `TimeZone` is specified according to the https://docs.oracle.com/jav
 @Test
 @DefaulTimeZone("CET")
 void test_with_short_zone_id() {
-	assertEquals(TimeZone.getTimeZone("CET"), TimeZone.getDefault());
+	assertThat(TimeZone.getDefault()).isEqualsTo(TimeZone.getTimeZone("CET"));
 }
 
 @Test
 @DefaultTimeZone("America/Los_Angeles")
 void test_with_long_zone_id() {
-	assertEquals(TimeZone.getTimeZone("America/Los_Angeles"), TimeZone.getDefault());
+	assertThat(TimeZone.getDefault()).isEqualsTo(TimeZone.getTimeZone("America/Los_Angeles"));
 }
 ----
 
@@ -97,13 +97,13 @@ class MyTimeZoneTests {
 
 	@Test
 	void test_with_class_level_configuration() {
-		assertEquals(TimeZone.getTimeZone("CET"), TimeZone.getDefault());
+		assertThat(TimeZone.getDefault()).isEqualsTo(TimeZone.getTimeZone("CET"));
 	}
 
 	@Test
 	@DefaultTimeZone("America/Los_Angeles")
 	void test_with_method_level_configuration() {
-		assertEquals(TimeZone.getTimeZone("America/Los_Angeles"), TimeZone.getDefault());
+        assertThat(TimeZone.getDefault()).isEqualsTo(TimeZone.getTimeZone("America/Los_Angeles"));
 	}
 }
 ----

--- a/docs/default-locale-timezone.adoc
+++ b/docs/default-locale-timezone.adoc
@@ -64,7 +64,7 @@ class MyLocaleTests {
 	@Test
 	@DefaultLocale(language = "en")
 	void test_with_method_level_configuration() {
-		aassertThat(Locale.getDefault()).isEqualsTo(new Locale("en"));
+		assertThat(Locale.getDefault()).isEqualsTo(new Locale("en"));
 	}
 }
 ----

--- a/docs/range-sources.adoc
+++ b/docs/range-sources.adoc
@@ -27,7 +27,7 @@ It can be positive or negative:
 ----
 @ParameterizedTest
 @DoubleRangeSource(from = -0.1, to = -10, step = -0.1)
-void howCouldIsIt(double d) {
+void howColdIsIt(double d) {
 	System.out.println(d + " degrees Celsius is cold");
 	System.out.println(d + " degrees Fahrenheit is REALY cold");
 	System.out.println(d + " degrees Kelvin is too cold to be true");
@@ -52,7 +52,7 @@ void illegalRange(byte arg) {
 @LongRangeSource(from = 0L, to = 0L, closed = true)
 void legalRrange(long arg) {
 	// But this is fine
-	assertEquals(0L, arg);
+	assertThat(arg).isEqualsTo(0L);
 }
 ----
 

--- a/docs/system-properties.adoc
+++ b/docs/system-properties.adoc
@@ -13,7 +13,7 @@ For example, clearing a system property for a test execution can be done as foll
 @Test
 @ClearSystemProperty(key = "some property")
 void test() {
-	assertNull(System.getProperty("some property"));
+	assertThat(System.getProperty("some property")).isNull();
 }
 ----
 
@@ -24,7 +24,7 @@ And setting a system property for a test execution:
 @Test
 @SetSystemProperty(key = "some property", value = "new value")
 void test() {
-	assertEquals("new value", System.getProperty("some property"));
+	assertThat(System.getProperty("some property")).isEqualsTo("new value");
 }
 ----
 
@@ -37,9 +37,9 @@ As mentioned before, both annotations are repeatable and they can also be combin
 @ClearSystemProperty(key = "2nd property")
 @SetSystemProperty(key = "3rd property", value = "new value")
 void test() {
-	assertNull(System.getProperty("1st property"));
-	assertNull(System.getProperty("2nd property"));
-	assertEquals("new value", System.getProperty("3rd property"));
+	assertThat(System.getProperty("1st property")).isNull();
+	assertThat(System.getProperty("2nd property")).isNull();
+	assertThat(System.getProperty("3rd property")).isEqualsTo("new value");
 }
 ----
 
@@ -52,7 +52,7 @@ class MySystemPropertyTest {
 	@Test
 	@SetSystemProperty(key = "some property", value = "new value")
 	void test() {
-		assertEquals("new value", System.getProperty("some property"));
+		assertThat(System.getProperty("some property")).isEqualsTo("new value");
 	}
 }
 ----

--- a/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
@@ -10,6 +10,11 @@
 
 package org.junitpioneer.jupiter;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Locale;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -22,11 +27,6 @@ import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.test.event.ExecutionEvent;
 import org.junit.platform.engine.test.event.ExecutionEventRecorder;
 import org.junitpioneer.AbstractPioneerTestEngineTests;
-
-import java.util.List;
-import java.util.Locale;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("DefaultLocale extension")
 class DefaultLocaleTests extends AbstractPioneerTestEngineTests {

--- a/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
@@ -10,12 +10,6 @@
 
 package org.junitpioneer.jupiter;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.util.List;
-import java.util.Locale;
-
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -28,6 +22,11 @@ import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.test.event.ExecutionEvent;
 import org.junit.platform.engine.test.event.ExecutionEventRecorder;
 import org.junitpioneer.AbstractPioneerTestEngineTests;
+
+import java.util.List;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("DefaultLocale extension")
 class DefaultLocaleTests extends AbstractPioneerTestEngineTests {
@@ -54,35 +53,35 @@ class DefaultLocaleTests extends AbstractPioneerTestEngineTests {
 		@Test
 		@DisplayName("does nothing when annotation is not present")
 		void testDefaultLocaleNoAnnotation() {
-			assertEquals(TEST_DEFAULT_LOCALE, Locale.getDefault());
+			assertThat(Locale.getDefault()).isEqualTo(TEST_DEFAULT_LOCALE);
 		}
 
 		@DefaultLocale("zh-Hant-TW")
 		@Test
 		@DisplayName("sets the default locale using a language tag")
 		void setsLocaleViaLanguageTag() {
-			assertEquals(Locale.forLanguageTag("zh-Hant-TW"), Locale.getDefault());
+			assertThat(Locale.getDefault()).isEqualTo(Locale.forLanguageTag("zh-Hant-TW"));
 		}
 
 		@DefaultLocale(language = "en_EN")
 		@Test
 		@DisplayName("sets the default locale using a language")
 		void setsLanguage() {
-			assertEquals(new Locale("en_EN"), Locale.getDefault());
+			assertThat(Locale.getDefault()).isEqualTo(new Locale("en_EN"));
 		}
 
 		@DefaultLocale(language = "en", country = "EN")
 		@Test
 		@DisplayName("sets the default locale using a language and a country")
 		void setsLanguageAndCountry() {
-			assertEquals(new Locale("en", "EN"), Locale.getDefault());
+			assertThat(Locale.getDefault()).isEqualTo(new Locale("en", "EN"));
 		}
 
 		@DefaultLocale(language = "en", country = "EN", variant = "gb")
 		@Test
 		@DisplayName("sets the default locale using a language, a country and a variant")
 		void setsLanguageAndCountryAndVariant() {
-			assertEquals(new Locale("en", "EN", "gb"), Locale.getDefault());
+			assertThat(Locale.getDefault()).isEqualTo(new Locale("en", "EN", "gb"));
 		}
 	}
 
@@ -92,20 +91,19 @@ class DefaultLocaleTests extends AbstractPioneerTestEngineTests {
 
 		@BeforeEach
 		void setUp() {
-			assertEquals(TEST_DEFAULT_LOCALE, Locale.getDefault());
+			assertThat(Locale.getDefault()).isEqualTo(TEST_DEFAULT_LOCALE);
 		}
 
 		@Test
 		@DisplayName("should execute tests with configured Locale")
 		void shouldExecuteTestsWithConfiguredLocale() {
 			ExecutionEventRecorder eventRecorder = executeTestsForClass(ClassLevelTestCase.class);
-
-			assertEquals(2, eventRecorder.getTestSuccessfulCount());
+			assertThat(eventRecorder.getTestSuccessfulCount()).isEqualTo(2);
 		}
 
 		@AfterEach
 		void tearDown() {
-			assertEquals(TEST_DEFAULT_LOCALE, Locale.getDefault());
+			assertThat(Locale.getDefault()).isEqualTo(TEST_DEFAULT_LOCALE);
 		}
 	}
 
@@ -114,13 +112,13 @@ class DefaultLocaleTests extends AbstractPioneerTestEngineTests {
 
 		@Test
 		void shouldExecuteWithClassLevelLocale() {
-			assertEquals(new Locale("fr", "FR"), Locale.getDefault());
+			assertThat(Locale.getDefault()).isEqualTo(new Locale("fr", "FR"));
 		}
 
 		@Test
 		@DefaultLocale(language = "de", country = "DE")
 		void shouldBeOverriddenWithMethodLevelLocale() {
-			assertEquals(new Locale("de", "DE"), Locale.getDefault());
+			assertThat(Locale.getDefault()).isEqualTo(new Locale("de", "DE"));
 		}
 	}
 
@@ -136,7 +134,7 @@ class DefaultLocaleTests extends AbstractPioneerTestEngineTests {
 			@Test
 			@DisplayName("DefaultLocale should be set from enclosed class when it is not provided in nested")
 			public void shouldSetLocaleFromEnclosedClass() {
-				assertEquals(Locale.getDefault().getLanguage(), "en");
+				assertThat("en").isEqualTo(Locale.getDefault().getLanguage());
 			}
 		}
 
@@ -148,14 +146,14 @@ class DefaultLocaleTests extends AbstractPioneerTestEngineTests {
 			@Test
 			@DisplayName("DefaultLocale should be set from nested class when it is provided")
 			public void shouldSetLocaleFromNestedClass() {
-				assertEquals(Locale.getDefault().getLanguage(), "de");
+				assertThat("de").isEqualTo(Locale.getDefault().getLanguage());
 			}
 
 			@Test
 			@DefaultLocale(language = "ch")
 			@DisplayName("DefaultLocale should be set from method when it is provided")
 			public void shouldSetLocaleFromMethodOfNestedClass() {
-				assertEquals(Locale.getDefault().getLanguage(), "ch");
+				assertThat("ch").isEqualTo(Locale.getDefault().getLanguage());
 			}
 		}
 
@@ -268,7 +266,7 @@ class DefaultLocaleTests extends AbstractPioneerTestEngineTests {
 	}
 
 	private static void assertExtensionConfigurationFailure(List<ExecutionEvent> failedTestFinishedEvents) {
-		assertEquals(1, failedTestFinishedEvents.size());
+		assertThat(failedTestFinishedEvents.size()).isEqualTo(1);
 		//@formatter:off
 		Throwable thrown = failedTestFinishedEvents.get(0)
 				.getPayload(TestExecutionResult.class)

--- a/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
@@ -10,6 +10,10 @@
 
 package org.junitpioneer.jupiter;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
@@ -21,10 +25,6 @@ import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.test.event.ExecutionEvent;
 import org.junit.platform.engine.test.event.ExecutionEventRecorder;
 import org.junitpioneer.AbstractPioneerTestEngineTests;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("SystemProperty extension")
 class SystemPropertyExtensionTests extends AbstractPioneerTestEngineTests {

--- a/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
@@ -10,17 +10,21 @@
 
 package org.junitpioneer.jupiter;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.util.List;
-
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.test.event.ExecutionEvent;
 import org.junit.platform.engine.test.event.ExecutionEventRecorder;
 import org.junitpioneer.AbstractPioneerTestEngineTests;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("SystemProperty extension")
 class SystemPropertyExtensionTests extends AbstractPioneerTestEngineTests {
@@ -250,7 +254,7 @@ class SystemPropertyExtensionTests extends AbstractPioneerTestEngineTests {
 	}
 
 	private static void assertExtensionConfigurationFailure(List<ExecutionEvent> failedTestFinishedEvents) {
-		assertEquals(1, failedTestFinishedEvents.size());
+		assertThat(failedTestFinishedEvents.size()).isEqualTo(1);
 		//@formatter:off
 		Throwable thrown = failedTestFinishedEvents.get(0)
 				.getPayload(TestExecutionResult.class)

--- a/src/test/java/org/junitpioneer/jupiter/TempDirectoryTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/TempDirectoryTests.java
@@ -10,7 +10,28 @@
 
 package org.junitpioneer.jupiter;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.platform.engine.TestExecutionResult.Status.FAILED;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.Optional;
+
 import com.google.common.jimfs.Jimfs;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -32,26 +53,6 @@ import org.junit.platform.engine.test.event.ExecutionEvent;
 import org.junit.platform.engine.test.event.ExecutionEventRecorder;
 import org.junitpioneer.AbstractPioneerTestEngineTests;
 import org.junitpioneer.jupiter.TempDirectory.TempDir;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.FileSystem;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.spi.FileSystemProvider;
-import java.util.Arrays;
-import java.util.Deque;
-import java.util.LinkedList;
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
-import static org.junit.platform.engine.TestExecutionResult.Status.FAILED;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @DisplayName("TempDirectory extension")
 class TempDirectoryTests extends AbstractPioneerTestEngineTests {

--- a/src/test/java/org/junitpioneer/jupiter/TempDirectoryTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/TempDirectoryTests.java
@@ -11,11 +11,7 @@
 package org.junitpioneer.jupiter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junit.platform.engine.TestExecutionResult.Status.FAILED;
 import static org.mockito.ArgumentMatchers.any;
@@ -57,6 +53,12 @@ import org.junit.platform.engine.test.event.ExecutionEvent;
 import org.junit.platform.engine.test.event.ExecutionEventRecorder;
 import org.junitpioneer.AbstractPioneerTestEngineTests;
 import org.junitpioneer.jupiter.TempDirectory.TempDir;
+
+//import static org.junit.jupiter.api.Assertions.assertEquals;
+//import static org.junit.jupiter.api.Assertions.assertNotEquals;
+//import static org.junit.jupiter.api.Assertions.assertNotNull;
+//import static org.junit.jupiter.api.Assertions.assertSame;
+//import static org.junit.jupiter.api.Assertions.fail;
 
 @DisplayName("TempDirectory extension")
 class TempDirectoryTests extends AbstractPioneerTestEngineTests {
@@ -109,9 +111,10 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 			ExecutionEventRecorder executionEventRecorder = executeTests(
 				AnnotationOnAfterAllMethodParameterTestCase.class);
 
-			assertEquals(1, executionEventRecorder.getTestStartedCount());
-			assertEquals(0, executionEventRecorder.getTestFailedCount());
-			assertEquals(1, executionEventRecorder.getTestSuccessfulCount());
+			assertThat(executionEventRecorder.getTestStartedCount()).isEqualTo(1);
+			assertThat(executionEventRecorder.getTestFailedCount()).isEqualTo(0);
+			assertThat(executionEventRecorder.getTestSuccessfulCount()).isEqualTo(1);
+
 			assertThat(AnnotationOnAfterAllMethodParameterTestCase.firstTempDir).isPresent();
 			assertThat(AnnotationOnAfterAllMethodParameterTestCase.firstTempDir.get()).doesNotExist();
 			assertThat(AnnotationOnAfterAllMethodParameterTestCase.secondTempDir).isPresent();
@@ -163,8 +166,8 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 			ExecutionEventRecorder executionEventRecorder = //
 				executeTests(DeletionTestCase.class, "test(java.nio.file.Path)");
 
-			assertEquals(1, executionEventRecorder.getTestStartedCount());
-			assertEquals(1, executionEventRecorder.getTestSuccessfulCount());
+			assertThat(executionEventRecorder.getTestStartedCount()).isEqualTo(1);
+			assertThat(executionEventRecorder.getTestSuccessfulCount()).isEqualTo(1);
 
 			assertThat(DeletionTestCase.tempDir).isPresent();
 			assertThat(DeletionTestCase.tempDir.get()).doesNotExist();
@@ -176,8 +179,8 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 			ExecutionEventRecorder executionEventRecorder = //
 				executeTests(DeletionTestCase.class, "testThatDeletes(java.nio.file.Path)");
 
-			assertEquals(1, executionEventRecorder.getTestStartedCount());
-			assertEquals(1, executionEventRecorder.getTestSuccessfulCount());
+			assertThat(executionEventRecorder.getTestStartedCount()).isEqualTo(1);
+			assertThat(executionEventRecorder.getTestSuccessfulCount()).isEqualTo(1);
 
 			assertThat(DeletionTestCase.tempDir).isPresent();
 			assertThat(DeletionTestCase.tempDir.get()).doesNotExist();
@@ -229,9 +232,10 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 	private void assertResolvesShareTempDir(Class<? extends BaseSharedTempDirTestCase> testClass) {
 		ExecutionEventRecorder executionEventRecorder = executeTests(testClass);
 
-		assertEquals(2, executionEventRecorder.getTestStartedCount());
-		assertEquals(0, executionEventRecorder.getTestFailedCount());
-		assertEquals(2, executionEventRecorder.getTestSuccessfulCount());
+		assertThat(executionEventRecorder.getTestStartedCount()).isEqualTo(2);
+		assertThat(executionEventRecorder.getTestFailedCount()).isEqualTo(0);
+		assertThat(executionEventRecorder.getTestSuccessfulCount()).isEqualTo(2);
+
 		assertThat(BaseSharedTempDirTestCase.tempDir).isPresent();
 		assertThat(BaseSharedTempDirTestCase.tempDir.get()).doesNotExist();
 	}
@@ -239,18 +243,19 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 	private void assertResolvesSeparateTempDirs(Class<? extends BaseSeparateTempDirsTestCase> testClass) {
 		ExecutionEventRecorder executionEventRecorder = executeTests(testClass);
 
-		assertEquals(2, executionEventRecorder.getTestStartedCount());
-		assertEquals(0, executionEventRecorder.getTestFailedCount());
-		assertEquals(2, executionEventRecorder.getTestSuccessfulCount());
+		assertThat(executionEventRecorder.getTestStartedCount()).isEqualTo(2);
+		assertThat(executionEventRecorder.getTestFailedCount()).isEqualTo(0);
+		assertThat(executionEventRecorder.getTestSuccessfulCount()).isEqualTo(2);
 		Deque<Path> tempDirs = BaseSeparateTempDirsTestCase.tempDirs;
 		assertThat(tempDirs).hasSize(2);
 	}
 
 	private void assertSingleFailedTest(ExecutionEventRecorder executionEventRecorder, Class<? extends Throwable> clazz,
 			String message) {
-		assertEquals(1, executionEventRecorder.getTestStartedCount());
-		assertEquals(1, executionEventRecorder.getTestFailedCount());
-		assertEquals(0, executionEventRecorder.getTestSuccessfulCount());
+
+		assertThat(executionEventRecorder.getTestStartedCount()).isEqualTo(1);
+		assertThat(executionEventRecorder.getTestFailedCount()).isEqualTo(1);
+		assertThat(executionEventRecorder.getTestSuccessfulCount()).isEqualTo(0);
 
 		ExecutionEvent executionEvent = executionEventRecorder.getFailedTestFinishedEvents().get(0);
 		Optional<TestExecutionResult> result = executionEvent.getPayload(TestExecutionResult.class);
@@ -352,7 +357,7 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 		@AfterAll
 		static void afterAll(@TempDir Path tempDir) {
 			assertThat(firstTempDir).isPresent();
-			assertNotEquals(firstTempDir.get(), tempDir);
+			assertThat(firstTempDir.get()).isNotEqualTo(tempDir);
 			secondTempDir = Optional.of(tempDir);
 		}
 
@@ -390,7 +395,7 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 		}
 
 		void check(@TempDir Path tempDir) {
-			assertSame(tempDirs.getLast(), tempDir);
+			assertThat(tempDirs.getLast()).isSameAs(tempDir);
 			assertThat(tempDir).exists();
 		}
 
@@ -480,7 +485,7 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 			private final FileSystem fileSystem;
 
 			JimfsFileSystemResource() {
-				this.fileSystem = Jimfs.newFileSystem();
+				fileSystem = Jimfs.newFileSystem();
 			}
 
 			FileSystem get() {
@@ -549,7 +554,7 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 
 		@Test
 		void test(@TempDir Path tempDir) {
-			assertNotNull(tempDir);
+			assertThat(tempDir).isNotNull();
 		}
 
 	}

--- a/src/test/java/org/junitpioneer/jupiter/TempDirectoryTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/TempDirectoryTests.java
@@ -10,28 +10,7 @@
 
 package org.junitpioneer.jupiter;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
-import static org.junit.platform.engine.TestExecutionResult.Status.FAILED;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.FileSystem;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.spi.FileSystemProvider;
-import java.util.Arrays;
-import java.util.Deque;
-import java.util.LinkedList;
-import java.util.Optional;
-
 import com.google.common.jimfs.Jimfs;
-
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -54,11 +33,25 @@ import org.junit.platform.engine.test.event.ExecutionEventRecorder;
 import org.junitpioneer.AbstractPioneerTestEngineTests;
 import org.junitpioneer.jupiter.TempDirectory.TempDir;
 
-//import static org.junit.jupiter.api.Assertions.assertEquals;
-//import static org.junit.jupiter.api.Assertions.assertNotEquals;
-//import static org.junit.jupiter.api.Assertions.assertNotNull;
-//import static org.junit.jupiter.api.Assertions.assertSame;
-//import static org.junit.jupiter.api.Assertions.fail;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.spi.FileSystemProvider;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+import static org.junit.platform.engine.TestExecutionResult.Status.FAILED;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @DisplayName("TempDirectory extension")
 class TempDirectoryTests extends AbstractPioneerTestEngineTests {

--- a/src/test/java/org/junitpioneer/jupiter/params/RangeSourceProviderTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/params/RangeSourceProviderTests.java
@@ -10,17 +10,6 @@
 
 package org.junitpioneer.jupiter.params;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.lang.reflect.Method;
-import java.util.List;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.LongStream;
-import java.util.stream.Stream;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -30,6 +19,16 @@ import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.test.event.ExecutionEvent;
 import org.junit.platform.engine.test.event.ExecutionEventRecorder;
 import org.junitpioneer.AbstractPioneerTestEngineTests;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for the {@link RangeSourceProvider}.
@@ -220,7 +219,8 @@ class RangeSourceProviderTests extends AbstractPioneerTestEngineTests {
 
 	private static void assertInvalidRange(ExecutionEventRecorder eventRecorder, String message) {
 		List<ExecutionEvent> failedContainerFinishedEvents = eventRecorder.getFailedContainerEvents();
-		assertEquals(1, failedContainerFinishedEvents.size());
+		assertThat(failedContainerFinishedEvents.size()).isEqualTo(1);
+
 		//@formatter:off
 		Throwable thrown = failedContainerFinishedEvents.get(0)
 				.getPayload(TestExecutionResult.class)
@@ -228,6 +228,6 @@ class RangeSourceProviderTests extends AbstractPioneerTestEngineTests {
 				.orElseThrow(AssertionError::new);
 		//@formatter:on
 		assertThat(thrown).isInstanceOf(PreconditionViolationException.class);
-		assertEquals(message, thrown.getMessage());
+		assertThat(thrown.getMessage()).isEqualTo(message);
 	}
 }

--- a/src/test/java/org/junitpioneer/jupiter/params/RangeSourceProviderTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/params/RangeSourceProviderTests.java
@@ -10,15 +10,7 @@
 
 package org.junitpioneer.jupiter.params;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.platform.commons.util.PreconditionViolationException;
-import org.junit.platform.engine.TestExecutionResult;
-import org.junit.platform.engine.test.event.ExecutionEvent;
-import org.junit.platform.engine.test.event.ExecutionEventRecorder;
-import org.junitpioneer.AbstractPioneerTestEngineTests;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -28,7 +20,15 @@ import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.platform.commons.util.PreconditionViolationException;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.test.event.ExecutionEvent;
+import org.junit.platform.engine.test.event.ExecutionEventRecorder;
+import org.junitpioneer.AbstractPioneerTestEngineTests;
 
 /**
  * Tests for the {@link RangeSourceProvider}.

--- a/src/test/java/org/junitpioneer/vintage/TestIntegrationTests.java
+++ b/src/test/java/org/junitpioneer/vintage/TestIntegrationTests.java
@@ -10,17 +10,16 @@
 
 package org.junitpioneer.vintage;
 
-import static java.lang.String.format;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junitpioneer.vintage.ExpectedExceptionExtension.EXPECTED_EXCEPTION_WAS_NOT_THROWN;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.test.event.ExecutionEventRecorder;
+import org.junitpioneer.AbstractPioneerTestEngineTests;
 
 import java.nio.file.InvalidPathException;
 import java.util.Optional;
 
-import org.junit.platform.engine.TestExecutionResult;
-import org.junit.platform.engine.test.event.ExecutionEventRecorder;
-import org.junitpioneer.AbstractPioneerTestEngineTests;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junitpioneer.vintage.ExpectedExceptionExtension.EXPECTED_EXCEPTION_WAS_NOT_THROWN;
 
 /**
  * Tests the vintage {@link Test @Test} annotation by running the entire test engine.
@@ -137,7 +136,7 @@ class TestIntegrationTests extends AbstractPioneerTestEngineTests {
 
 		@Test
 		void test_successfulTest() {
-			assertTrue(true);
+			assertThat(true).isTrue();
 		}
 
 		@Test
@@ -149,7 +148,7 @@ class TestIntegrationTests extends AbstractPioneerTestEngineTests {
 
 		@Test(expected = IllegalArgumentException.class)
 		void testWithExpectedException_successfulTest() {
-			assertTrue(true);
+			assertThat(true).isTrue();
 		}
 
 		@Test(expected = IllegalArgumentException.class)
@@ -171,7 +170,7 @@ class TestIntegrationTests extends AbstractPioneerTestEngineTests {
 
 		@Test(timeout = 10_000)
 		void testWithTimeout_belowTimeout() {
-			assertTrue(true);
+			assertThat(true).isTrue();
 		}
 
 		@Test(timeout = 1)

--- a/src/test/java/org/junitpioneer/vintage/TestIntegrationTests.java
+++ b/src/test/java/org/junitpioneer/vintage/TestIntegrationTests.java
@@ -10,16 +10,16 @@
 
 package org.junitpioneer.vintage;
 
-import org.junit.platform.engine.TestExecutionResult;
-import org.junit.platform.engine.test.event.ExecutionEventRecorder;
-import org.junitpioneer.AbstractPioneerTestEngineTests;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junitpioneer.vintage.ExpectedExceptionExtension.EXPECTED_EXCEPTION_WAS_NOT_THROWN;
 
 import java.nio.file.InvalidPathException;
 import java.util.Optional;
 
-import static java.lang.String.format;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junitpioneer.vintage.ExpectedExceptionExtension.EXPECTED_EXCEPTION_WAS_NOT_THROWN;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.test.event.ExecutionEventRecorder;
+import org.junitpioneer.AbstractPioneerTestEngineTests;
 
 /**
  * Tests the vintage {@link Test @Test} annotation by running the entire test engine.


### PR DESCRIPTION
In #165 most people voted for always using assertions of `AssertJ` instead of `Junit Jupiter`. This PR changes all occurences to the right one.

Fixes #165 
---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
