### PR TITLE
Fix Discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ We welcome contributions of all shapes and forms! 🌞
 
 * If you have an idea for an extension, [open an issue](https://github.com/junit-pioneer/junit-pioneer/issues/new) and let's discuss.
 * If you want to help but don't know how, have a look at [the existing issues](https://github.com/junit-pioneer/junit-pioneer/issues), particularly [unassigned ones](https://github.com/junit-pioneer/junit-pioneer/issues?q=is%3Aopen+is%3Aissue+no%3Aassignee) and those [marked as up for grabs](https://github.com/junit-pioneer/junit-pioneer/issues?q=is%3Aissue+is%3Aopen+label%3Aup-for-grabs).
-* If you want to have a chat about JUnit Pioneer, [join our discord](https://discord.gg/6aWYe8) - we have a `#junit-pioneer` channel. 😊
+* If you want to have a chat about JUnit Pioneer, [join our discord](https://discord.gg/rHfJeCF) - we have a `#junit-pioneer` channel. 😊
 
 Before contributing, please read the [contribution guide](CONTRIBUTING.md).
 


### PR DESCRIPTION
```
The old discord link got expired and got invalid.
The new one will not expire and has no user limit.

fixes #230

[ci skip-release]
```
![newlink](https://user-images.githubusercontent.com/4354359/79630622-30402400-8153-11ea-8b73-254b5c654826.png)
---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).

