### PR TITLE
Update JUnit and test frameworks dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,14 +32,14 @@ repositories {
 }
 
 dependencies {
-    implementation(group = "org.junit.jupiter", name = "junit-jupiter-api", version = "5.3.2")
-    implementation(group = "org.junit.jupiter", name = "junit-jupiter-params", version = "5.3.2")
+    implementation(group = "org.junit.jupiter", name = "junit-jupiter-api", version = "5.6.1")
+    implementation(group = "org.junit.jupiter", name = "junit-jupiter-params", version = "5.6.1")
 
-    testImplementation(group = "org.junit.jupiter", name = "junit-jupiter-engine", version = "5.3.2")
-    testImplementation(group = "org.junit.platform", name = "junit-platform-launcher", version = "1.3.2")
+    testImplementation(group = "org.junit.jupiter", name = "junit-jupiter-engine", version = "5.6.1")
+    testImplementation(group = "org.junit.platform", name = "junit-platform-launcher", version = "1.6.1")
 
-    testImplementation(group = "org.assertj", name = "assertj-core", version = "3.13.2")
-    testImplementation(group = "org.mockito", name = "mockito-core", version = "3.1.0")
+    testImplementation(group = "org.assertj", name = "assertj-core", version = "3.15.0")
+    testImplementation(group = "org.mockito", name = "mockito-core", version = "3.3.3")
     testImplementation(group = "com.google.jimfs", name = "jimfs", version = "1.1")
 
     testRuntimeOnly(group = "org.apache.logging.log4j", name = "log4j-core", version = "2.12.1")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,11 +32,11 @@ repositories {
 }
 
 dependencies {
-    implementation(group = "org.junit.jupiter", name = "junit-jupiter-api", version = "5.6.1")
-    implementation(group = "org.junit.jupiter", name = "junit-jupiter-params", version = "5.6.1")
+    implementation(group = "org.junit.jupiter", name = "junit-jupiter-api", version = "5.4.2")
+    implementation(group = "org.junit.jupiter", name = "junit-jupiter-params", version = "5.4.2")
 
-    testImplementation(group = "org.junit.jupiter", name = "junit-jupiter-engine", version = "5.6.1")
-    testImplementation(group = "org.junit.platform", name = "junit-platform-launcher", version = "1.6.1")
+    testImplementation(group = "org.junit.jupiter", name = "junit-jupiter-engine", version = "5.4.2")
+    testImplementation(group = "org.junit.platform", name = "junit-platform-launcher", version = "1.4.2")
 
     testImplementation(group = "org.assertj", name = "assertj-core", version = "3.15.0")
     testImplementation(group = "org.mockito", name = "mockito-core", version = "3.3.3")


### PR DESCRIPTION
Also used this to upgrade `Mockito` and `AssertJ` versions to current ones.

fixes #209


---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
