### PR TITLE
Add link to GitHub help about fork and PR basics

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,10 +30,11 @@ The guidelines apply to maintainers as well as contributors!
 
 First of all, welcome!
 We really appreciate that you consider contributing to JUnit Pioneer.
-We know that this can be quite daunting at first.
+
+We know that this can be quite daunting at first:
 Everybody uses a vocabulary and techniques that appear quite cryptic to those not steeped in them.
 We can't fix that in a short file like this, but we want to provide some pointers to get you started.
-If anything's unclear, [open an issue](https://github.com/junit-pioneer/junit-pioneer/issues/new) and ask us to clarify.
+If anything that follows in this document isn't clear, [open an issue](https://github.com/junit-pioneer/junit-pioneer/issues/new) and ask us to explain it better.
 
 First off, like for many open source projects, contributing code changes to JUnit Pioneer should be done via pull requests from a fork.
 If you are not familiar with this concept, please have a look at the [GitHub help page](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,10 @@ The guidelines apply to maintainers as well as contributors!
   This means that if you are employed you have received the necessary permissions from your employer to make the contributions.
 * Whatever content you contribute will be provided under the project license(s).
 
+## Basics
+
+Like for many open source projects, contributing code changes for JUnit Pioneer should be be done via pull requests from a fork.
+If you are not familiar with this concept, please have a look at the [GitHub help page](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks).
 
 ## Fixing Bugs, Developing Features
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,7 @@ The following guidelines were chosen very deliberately to make sure the project 
 This is true for such diverse areas as a firm legal foundation or a sensible and helpful commit history.
 
 * [Contributor License Agreement](#junit-pioneer-contributor-license-agreement)
+* [If you're new to Open Source](#if-youre-new-to-open-source)
 * [Fixing Bugs, Developing Features](#fixing-bugs-developing-features)
 	* [Branching Strategy](#branching-strategy)
 	* [Commits](#commits)
@@ -25,9 +26,16 @@ The guidelines apply to maintainers as well as contributors!
   This means that if you are employed you have received the necessary permissions from your employer to make the contributions.
 * Whatever content you contribute will be provided under the project license(s).
 
-## Basics
+## If you're new to Open Source
 
-Like for many open source projects, contributing code changes for JUnit Pioneer should be be done via pull requests from a fork.
+First of all, welcome!
+We really appreciate that you consider contributing to JUnit Pioneer.
+We know that this can be quite daunting at first.
+Everybody uses a vocabulary and techniques that appear quite cryptic to those not steeped in them.
+We can't fix that in a short file like this, but we want to provide some pointers to get you started.
+If anything's unclear, [open an issue](https://github.com/junit-pioneer/junit-pioneer/issues/new) and ask us to clarify.
+
+First off, like for many open source projects, contributing code changes to JUnit Pioneer should be done via pull requests from a fork.
 If you are not familiar with this concept, please have a look at the [GitHub help page](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/working-with-forks).
 
 ## Fixing Bugs, Developing Features


### PR DESCRIPTION
_As I wrecked my last PR (#204), I create this new PR..._

---

In #205 we discussed if and where we should document underlying tools and processes.
We came to the conclusion that we don't want to duplicate external documentation, but like to point to these sources for those who are not familiar with the basics, e.g. working with forks and pull requests.

This commits adds a little paragraph with a link to the official GitHub help page about this topic.


closes: #205
[ci skip-release]

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
