### PR TITLE
Improve GitHub Actions workflow

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -20,6 +20,9 @@ jobs:
     name: ${{ matrix.os }} - Java ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v2
+        # fetch unshallow to enable blame for Sonar
+      - name: Fetch unshallow
+        run: git fetch --prune --unshallow
       - name: Setup java
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -24,6 +24,11 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+      - name: Cache Sonar
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache/
+          key: ${{ runner.os }}-sonar
       - name: Gradle build
         uses: eskatos/gradle-command-action@v1
         with:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -28,6 +28,12 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+      - name: Cache Gradle
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches/
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: ${{ runner.os }}-gradle-
       - name: Cache Sonar
         uses: actions/cache@v1
         with:
@@ -56,6 +62,12 @@ jobs:
   #       uses: actions/setup-java@v1
   #       with:
   #         java-version: 8
+  #     - name: Cache Gradle
+  #       uses: actions/cache@v1
+  #       with:
+  #         path: ~/.gradle/caches
+  #         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+  #         restore-keys: ${{ runner.os }}-gradle-
   #     - name: Perform Release
   #       uses: eskatos/gradle-command-action@v1
   #       if:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -3,7 +3,11 @@
 
 name: JUnit Pioneer Flow
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: '*'
 
 jobs:
   build:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -19,7 +19,8 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     name: ${{ matrix.os }} - Java ${{ matrix.java }}
     steps:
-      - uses: actions/checkout@v2
+      - name: Check out repo
+        uses: actions/checkout@v2
         # fetch unshallow to enable blame for Sonar
       - name: Fetch unshallow
         run: git fetch --prune --unshallow
@@ -49,7 +50,8 @@ jobs:
   #   name: Deploy
   #   if: github.ref == 'refs/heads/master'
   #   steps:
-  #     - uses: actions/checkout@v2
+  #     - name: Check out repo
+  #       uses: actions/checkout@v2
   #     - name: Setup java
   #       uses: actions/setup-java@v1
   #       with:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -36,6 +36,7 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle-
       - name: Cache Sonar
         uses: actions/cache@v1
+        if: matrix.java == '8' && matrix.os == 'ubuntu-latest'
         with:
           path: ~/.sonar/cache/
           key: ${{ runner.os }}-sonar
@@ -44,10 +45,10 @@ jobs:
         with:
           arguments: --refresh-dependencies --stacktrace --scan clean build
       - name: Sonarqube
+        if: matrix.java == '8' && matrix.os == 'ubuntu-latest'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: "61ab2579215aa8a0024a2f9368fc1298fdecfd18"
-        if:  matrix.java == '8' && matrix.os == 'ubuntu-latest'
         run: ./gradlew jacocoTestReport sonarqube --stacktrace -i
 
   # This will be handled on a later stage

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -3,11 +3,7 @@
 
 name: JUnit Pioneer Flow
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: '*'
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
Improves the current GitHub Actions workflow by several means:

* Cache Gradle and Sonar files, see Travis example e.g. [here](https://github.com/SonarSource/sq-com_example_java-gradle-travis/blob/master/.travis.yml#L17).
* Fetch unshallow to enable blame for Sonar, see warning e.g. [here](https://github.com/junit-pioneer/junit-pioneer/runs/550297033?check_suite_focus=true#step:5:357).
* Use step names consistently.

~Also note that according to the [SonarCloud GitHub Action](https://github.com/SonarSource/sonarcloud-github-action#do-not-use-this-github-action-if-you-are-in-the-following-situations), we should _not_ use the action itself but the SonarQube plugin for Gradle during the build. I'm a Gradle noob, but can have a look later on if nobody is quicker?~

Realized that this is already done. 👍

Proposed commit message:

```
Improve GitHub Actions workflow

* Cache Gradle and Sonar files.
* Fetch unshallow to enable blame for Sonar.
* Use step names consistently.

PR: 214
```

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
