### PR TITLE
Fix sonarqube violations (#217)

### DIFF
--- a/src/main/java/org/junitpioneer/jupiter/ReportEntryExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReportEntryExtension.java
@@ -22,15 +22,17 @@ class ReportEntryExtension implements BeforeEachCallback {
 	public void beforeEach(ExtensionContext context) throws Exception {
 		PioneerAnnotationUtils
 				.findAllEnclosingRepeatableAnnotations(context, ReportEntry.class)
-				.peek(ReportEntryExtension::verifyKeyValueAreNotBlank)
+				.map(this::verifyKeyValueAreNotBlank)
 				.forEach(entry -> context.publishReportEntry(entry.key(), entry.value()));
 	}
 
-	private static void verifyKeyValueAreNotBlank(ReportEntry entry) {
+	private ReportEntry verifyKeyValueAreNotBlank(ReportEntry entry) {
 		if (entry.key().isEmpty() || entry.value().isEmpty()) {
 			String message = "Report entries can't have blank key or value: { key=\"%s\", value=\"%s\" }";
 			throw new ExtensionConfigurationException(format(message, entry.key(), entry.value()));
 		}
+
+		return entry;
 	}
 
 }

--- a/src/main/java/org/junitpioneer/jupiter/TempDirectoryExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/TempDirectoryExtension.java
@@ -306,7 +306,7 @@ public class TempDirectoryExtension implements ParameterResolver {
 			String joinedPaths = failures
 					.keySet()
 					.stream()
-					.peek(this::tryToDeleteOnExit)
+					.map(this::tryToDeleteOnExit)
 					.map(this::relativizeSafely)
 					.map(String::valueOf)
 					.collect(joining(", "));
@@ -317,7 +317,7 @@ public class TempDirectoryExtension implements ParameterResolver {
 			return exception;
 		}
 
-		private void tryToDeleteOnExit(Path path) {
+		private Path tryToDeleteOnExit(Path path) {
 			try {
 				path.toFile().deleteOnExit();
 			}
@@ -328,6 +328,7 @@ public class TempDirectoryExtension implements ParameterResolver {
 				// nicety towards the user, it is entirely optional and shouldn't affect
 				// the extension's behavior.
 			}
+			return path;
 		}
 
 		private Path relativizeSafely(Path path) {


### PR DESCRIPTION
This PR replaces the two `peek()` calls with `map` as suggested by @Michael1993 in #217. Sonar cries about using `peek()` as it should be used for debugging only. 

This lefts us with only one violation (`Mind to remove this deprecated class in the future` for the vintage `@Test` annotation which has to be excluded in sonar in my opinion.

So I call this the last PR for the issue.

closes: #217

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
