### PR TITLE
(PROPOSAL) Sonarcloud integration example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ jdk:
   - openjdk8
   - openjdk11
 
+addons:
+  sonarcloud:
+    organization: "aepfli" # the key of the org you chose at step #3
+    token:
+      secure: $SONAR_TOKEN # encrypted value of your token
+
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ script:
   - java -version
   - ./gradlew -version
   - ./gradlew --refresh-dependencies --stacktrace --scan clean build
+  - ./gradlew jacocoTestReport sonarqube
 
 deploy:
   - provider: script

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,10 +2,12 @@ plugins {
     java
     checkstyle
     `maven-publish`
+    jacoco
     id("com.diffplug.gradle.spotless") version "3.27.1"
     id("org.shipkit.java") version "2.2.5"
     id("at.zierler.yamlvalidator") version "1.5.0"
     id("com.gradle.build-scan") version "2.4.2"
+    id("org.sonarqube") version "2.8"
 }
 
 group = "org.junit-pioneer"
@@ -86,6 +88,20 @@ yamlValidator {
     isSearchRecursive = true
 }
 
+sonarqube {
+    properties {
+        /* 
+        TODO: this part need to be reworked and included into travisCI.
+            eg. the login needs to be removed and also the location/organization
+            needs to change
+         */
+        property("sonar.projectKey", "aepfli_junit-pioneer")
+        property("sonar.organization", "aepfli")
+        property("sonar.host.url", "https://sonarcloud.io")
+        property("sonar.login", "6af2d758574bc471864b3d239cc1b92628147e08")
+    }
+}
+
 tasks {
 
     test {
@@ -105,9 +121,15 @@ tasks {
         shouldRunAfter(test)
     }
 
+    jacocoTestReport {
+        reports {
+            xml.isEnabled = true
+        }
+    }
+
     check {
         // to find Javadoc errors early, let "javadoc" task run during "check"
-        dependsOn(javadoc, validateYaml)
+        dependsOn(javadoc, validateYaml, jacocoTestReport, sonarqube)
     }
 
     // the manifest needs to declare the future module name


### PR DESCRIPTION
I added basic sonarqube configuration and also testcoverage generation
so i can show of the functionality within sonarcloud. There are additional
steps, like build steps in travis CI which we could easily add. This can be
also used as a basic for coverage detection with codecov.io like mentioned
here: https://github.com/codecov/example-gradle.

- added jacoco plugin for coverage with html and xml
- added sonarqube configuration pointing currently to https://sonarcloud.io/dashboard?id=aepfli_junit-pioneer
    - [Coverage overview](https://sonarcloud.io/component_measures?id=aepfli_junit-pioneer&metric=coverage&selected=aepfli_junit-pioneer%3Asrc%2Fmain%2Fjava%2Forg%2Fjunitpioneer%2Fjupiter&view=treemap)
    - [Bugs](https://sonarcloud.io/project/issues?id=aepfli_junit-pioneer&resolved=false&types=BUG)
    - [Code Smells](https://sonarcloud.io/project/issues?id=aepfli_junit-pioneer&resolved=false&types=CODE_SMELL)



This is only a proposal. Theoretically we could also fletch the full potential of pullrequest analysis with sonarcloud and have branchbased analysis for each branch. I just wanted to quickly show of, what sonarcloud would report, and where it might not shine ;D

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
