### PR TITLE
Improve Code Formatting

### DIFF
--- a/.infra/checkstyle/checkstyle.xml
+++ b/.infra/checkstyle/checkstyle.xml
@@ -21,6 +21,7 @@
 		<module name="UnusedImports">
 			<property name="processJavadoc" value="true" />
 		</module>
+		<module name="AvoidStarImport" />
 
 	</module>
 

--- a/.infra/eclipse/junit-eclipse-formatter-settings.xml
+++ b/.infra/eclipse/junit-eclipse-formatter-settings.xml
@@ -133,7 +133,8 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
-<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_last_class_body_declaration" value="1"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_closing_brace_in_array_initializer" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>

--- a/.infra/eclipse/junit-eclipse-formatter-settings.xml
+++ b/.infra/eclipse/junit-eclipse-formatter-settings.xml
@@ -203,7 +203,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
-<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
 <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="0"/>

--- a/.infra/eclipse/junit-eclipse-formatter-settings.xml
+++ b/.infra/eclipse/junit-eclipse-formatter-settings.xml
@@ -162,7 +162,7 @@
 <setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
 <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
-<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="48"/>
 <setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
 <setting id="org.eclipse.jdt.core.compiler.source" value="1.8"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>

--- a/.infra/eclipse/junit-eclipse-formatter-settings.xml
+++ b/.infra/eclipse/junit-eclipse-formatter-settings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<profiles version="12">
-<profile kind="CodeFormatterProfile" name="JUnit 5" version="12">
+<profiles version="18">
+<profile kind="CodeFormatterProfile" name="JUnit Pioneer" version="18">
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
 <setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration" value="insert"/>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     java
     checkstyle
     `maven-publish`
-    id("com.diffplug.gradle.spotless") version "3.24.3"
+    id("com.diffplug.gradle.spotless") version "3.27.1"
     id("org.shipkit.java") version "2.2.5"
     id("at.zierler.yamlvalidator") version "1.5.0"
     id("com.gradle.build-scan") version "2.4.2"

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
@@ -81,4 +81,5 @@ public @interface DefaultLocale {
 	 * See the {@link java.util.Locale} class description for the details.
 	 */
 	String variant() default "";
+
 }

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocaleExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocaleExtension.java
@@ -59,8 +59,7 @@ class DefaultLocaleExtension implements BeforeAllCallback, BeforeEachCallback, A
 	private static Locale createLocale(DefaultLocale annotation) {
 		if (!annotation.value().isEmpty()) {
 			return createFromLanguageTag(annotation);
-		}
-		else {
+		} else {
 			return createFromParts(annotation);
 		}
 	}
@@ -79,14 +78,11 @@ class DefaultLocaleExtension implements BeforeAllCallback, BeforeEachCallback, A
 		String variant = annotation.variant();
 		if (!language.isEmpty() && !country.isEmpty() && !variant.isEmpty()) {
 			return new Locale(language, country, variant);
-		}
-		else if (!language.isEmpty() && !country.isEmpty()) {
+		} else if (!language.isEmpty() && !country.isEmpty()) {
 			return new Locale(language, country);
-		}
-		else if (!language.isEmpty() && variant.isEmpty()) {
+		} else if (!language.isEmpty() && variant.isEmpty()) {
 			return new Locale(language);
-		}
-		else {
+		} else {
 			throw new ExtensionConfigurationException(
 				"@DefaultLocale not configured correctly. When not using a language tag, specify either"
 						+ "language, or language and country, or language and country and variant.");

--- a/src/main/java/org/junitpioneer/jupiter/DefaultTimeZone.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultTimeZone.java
@@ -48,4 +48,5 @@ public @interface DefaultTimeZone {
 	 * compatibility only and full names should be used.
 	 */
 	String value();
+
 }

--- a/src/main/java/org/junitpioneer/jupiter/SystemPropertyExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/SystemPropertyExtension.java
@@ -10,10 +10,16 @@
 
 package org.junitpioneer.jupiter;
 
-import static java.util.stream.Collectors.*;
+import static java.util.stream.Collectors.toMap;
 
 import java.lang.annotation.Annotation;
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.extension.AfterAllCallback;

--- a/src/main/java/org/junitpioneer/jupiter/SystemPropertyExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/SystemPropertyExtension.java
@@ -37,8 +37,9 @@ class SystemPropertyExtension implements BeforeAllCallback, BeforeEachCallback, 
 
 	@Override
 	public void beforeEach(ExtensionContext context) throws Exception {
-		boolean present = Utils.annotationPresentOnTestMethod(context, ClearSystemProperty.class,
-			ClearSystemProperties.class, SetSystemProperty.class, SetSystemProperties.class);
+		boolean present = Utils
+				.annotationPresentOnTestMethod(context, ClearSystemProperty.class, ClearSystemProperties.class,
+					SetSystemProperty.class, SetSystemProperties.class);
 		if (present) {
 			handleSystemProperties(context);
 		}
@@ -48,10 +49,13 @@ class SystemPropertyExtension implements BeforeAllCallback, BeforeEachCallback, 
 		Set<String> propertiesToClear;
 		Map<String, String> propertiesToSet;
 		try {
-			propertiesToClear = findRepeatableAnnotations(context, ClearSystemProperty.class).stream().map(
-				ClearSystemProperty::key).collect(Utils.distinctToSet());
-			propertiesToSet = findRepeatableAnnotations(context, SetSystemProperty.class).stream().collect(
-				toMap(SetSystemProperty::key, SetSystemProperty::value));
+			propertiesToClear = findRepeatableAnnotations(context, ClearSystemProperty.class)
+					.stream()
+					.map(ClearSystemProperty::key)
+					.collect(Utils.distinctToSet());
+			propertiesToSet = findRepeatableAnnotations(context, SetSystemProperty.class)
+					.stream()
+					.collect(toMap(SetSystemProperty::key, SetSystemProperty::value));
 			preventClearAndSetSameSystemProperties(propertiesToClear, propertiesToSet.keySet());
 		}
 		catch (IllegalStateException ex) {
@@ -65,24 +69,22 @@ class SystemPropertyExtension implements BeforeAllCallback, BeforeEachCallback, 
 
 	private void preventClearAndSetSameSystemProperties(Collection<String> propertiesToClear,
 			Collection<String> propertiesToSet) {
-		// @formatter:off
-		propertiesToClear.stream()
+		propertiesToClear
+				.stream()
 				.filter(propertiesToSet::contains)
 				.reduce((k0, k1) -> k0 + ", " + k1)
 				.ifPresent(duplicateKeys -> {
 					throw new IllegalStateException(
-							"Cannot clear and set the following system properties at the same time: " + duplicateKeys);
+						"Cannot clear and set the following system properties at the same time: " + duplicateKeys);
 				});
-		// @formatter:on
 	}
 
 	private <A extends Annotation> List<A> findRepeatableAnnotations(ExtensionContext context,
 			Class<A> annotationType) {
-		// @formatter:off
-		return context.getElement()
+		return context
+				.getElement()
 				.map(element -> AnnotationSupport.findRepeatableAnnotations(element, annotationType))
 				.orElseGet(Collections::emptyList);
-		// @formatter:on
 	}
 
 	private void storeOriginalSystemProperties(ExtensionContext context, Collection<String> clearProperties,
@@ -95,14 +97,17 @@ class SystemPropertyExtension implements BeforeAllCallback, BeforeEachCallback, 
 	}
 
 	private void setSystemProperties(Map<String, String> setProperties) {
-		setProperties.entrySet().forEach(
-			propertyWithValue -> System.setProperty(propertyWithValue.getKey(), propertyWithValue.getValue()));
+		setProperties
+				.entrySet()
+				.forEach(
+					propertyWithValue -> System.setProperty(propertyWithValue.getKey(), propertyWithValue.getValue()));
 	}
 
 	@Override
 	public void afterEach(ExtensionContext context) throws Exception {
-		boolean present = Utils.annotationPresentOnTestMethod(context, ClearSystemProperty.class,
-			ClearSystemProperties.class, SetSystemProperty.class, SetSystemProperties.class);
+		boolean present = Utils
+				.annotationPresentOnTestMethod(context, ClearSystemProperty.class, ClearSystemProperties.class,
+					SetSystemProperty.class, SetSystemProperties.class);
 		if (present) {
 			restoreOriginalSystemProperties(context);
 		}
@@ -128,28 +133,21 @@ class SystemPropertyExtension implements BeforeAllCallback, BeforeEachCallback, 
 		public SystemPropertyBackup(Collection<String> clearProperties, Collection<String> setProperties) {
 			propertiesToSet = new HashMap<>();
 			propertiesToUnset = new HashSet<>();
-			// @formatter:off
-			Stream.concat(clearProperties.stream(), setProperties.stream())
-					.forEach(property -> {
-						String backup = System.getProperty(property);
-						if (backup == null)
-							propertiesToUnset.add(property);
-						else
-							propertiesToSet.put(property, backup);
-					});
-			// @formatter:on
+			Stream.concat(clearProperties.stream(), setProperties.stream()).forEach(property -> {
+				String backup = System.getProperty(property);
+				if (backup == null)
+					propertiesToUnset.add(property);
+				else
+					propertiesToSet.put(property, backup);
+			});
 		}
 
 		public void restoreProperties() {
-			// @formatter:off
 			propertiesToSet
 					.entrySet()
-					.forEach(propertyWithValue -> System.setProperty(
-							propertyWithValue.getKey(),
-							propertyWithValue.getValue()));
-			propertiesToUnset
-					.forEach(System::clearProperty);
-			// @formatter:on
+					.forEach(propertyWithValue -> System
+							.setProperty(propertyWithValue.getKey(), propertyWithValue.getValue()));
+			propertiesToUnset.forEach(System::clearProperty);
 		}
 
 	}

--- a/src/main/java/org/junitpioneer/jupiter/TempDirectory.java
+++ b/src/main/java/org/junitpioneer/jupiter/TempDirectory.java
@@ -118,6 +118,7 @@ public class TempDirectory implements ParameterResolver {
 	 */
 	@FunctionalInterface
 	public interface ParentDirProvider {
+
 		/**
 		 * Get the parent directory for all temporary directories created by the
 		 * {@link TempDirectory} extension this is used with.
@@ -125,6 +126,7 @@ public class TempDirectory implements ParameterResolver {
 		 * @return the parent directory for all temporary directories
 		 */
 		Path get(ParameterContext parameterContext, ExtensionContext extensionContext) throws Exception;
+
 	}
 
 	/**
@@ -140,7 +142,9 @@ public class TempDirectory implements ParameterResolver {
 	 */
 	@FunctionalInterface
 	private interface TempDirProvider {
+
 		CloseablePath get(ParameterContext parameterContext, ExtensionContext extensionContext, String dirPrefix);
+
 	}
 
 	private static final Namespace NAMESPACE = Namespace.create(TempDirectory.class);
@@ -317,6 +321,7 @@ public class TempDirectory implements ParameterResolver {
 					}
 					return CONTINUE;
 				}
+
 			});
 			return failures;
 		}
@@ -352,5 +357,7 @@ public class TempDirectory implements ParameterResolver {
 				return path;
 			}
 		}
+
 	}
+
 }

--- a/src/main/java/org/junitpioneer/jupiter/TempDirectory.java
+++ b/src/main/java/org/junitpioneer/jupiter/TempDirectory.java
@@ -199,10 +199,8 @@ public class TempDirectory implements ParameterResolver {
 	 */
 	public static TempDirectory createInCustomDirectory(ParentDirProvider parentDirProvider) {
 		requireNonNull(parentDirProvider);
-		// @formatter:off
-		return new TempDirectory((parameterContext, extensionContext, dirPrefix) ->
-				createCustomTempDir(parentDirProvider, parameterContext, extensionContext, dirPrefix));
-		// @formatter:on
+		return new TempDirectory((parameterContext, extensionContext,
+				dirPrefix) -> createCustomTempDir(parentDirProvider, parameterContext, extensionContext, dirPrefix));
 	}
 
 	/**
@@ -233,7 +231,8 @@ public class TempDirectory implements ParameterResolver {
 			throw new ParameterResolutionException(
 				"Can only resolve parameter of type " + Path.class.getName() + " but was: " + parameterType.getName());
 		}
-		return extensionContext.getStore(NAMESPACE) //
+		return extensionContext
+				.getStore(NAMESPACE) //
 				.getOrComputeIfAbsent(KEY,
 					key -> tempDirProvider.get(parameterContext, extensionContext, TEMP_DIR_PREFIX),
 					CloseablePath.class) //
@@ -327,13 +326,13 @@ public class TempDirectory implements ParameterResolver {
 		}
 
 		private IOException createIOExceptionWithAttachedFailures(SortedMap<Path, IOException> failures) {
-			// @formatter:off
-			String joinedPaths = failures.keySet().stream()
+			String joinedPaths = failures
+					.keySet()
+					.stream()
 					.peek(this::tryToDeleteOnExit)
 					.map(this::relativizeSafely)
 					.map(String::valueOf)
 					.collect(joining(", "));
-			// @formatter:on
 			IOException exception = new IOException("Failed to delete temp directory " + dir.toAbsolutePath()
 					+ ". The following paths could not be deleted (see suppressed exceptions for details): "
 					+ joinedPaths);

--- a/src/main/java/org/junitpioneer/jupiter/Utils.java
+++ b/src/main/java/org/junitpioneer/jupiter/Utils.java
@@ -37,13 +37,12 @@ class Utils {
 	 */
 	public static boolean annotationPresentOnTestMethod(ExtensionContext context,
 			Class<? extends Annotation>... annotationTypes) {
-		//@formatter:off
-		return context.getTestMethod()
+		return context
+				.getTestMethod()
 				.map(testMethod -> Stream
 						.of(annotationTypes)
 						.anyMatch(annotationType -> AnnotationSupport.isAnnotated(testMethod, annotationType)))
 				.orElse(false);
-		//@formatter:on
 	}
 
 	/**
@@ -51,13 +50,12 @@ class Utils {
 	 * <em>meta-present</em> on the test method belonging to the specified {@code context}.
 	 */
 	public static <A extends Annotation> Optional<A> findAnnotation(ExtensionContext context, Class<A> annotationType) {
-		//@formatter:off
-		return Stream.of(context.getElement(), context.getTestClass().map(Class::getEnclosingClass))
+		return Stream
+				.of(context.getElement(), context.getTestClass().map(Class::getEnclosingClass))
 				.map(el -> AnnotationSupport.findAnnotation(el, annotationType))
 				.filter(Optional::isPresent)
 				.findFirst()
 				.orElse(Optional.empty());
-		//@formatter:on
 	}
 
 	/**

--- a/src/main/java/org/junitpioneer/jupiter/params/ByteRange.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/ByteRange.java
@@ -11,6 +11,7 @@
 package org.junitpioneer.jupiter.params;
 
 class ByteRange extends Range<Byte> {
+
 	public ByteRange(ByteRangeSource source) {
 		super(source.from(), source.to(), source.step(), source.closed());
 	}
@@ -24,4 +25,5 @@ class ByteRange extends Range<Byte> {
 	Byte getZero() {
 		return 0;
 	}
+
 }

--- a/src/main/java/org/junitpioneer/jupiter/params/ByteRangeSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/ByteRangeSource.java
@@ -53,4 +53,5 @@ public @interface ByteRangeSource {
 	 * Whether the range is closed (inclusive of the {@link #to()}) or not.
 	 */
 	boolean closed() default false;
+
 }

--- a/src/main/java/org/junitpioneer/jupiter/params/DoubleRange.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/DoubleRange.java
@@ -11,6 +11,7 @@
 package org.junitpioneer.jupiter.params;
 
 class DoubleRange extends Range<Double> {
+
 	public DoubleRange(DoubleRangeSource source) {
 		super(source.from(), source.to(), source.step(), source.closed());
 	}
@@ -24,4 +25,5 @@ class DoubleRange extends Range<Double> {
 	Double getZero() {
 		return 0.0D;
 	}
+
 }

--- a/src/main/java/org/junitpioneer/jupiter/params/DoubleRangeSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/DoubleRangeSource.java
@@ -53,4 +53,5 @@ public @interface DoubleRangeSource {
 	 * Whether the range is closed (inclusive of the {@link #to()}) or not.
 	 */
 	boolean closed() default false;
+
 }

--- a/src/main/java/org/junitpioneer/jupiter/params/FloatRange.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/FloatRange.java
@@ -11,6 +11,7 @@
 package org.junitpioneer.jupiter.params;
 
 class FloatRange extends Range<Float> {
+
 	public FloatRange(FloatRangeSource source) {
 		super(source.from(), source.to(), source.step(), source.closed());
 	}
@@ -24,4 +25,5 @@ class FloatRange extends Range<Float> {
 	Float getZero() {
 		return 0.0F;
 	}
+
 }

--- a/src/main/java/org/junitpioneer/jupiter/params/FloatRangeSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/FloatRangeSource.java
@@ -53,4 +53,5 @@ public @interface FloatRangeSource {
 	 * Whether the range is closed (inclusive of the {@link #to()}) or not.
 	 */
 	boolean closed() default false;
+
 }

--- a/src/main/java/org/junitpioneer/jupiter/params/IntRange.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/IntRange.java
@@ -11,6 +11,7 @@
 package org.junitpioneer.jupiter.params;
 
 class IntRange extends Range<Integer> {
+
 	public IntRange(IntRangeSource source) {
 		super(source.from(), source.to(), source.step(), source.closed());
 	}
@@ -24,4 +25,5 @@ class IntRange extends Range<Integer> {
 	Integer getZero() {
 		return 0;
 	}
+
 }

--- a/src/main/java/org/junitpioneer/jupiter/params/IntRangeSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/IntRangeSource.java
@@ -53,4 +53,5 @@ public @interface IntRangeSource {
 	 * Whether the range is closed (inclusive of the {@link #to()}) or not.
 	 */
 	boolean closed() default false;
+
 }

--- a/src/main/java/org/junitpioneer/jupiter/params/LongRange.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/LongRange.java
@@ -11,6 +11,7 @@
 package org.junitpioneer.jupiter.params;
 
 class LongRange extends Range<Long> {
+
 	public LongRange(LongRangeSource source) {
 		super(source.from(), source.to(), source.step(), source.closed());
 	}
@@ -24,4 +25,5 @@ class LongRange extends Range<Long> {
 	Long getZero() {
 		return 0L;
 	}
+
 }

--- a/src/main/java/org/junitpioneer/jupiter/params/LongRangeSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/LongRangeSource.java
@@ -53,4 +53,5 @@ public @interface LongRangeSource {
 	 * Whether the range is closed (inclusive of the {@link #to()}) or not.
 	 */
 	boolean closed() default false;
+
 }

--- a/src/main/java/org/junitpioneer/jupiter/params/Range.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/Range.java
@@ -21,6 +21,7 @@ import org.junit.platform.commons.util.Preconditions;
  * @param <N> The numerical type used by the range.
  */
 abstract class Range<N extends Number & Comparable<N>> implements Iterator<N> {
+
 	private N from;
 	private N to;
 	private N step;
@@ -97,4 +98,5 @@ abstract class Range<N extends Number & Comparable<N>> implements Iterator<N> {
 		current = getNextValue();
 		return current;
 	}
+
 }

--- a/src/main/java/org/junitpioneer/jupiter/params/Range.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/Range.java
@@ -45,13 +45,15 @@ abstract class Range<N extends Number & Comparable<N>> implements Iterator<N> {
 	void validate() throws PreconditionViolationException {
 		Preconditions.condition(!step.equals(getZero()), "Illegal range. The step cannot be zero.");
 
-		Preconditions.condition(closed || !from.equals(to),
-			"Illegal range. Equal from and to will produce an empty range.");
+		Preconditions
+				.condition(closed || !from.equals(to), "Illegal range. Equal from and to will produce an empty range.");
 
 		int cmp = from.compareTo(to);
-		Preconditions.condition((cmp < 0 != sign < 0) || (closed && cmp == 0),
-			() -> String.format("Illegal range. There's no way to get from %s to %s with a step of %s.", from, to,
-				step));
+		Preconditions
+				.condition((cmp < 0 != sign < 0) || (closed && cmp == 0),
+					() -> String
+							.format("Illegal range. There's no way to get from %s to %s with a step of %s.", from, to,
+								step));
 	}
 
 	N getStep() {

--- a/src/main/java/org/junitpioneer/jupiter/params/RangeClass.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/RangeClass.java
@@ -25,5 +25,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface RangeClass {
+
 	Class<? extends Range> value();
+
 }

--- a/src/main/java/org/junitpioneer/jupiter/params/RangeSourceProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/RangeSourceProvider.java
@@ -46,7 +46,6 @@ class RangeSourceProvider implements ArgumentsProvider {
 
 	@Override
 	public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
-		// @formatter:off
 		// since it's a method annotation, the element will always be present
 		List<Annotation> argumentsSources = context
 				.getElement()
@@ -58,13 +57,11 @@ class RangeSourceProvider implements ArgumentsProvider {
 						.collect(Collectors.toList()))
 				.get();
 
-		Preconditions.condition(
-				argumentsSources.size() == 1,
-				() -> String.format(
-						"Expected exactly one annotation to provide an ArgumentSource, found %d.",
-						argumentsSources.size()));
-		// @formatter:on
-
+		Preconditions
+				.condition(argumentsSources.size() == 1,
+					() -> String
+							.format("Expected exactly one annotation to provide an ArgumentSource, found %d.",
+								argumentsSources.size()));
 		Annotation argumentsSource = argumentsSources.get(0);
 		Class<? extends Annotation> argumentsSourceClass = argumentsSource.annotationType();
 		Class<? extends Range> rangeClass = argumentsSourceClass.getAnnotation(RangeClass.class).value();

--- a/src/main/java/org/junitpioneer/jupiter/params/ShortRange.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/ShortRange.java
@@ -11,6 +11,7 @@
 package org.junitpioneer.jupiter.params;
 
 class ShortRange extends Range<Short> {
+
 	public ShortRange(ShortRangeSource source) {
 		super(source.from(), source.to(), source.step(), source.closed());
 	}
@@ -24,4 +25,5 @@ class ShortRange extends Range<Short> {
 	Short getZero() {
 		return 0;
 	}
+
 }

--- a/src/main/java/org/junitpioneer/jupiter/params/ShortRangeSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/ShortRangeSource.java
@@ -53,4 +53,5 @@ public @interface ShortRangeSource {
 	 * Whether the range is closed (inclusive of the {@link #to()}) or not.
 	 */
 	boolean closed() default false;
+
 }

--- a/src/main/java/org/junitpioneer/vintage/ExpectedExceptionExtension.java
+++ b/src/main/java/org/junitpioneer/vintage/ExpectedExceptionExtension.java
@@ -52,8 +52,7 @@ class ExpectedExceptionExtension implements TestExecutionExceptionHandler, After
 		// (NOTE that if no exception was thrown, NOTHING is registered)
 		if (throwableMatchesExpectedException) {
 			storeExceptionStatus(context, EXCEPTION.WAS_THROWN_AS_EXPECTED);
-		}
-		else {
+		} else {
 			// this extension is not in charge of the throwable, so we need to rethrow;
 			storeExceptionStatus(context, EXCEPTION.WAS_THROWN_NOT_AS_EXPECTED);
 			throw throwable;
@@ -96,8 +95,7 @@ class ExpectedExceptionExtension implements TestExecutionExceptionHandler, After
 		EXCEPTION thrown = context.getStore(NAMESPACE).get(KEY, EXCEPTION.class);
 		if (thrown == null) {
 			return EXCEPTION.WAS_NOT_THROWN;
-		}
-		else {
+		} else {
 			return thrown;
 		}
 	}

--- a/src/main/java/org/junitpioneer/vintage/Test.java
+++ b/src/main/java/org/junitpioneer/vintage/Test.java
@@ -46,6 +46,7 @@ public @interface Test {
 
 		private None() {
 		}
+
 	}
 
 	/**

--- a/src/test/java/org/junit/platform/engine/test/TestDescriptorStub.java
+++ b/src/test/java/org/junit/platform/engine/test/TestDescriptorStub.java
@@ -26,4 +26,5 @@ public class TestDescriptorStub extends AbstractTestDescriptor {
 	public Type getType() {
 		return getChildren().isEmpty() ? Type.TEST : Type.CONTAINER;
 	}
+
 }

--- a/src/test/java/org/junit/platform/engine/test/TestEngineSpy.java
+++ b/src/test/java/org/junit/platform/engine/test/TestEngineSpy.java
@@ -48,4 +48,5 @@ public class TestEngineSpy implements TestEngine {
 	public void execute(ExecutionRequest request) {
 		this.requestForExecution = request;
 	}
+
 }

--- a/src/test/java/org/junit/platform/engine/test/event/ExecutionEvent.java
+++ b/src/test/java/org/junit/platform/engine/test/event/ExecutionEvent.java
@@ -94,13 +94,11 @@ public class ExecutionEvent {
 
 	@Override
 	public String toString() {
-		// @formatter:off
 		return new ToStringBuilder(this)
 				.append("type", type)
 				.append("testDescriptor", testDescriptor)
 				.append("payload", payload)
 				.toString();
-		// @formatter:on
 	}
 
 }

--- a/src/test/java/org/junit/platform/engine/test/event/ExecutionEventRecorder.java
+++ b/src/test/java/org/junit/platform/engine/test/event/ExecutionEventRecorder.java
@@ -47,11 +47,12 @@ import org.junit.platform.engine.test.event.ExecutionEvent.Type;
 public class ExecutionEventRecorder implements EngineExecutionListener {
 
 	public static List<ExecutionEvent> execute(TestEngine testEngine, EngineDiscoveryRequest discoveryRequest) {
-		TestDescriptor engineTestDescriptor = testEngine.discover(discoveryRequest,
-			UniqueId.forEngine(testEngine.getId()));
+		TestDescriptor engineTestDescriptor = testEngine
+				.discover(discoveryRequest, UniqueId.forEngine(testEngine.getId()));
 		ExecutionEventRecorder listener = new ExecutionEventRecorder();
-		testEngine.execute(
-			new ExecutionRequest(engineTestDescriptor, listener, discoveryRequest.getConfigurationParameters()));
+		testEngine
+				.execute(new ExecutionRequest(engineTestDescriptor, listener,
+					discoveryRequest.getConfigurationParameters()));
 		return listener.getExecutionEvents();
 	}
 
@@ -159,8 +160,8 @@ public class ExecutionEventRecorder implements EngineExecutionListener {
 	}
 
 	private Stream<ExecutionEvent> testFinishedEvents(Status status) {
-		return testEventsByType(FINISHED).filter(
-			byPayload(TestExecutionResult.class, where(TestExecutionResult::getStatus, isEqual(status))));
+		return testEventsByType(FINISHED)
+				.filter(byPayload(TestExecutionResult.class, where(TestExecutionResult::getStatus, isEqual(status))));
 	}
 
 	private Stream<ExecutionEvent> testEventsByType(Type type) {
@@ -168,8 +169,8 @@ public class ExecutionEventRecorder implements EngineExecutionListener {
 	}
 
 	private Stream<ExecutionEvent> containerFinishedEvents(Status status) {
-		return containerEventsByType(FINISHED).filter(
-			byPayload(TestExecutionResult.class, where(TestExecutionResult::getStatus, isEqual(status))));
+		return containerEventsByType(FINISHED)
+				.filter(byPayload(TestExecutionResult.class, where(TestExecutionResult::getStatus, isEqual(status))));
 	}
 
 	private Stream<ExecutionEvent> containerEventsByType(Type type) {

--- a/src/test/java/org/junitpioneer/AbstractPioneerTestEngineTests.java
+++ b/src/test/java/org/junitpioneer/AbstractPioneerTestEngineTests.java
@@ -54,8 +54,7 @@ public abstract class AbstractPioneerTestEngineTests extends AbstractJupiterTest
 			String methodName = methodSignature.substring(0, open);
 			String methodParameters = methodSignature.substring(open + 1, close);
 			return selectMethod(type, methodName, methodParameters);
-		}
-		else {
+		} else {
 			return selectMethod(type, methodSignature);
 		}
 	}

--- a/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
@@ -83,6 +83,7 @@ class DefaultLocaleTests extends AbstractPioneerTestEngineTests {
 		void setsLanguageAndCountryAndVariant() {
 			assertThat(Locale.getDefault()).isEqualTo(new Locale("en", "EN", "gb"));
 		}
+
 	}
 
 	@Nested
@@ -105,6 +106,7 @@ class DefaultLocaleTests extends AbstractPioneerTestEngineTests {
 		void tearDown() {
 			assertThat(Locale.getDefault()).isEqualTo(TEST_DEFAULT_LOCALE);
 		}
+
 	}
 
 	@DefaultLocale(language = "fr", country = "FR")
@@ -120,6 +122,7 @@ class DefaultLocaleTests extends AbstractPioneerTestEngineTests {
 		void shouldBeOverriddenWithMethodLevelLocale() {
 			assertThat(Locale.getDefault()).isEqualTo(new Locale("de", "DE"));
 		}
+
 	}
 
 	@DisplayName("with nested classes")
@@ -136,6 +139,7 @@ class DefaultLocaleTests extends AbstractPioneerTestEngineTests {
 			public void shouldSetLocaleFromEnclosedClass() {
 				assertThat("en").isEqualTo(Locale.getDefault().getLanguage());
 			}
+
 		}
 
 		@Nested
@@ -155,6 +159,7 @@ class DefaultLocaleTests extends AbstractPioneerTestEngineTests {
 			public void shouldSetLocaleFromMethodOfNestedClass() {
 				assertThat("ch").isEqualTo(Locale.getDefault().getLanguage());
 			}
+
 		}
 
 	}
@@ -211,6 +216,7 @@ class DefaultLocaleTests extends AbstractPioneerTestEngineTests {
 
 				assertExtensionConfigurationFailure(eventRecorder.getFailedTestFinishedEvents());
 			}
+
 		}
 
 		@Nested
@@ -225,7 +231,9 @@ class DefaultLocaleTests extends AbstractPioneerTestEngineTests {
 
 				assertExtensionConfigurationFailure(eventRecorder.getFailedContainerEvents());
 			}
+
 		}
+
 	}
 
 	static class MethodLevelInitializationFailureTestCase {
@@ -275,4 +283,5 @@ class DefaultLocaleTests extends AbstractPioneerTestEngineTests {
 		//@formatter:on
 		assertThat(thrown).isInstanceOf(ExtensionConfigurationException.class);
 	}
+
 }

--- a/src/test/java/org/junitpioneer/jupiter/DefaultTimeZoneTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultTimeZoneTests.java
@@ -39,8 +39,7 @@ class DefaultTimeZoneTests extends AbstractPioneerTestEngineTests {
 		TimeZone gmt = TimeZone.getTimeZone("GMT");
 		if (DEFAULT_TIMEZONE_BEFORE_TEST.equals(utc)) {
 			TimeZone.setDefault(gmt);
-		}
-		else {
+		} else {
 			TimeZone.setDefault(utc);
 		}
 		TEST_DEFAULT_TIMEZONE = TimeZone.getDefault();

--- a/src/test/java/org/junitpioneer/jupiter/DefaultTimeZoneTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultTimeZoneTests.java
@@ -73,6 +73,7 @@ class DefaultTimeZoneTests extends AbstractPioneerTestEngineTests {
 		void setsTimeZoneFromFullName() {
 			assertEquals(TimeZone.getTimeZone("America/Los_Angeles"), TimeZone.getDefault());
 		}
+
 	}
 
 	@Nested
@@ -96,6 +97,7 @@ class DefaultTimeZoneTests extends AbstractPioneerTestEngineTests {
 		void tearDown() {
 			assertEquals(TEST_DEFAULT_TIMEZONE, TimeZone.getDefault());
 		}
+
 	}
 
 	@DefaultTimeZone("GMT-8:00")
@@ -111,6 +113,7 @@ class DefaultTimeZoneTests extends AbstractPioneerTestEngineTests {
 		void shouldBeOverriddenWithMethodLevelTimeZone() {
 			assertEquals(TimeZone.getTimeZone("GMT-12:00"), TimeZone.getDefault());
 		}
+
 	}
 
 	@DisplayName("with nested classes")
@@ -127,6 +130,7 @@ class DefaultTimeZoneTests extends AbstractPioneerTestEngineTests {
 			public void shouldSetTimeZoneFromEnclosedClass() {
 				assertEquals(TimeZone.getTimeZone("GMT-8:00"), TimeZone.getDefault());
 			}
+
 		}
 
 		@Nested
@@ -146,6 +150,7 @@ class DefaultTimeZoneTests extends AbstractPioneerTestEngineTests {
 			public void shouldSetTimeZoneFromMethodOfNestedClass() {
 				assertEquals(TimeZone.getTimeZone("GMT-6:00"), TimeZone.getDefault());
 			}
+
 		}
 
 	}

--- a/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
@@ -171,6 +171,7 @@ class SystemPropertyExtensionTests extends AbstractPioneerTestEngineTests {
 				assertThat(System.getProperty("set prop A")).isNull();
 				assertThat(System.getProperty("set prop B")).isEqualTo("new B");
 			}
+
 		}
 
 		@Nested
@@ -190,6 +191,7 @@ class SystemPropertyExtensionTests extends AbstractPioneerTestEngineTests {
 			public void shouldSetSystemPropertyFromMethodOfNestedClass() {
 				assertThat(System.getProperty("set prop B")).isEqualTo("newest B");
 			}
+
 		}
 
 	}

--- a/src/test/java/org/junitpioneer/jupiter/TempDirectoryTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/TempDirectoryTests.java
@@ -131,6 +131,7 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 			assertThat(BaseSeparateTempDirsTestCase.tempDirs.getFirst()).doesNotExist();
 			assertThat(BaseSeparateTempDirsTestCase.tempDirs.getLast()).doesNotExist();
 		}
+
 	}
 
 	@Nested
@@ -148,6 +149,7 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 		void resolvesTempDirWithCustomParentDirFromProvider() {
 			assertResolvesSeparateTempDirs(ParentDirFromProviderTestCase.class);
 		}
+
 	}
 
 	@Nested
@@ -474,6 +476,7 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 		});
 
 		static class JimfsFileSystemResource implements CloseableResource {
+
 			private final FileSystem fileSystem;
 
 			JimfsFileSystemResource() {
@@ -490,6 +493,7 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 				assertThat(tempDirs.getLast()).doesNotExist();
 				fileSystem.close();
 			}
+
 		}
 
 	}

--- a/src/test/java/org/junitpioneer/jupiter/TempDirectoryTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/TempDirectoryTests.java
@@ -300,8 +300,7 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 		AnnotationOnConstructorParameterTestCase(@TempDir Path tempDir) {
 			if (BaseSharedTempDirTestCase.tempDir.isPresent()) {
 				assertThat(BaseSharedTempDirTestCase.tempDir).containsSame(tempDir);
-			}
-			else {
+			} else {
 				BaseSharedTempDirTestCase.tempDir = Optional.of(tempDir);
 			}
 			check(tempDir);
@@ -424,8 +423,7 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 		private void storeTempDir(@TempDir Path tempDir) {
 			if (DeletionTestCase.tempDir.isPresent()) {
 				assertThat(DeletionTestCase.tempDir).containsSame(tempDir);
-			}
-			else {
+			} else {
 				assertThat(tempDir).exists();
 				DeletionTestCase.tempDir = Optional.of(tempDir);
 			}

--- a/src/test/java/org/junitpioneer/jupiter/TempDirectoryTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/TempDirectoryTests.java
@@ -460,8 +460,8 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 		}
 
 		@RegisterExtension
-		Extension tempDirectory = TempDirectory.createInCustomDirectory(
-			() -> Files.createDirectories(fileSystem.getPath("tmp")));
+		Extension tempDirectory = TempDirectory
+				.createInCustomDirectory(() -> Files.createDirectories(fileSystem.getPath("tmp")));
 
 	}
 
@@ -470,8 +470,10 @@ class TempDirectoryTests extends AbstractPioneerTestEngineTests {
 		@RegisterExtension
 		Extension tempDirectory = TempDirectory.createInCustomDirectory((parameterContext, extensionContext) -> {
 			Store store = extensionContext.getRoot().getStore(Namespace.GLOBAL);
-			FileSystem fileSystem = store.getOrComputeIfAbsent("jimfs.fileSystem", key -> new JimfsFileSystemResource(),
-				JimfsFileSystemResource.class).get();
+			FileSystem fileSystem = store
+					.getOrComputeIfAbsent("jimfs.fileSystem", key -> new JimfsFileSystemResource(),
+						JimfsFileSystemResource.class)
+					.get();
 			return Files.createDirectories(fileSystem.getPath("tmp"));
 		});
 

--- a/src/test/java/org/junitpioneer/jupiter/params/RangeSourceProviderTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/params/RangeSourceProviderTests.java
@@ -91,6 +91,7 @@ class RangeSourceProviderTests extends AbstractPioneerTestEngineTests {
 
 	@Nested
 	class RangeTestCases {
+
 		@ParameterizedTest(name = "Byte {0}")
 		@ByteRangeSource(from = 0, to = 10)
 		void ascendingByte(byte param) {
@@ -165,10 +166,12 @@ class RangeSourceProviderTests extends AbstractPioneerTestEngineTests {
 		@ByteRangeSource(from = -120, to = -125, step = -10)
 		void underflowProtection(byte param) {
 		}
+
 	}
 
 	@Nested
 	class InvalidRangeTestCases {
+
 		@Test
 		void twoAnnotations() {
 			ExecutionEventRecorder eventRecorder = executeTests(InvalidRanges.class, "twoAnnotations");
@@ -192,9 +195,11 @@ class RangeSourceProviderTests extends AbstractPioneerTestEngineTests {
 			ExecutionEventRecorder eventRecorder = executeTests(InvalidRanges.class, "emptyRange");
 			assertInvalidRange(eventRecorder, "Illegal range. Equal from and to will produce an empty range.");
 		}
+
 	}
 
 	static class InvalidRanges {
+
 		@IntRangeSource(from = 1, to = 2)
 		@LongRangeSource(from = 1L, to = 2L)
 		@ParameterizedTest
@@ -215,6 +220,7 @@ class RangeSourceProviderTests extends AbstractPioneerTestEngineTests {
 		@ParameterizedTest
 		void emptyRange() {
 		}
+
 	}
 
 	private static void assertInvalidRange(ExecutionEventRecorder eventRecorder, String message) {
@@ -230,4 +236,5 @@ class RangeSourceProviderTests extends AbstractPioneerTestEngineTests {
 		assertThat(thrown).isInstanceOf(PreconditionViolationException.class);
 		assertThat(thrown.getMessage()).isEqualTo(message);
 	}
+
 }

--- a/src/test/java/org/junitpioneer/jupiter/params/RangeSourceProviderTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/params/RangeSourceProviderTests.java
@@ -66,10 +66,12 @@ class RangeSourceProviderTests extends AbstractPioneerTestEngineTests {
 	void assertAllValuesSupplied() {
 		ExecutionEventRecorder eventRecorder = executeTestsForClass(RangeTestCases.class);
 
-		List<Number> actualValues = eventRecorder.eventStream().filter(
-			e -> e.getType() == ExecutionEvent.Type.DYNAMIC_TEST_REGISTERED).map(
-				e -> e.getTestDescriptor().getDisplayName()).map(RangeSourceProviderTests::displayNameToNumber).collect(
-					Collectors.toList());
+		List<Number> actualValues = eventRecorder
+				.eventStream()
+				.filter(e -> e.getType() == ExecutionEvent.Type.DYNAMIC_TEST_REGISTERED)
+				.map(e -> e.getTestDescriptor().getDisplayName())
+				.map(RangeSourceProviderTests::displayNameToNumber)
+				.collect(Collectors.toList());
 
 		assertThat(actualValues).containsExactlyInAnyOrder(expectedValues);
 	}


### PR DESCRIPTION
See #130

Current state of affairs:

* :heavy_check_mark: make `//@formatter:off` before each stream pipeline unnecessary
    ~> there's a magic value (two actually, `80` is ok as well) - they correspond to _Line Wrapping ~> Wrapping Settings ~> Function Calls ~> Qualified Invocations_ in Eclipse's formatter settings.

    ```
    <setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="48"/>
    ```

* :heavy_check_mark: disable star imports
    ~> not governed by the formatter, so we created [a Checkstyle rule](https://checkstyle.sourceforge.io/config_imports.html#AvoidStarImport) for it:

    ```
    module name="AvoidStarImport" />
    ```

* :heavy_check_mark: enforce empty lines at start and end of class
    ~> thanks to [Bug 169131](https://bugs.eclipse.org/bugs/show_bug.cgi?id=169131) getting fixed after 13 years, add:

    ```
    <setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="1"/>
    <setting id="org.eclipse.jdt.core.formatter.blank_lines_after_last_class_body_declaration" value="1"/>
    ```

* :heavy_check_mark: in `if`, closing `}` and `else` on the same line
    ~> add:

    ```
    <setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
    ```

* :heavy_check_mark: make sure line continuations are indented twice (see, e.g. `SystemPropertyExtension`)
    ~> looks like a brain fart on my end; everything seems to be ok

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
