### PR TITLE
Reduce duplication

### DIFF
--- a/src/main/java/org/junitpioneer/jupiter/AbstractEntryBasedExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/AbstractEntryBasedExtension.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junitpioneer.jupiter;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+
+/**
+ * An abstract base class for entry-based extensions, where entries (key-value
+ * pairs) can be cleared or set.
+ *
+ * @param <K> The entry's key type.
+ * @param <V> The entry's value type.
+ */
+abstract class AbstractEntryBasedExtension<K, V>
+		implements BeforeAllCallback, BeforeEachCallback, AfterAllCallback, AfterEachCallback {
+
+	private static final Namespace NAMESPACE = Namespace.create(AbstractEntryBasedExtension.class);
+	private static final String BACKUP = "Backup";
+
+	/**
+	 * @param context The current extension context.
+	 * @return <code>true</code> if one or more of the extension's annotations are present.
+	 */
+	protected abstract boolean isAnnotationPresent(ExtensionContext context);
+
+	/**
+	 * @param context The current extension context.
+	 * @return The entry keys to be cleared.
+	 */
+	protected abstract Set<K> entriesToClear(ExtensionContext context);
+
+	/**
+	 * @param context The current extension context.
+	 * @return The entry keys and values to be set.
+	 */
+	protected abstract Map<K, V> entriesToSet(ExtensionContext context);
+
+	/**
+	 * @return How to clear an entry based on its key.
+	 */
+	protected abstract Consumer<? super K> clearer();
+
+	/**
+	 * @return How to get an entry value based on its key.
+	 */
+	protected abstract Function<? super K, ? extends V> getter();
+
+	/**
+	 * @return How to set an entry value based on its key.
+	 */
+	protected abstract BiConsumer<? super K, ? super V> setter();
+
+	@Override
+	public void beforeAll(ExtensionContext context) throws Exception {
+		clearAndSetEntries(context);
+	}
+
+	@Override
+	public void beforeEach(ExtensionContext context) throws Exception {
+		clearAndSetEntries(context);
+	}
+
+	private void clearAndSetEntries(ExtensionContext context) {
+		Set<K> entriesToClear;
+		Map<K, V> entriesToSet;
+
+		try {
+			entriesToClear = entriesToClear(context);
+			entriesToSet = entriesToSet(context);
+			preventClearAndSetSameEntries(entriesToClear, entriesToSet.keySet());
+		}
+		catch (IllegalStateException ex) {
+			throw new ExtensionConfigurationException("Don't clear/set the same entry more than once.", ex);
+		}
+
+		if (entriesToClear.isEmpty() && entriesToSet.isEmpty())
+			return;
+
+		storeOriginalEntries(context, entriesToClear, entriesToSet.keySet());
+		clearEntries(entriesToClear);
+		setEntries(entriesToSet);
+	}
+
+	private void preventClearAndSetSameEntries(Collection<K> entriesToClear, Collection<K> entriesToSet) {
+		entriesToClear
+				.stream()
+				.filter(entriesToSet::contains)
+				.map(Object::toString)
+				.reduce((e0, e1) -> e0 + ", " + e1)
+				.ifPresent(duplicateEntries -> {
+					throw new IllegalStateException(
+						"Cannot clear and set the following entries at the same time: " + duplicateEntries);
+				});
+	}
+
+	private void storeOriginalEntries(ExtensionContext context, Collection<K> entriesToClear,
+			Collection<K> entriesToSet) {
+		context.getStore(NAMESPACE).put(BACKUP, new EntriesBackup(entriesToClear, entriesToSet));
+	}
+
+	private void clearEntries(Collection<K> entriesToClear) {
+		entriesToClear.forEach(clearer());
+	}
+
+	private void setEntries(Map<K, V> entriesToSet) {
+		entriesToSet.forEach(setter());
+	}
+
+	@Override
+	public void afterEach(ExtensionContext context) throws Exception {
+		if (isAnnotationPresent(context))
+			restoreOriginalEntries(context);
+	}
+
+	@Override
+	public void afterAll(ExtensionContext context) throws Exception {
+		restoreOriginalEntries(context);
+	}
+
+	private void restoreOriginalEntries(ExtensionContext context) {
+		context.getStore(NAMESPACE).get(BACKUP, EntriesBackup.class).restoreBackup();
+	}
+
+	private class EntriesBackup {
+
+		private final Set<K> entriesToClear = new HashSet<>();
+		private final Map<K, V> entriesToSet = new HashMap<>();
+
+		public EntriesBackup(Collection<K> entriesToClear, Collection<K> entriesToSet) {
+			Stream.concat(entriesToClear.stream(), entriesToSet.stream()).forEach(entry -> {
+				V backup = AbstractEntryBasedExtension.this.getter().apply(entry);
+				if (backup == null)
+					this.entriesToClear.add(entry);
+				else
+					this.entriesToSet.put(entry, backup);
+			});
+		}
+
+		public void restoreBackup() {
+			entriesToClear.forEach(AbstractEntryBasedExtension.this.clearer());
+			entriesToSet.forEach(AbstractEntryBasedExtension.this.setter());
+		}
+
+	}
+
+}

--- a/src/main/java/org/junitpioneer/jupiter/AbstractEntryBasedExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/AbstractEntryBasedExtension.java
@@ -57,19 +57,19 @@ abstract class AbstractEntryBasedExtension<K, V>
 	protected abstract Map<K, V> entriesToSet(ExtensionContext context);
 
 	/**
-	 * Clear an entry based on its key.
+	 * Removes the entry indicated by the specified key.
 	 */
 	protected abstract void clearEntry(K key);
 
 	/**
-	 * Get an entry value based on its key.
+	 * Gets the entry indicated by the specified key.
 	 */
-	protected abstract V getValue(K key);
+	protected abstract V getEntry(K key);
 
 	/**
-	 * Put a key/value pair as an entry.
+	 * Sets the entry indicated by the specified key.
 	 */
-	protected abstract void put(K key, V value);
+	protected abstract void setEntry(K key, V value);
 
 	@Override
 	public void beforeAll(ExtensionContext context) throws Exception {
@@ -124,7 +124,7 @@ abstract class AbstractEntryBasedExtension<K, V>
 	}
 
 	private void setEntries(Map<K, V> entriesToSet) {
-		entriesToSet.forEach(this::put);
+		entriesToSet.forEach(this::setEntry);
 	}
 
 	@Override
@@ -149,7 +149,7 @@ abstract class AbstractEntryBasedExtension<K, V>
 
 		public EntriesBackup(Collection<K> entriesToClear, Collection<K> entriesToSet) {
 			Stream.concat(entriesToClear.stream(), entriesToSet.stream()).forEach(entry -> {
-				V backup = AbstractEntryBasedExtension.this.getValue(entry);
+				V backup = AbstractEntryBasedExtension.this.getEntry(entry);
 				if (backup == null)
 					this.entriesToClear.add(entry);
 				else
@@ -159,7 +159,7 @@ abstract class AbstractEntryBasedExtension<K, V>
 
 		public void restoreBackup() {
 			entriesToClear.forEach(AbstractEntryBasedExtension.this::clearEntry);
-			entriesToSet.forEach(AbstractEntryBasedExtension.this::put);
+			entriesToSet.forEach(AbstractEntryBasedExtension.this::setEntry);
 		}
 
 	}

--- a/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
@@ -15,9 +15,6 @@ import static java.util.stream.Collectors.toMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
-import java.util.function.Function;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -58,18 +55,19 @@ class EnvironmentVariableExtension extends AbstractEntryBasedExtension<String, S
 			context.publishReportEntry(WARNING_KEY, WARNING_VALUE);
 	}
 
-	protected Consumer<String> clearer() {
-		return EnvironmentVariableUtils::clear;
+	@Override
+	protected void clearEntry(String key) {
+		EnvironmentVariableUtils.clear(key);
 	}
 
 	@Override
-	protected Function<String, String> getter() {
-		return System::getenv;
+	protected String getValue(String key) {
+		return System.getenv(key);
 	}
 
 	@Override
-	protected BiConsumer<String, String> setter() {
-		return EnvironmentVariableUtils::set;
+	protected void put(String key, String value) {
+		EnvironmentVariableUtils.set(key, value);
 	}
 
 }

--- a/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
@@ -61,12 +61,12 @@ class EnvironmentVariableExtension extends AbstractEntryBasedExtension<String, S
 	}
 
 	@Override
-	protected String getValue(String key) {
+	protected String getEntry(String key) {
 		return System.getenv(key);
 	}
 
 	@Override
-	protected void put(String key, String value) {
+	protected void setEntry(String key, String value) {
 		EnvironmentVariableUtils.set(key, value);
 	}
 

--- a/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
@@ -12,27 +12,16 @@ package org.junitpioneer.jupiter;
 
 import static java.util.stream.Collectors.toMap;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Stream;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.BeforeEachCallback;
-import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 
-class EnvironmentVariableExtension
-		implements BeforeAllCallback, BeforeEachCallback, AfterAllCallback, AfterEachCallback {
-
-	private static final Namespace NAMESPACE = Namespace.create(EnvironmentVariableExtension.class);
-	private static final String BACKUP = "Backup";
+class EnvironmentVariableExtension extends AbstractEntryBasedExtension<String, String> {
 
 	// package visible to make accessible for tests
 	static final AtomicBoolean REPORTED_WARNING = new AtomicBoolean(false);
@@ -40,54 +29,27 @@ class EnvironmentVariableExtension
 	static final String WARNING_VALUE = "This extension uses reflection to mutate JDK-internal state, which is fragile. Check the Javadoc or documentation for more details.";
 
 	@Override
-	public void beforeAll(ExtensionContext context) {
-		clearAndSetEnvironmentVariables(context);
+	protected boolean isAnnotationPresent(ExtensionContext context) {
+		return PioneerAnnotationUtils
+				.isAnyRepeatableAnnotationPresent(context, ClearEnvironmentVariable.class,
+					SetEnvironmentVariable.class);
 	}
 
 	@Override
-	public void beforeEach(ExtensionContext context) {
-		clearAndSetEnvironmentVariables(context);
-	}
-
-	private void clearAndSetEnvironmentVariables(ExtensionContext context) {
-		Set<String> variablesToClear;
-		Map<String, String> variablesToSet;
-		try {
-			variablesToClear = PioneerAnnotationUtils
-					.findClosestEnclosingRepeatableAnnotations(context, ClearEnvironmentVariable.class)
-					.map(ClearEnvironmentVariable::key)
-					.collect(PioneerUtils.distinctToSet());
-			variablesToSet = PioneerAnnotationUtils
-					.findClosestEnclosingRepeatableAnnotations(context, SetEnvironmentVariable.class)
-					.collect(toMap(SetEnvironmentVariable::key, SetEnvironmentVariable::value));
-			preventClearAndSetSameEnvironmentVariables(variablesToClear, variablesToSet.keySet());
-		}
-		catch (IllegalStateException ex) {
-			throw new ExtensionConfigurationException("Don't clear/set the same environment variable more than once.",
-				ex);
-		}
-
-		storeOriginalEnvironmentVariables(context, variablesToClear, variablesToSet.keySet());
+	protected Set<String> entriesToClear(ExtensionContext context) {
 		reportWarning(context);
-		EnvironmentVariableUtils.clear(variablesToClear);
-		EnvironmentVariableUtils.set(variablesToSet);
+		return PioneerAnnotationUtils
+				.findClosestEnclosingRepeatableAnnotations(context, ClearEnvironmentVariable.class)
+				.map(ClearEnvironmentVariable::key)
+				.collect(PioneerUtils.distinctToSet());
 	}
 
-	private void preventClearAndSetSameEnvironmentVariables(Collection<String> variablesToClear,
-			Collection<String> variablesToSet) {
-		variablesToClear
-				.stream()
-				.filter(variablesToSet::contains)
-				.reduce((k0, k1) -> k0 + ", " + k1)
-				.ifPresent(duplicateKeys -> {
-					throw new IllegalStateException(
-						"Cannot clear and set the following environment variable at the same time: " + duplicateKeys);
-				});
-	}
-
-	private void storeOriginalEnvironmentVariables(ExtensionContext context, Collection<String> clearVariables,
-			Collection<String> setVariables) {
-		context.getStore(NAMESPACE).put(BACKUP, new EnvironmentVariableBackup(clearVariables, setVariables));
+	@Override
+	protected Map<String, String> entriesToSet(ExtensionContext context) {
+		reportWarning(context);
+		return PioneerAnnotationUtils
+				.findClosestEnclosingRepeatableAnnotations(context, SetEnvironmentVariable.class)
+				.collect(toMap(SetEnvironmentVariable::key, SetEnvironmentVariable::value));
 	}
 
 	private void reportWarning(ExtensionContext context) {
@@ -96,51 +58,18 @@ class EnvironmentVariableExtension
 			context.publishReportEntry(WARNING_KEY, WARNING_VALUE);
 	}
 
-	@Override
-	public void afterEach(ExtensionContext context) {
-		boolean present = PioneerAnnotationUtils
-				.isAnyAnnotationPresent(context, ClearEnvironmentVariable.class,
-					ClearEnvironmentVariable.ClearEnvironmentVariables.class, SetEnvironmentVariable.class,
-					SetEnvironmentVariable.SetEnvironmentVariables.class);
-		if (present) {
-			restoreOriginalEnvironmentVariables(context);
-		}
+	protected Consumer<String> clearer() {
+		return EnvironmentVariableUtils::clear;
 	}
 
 	@Override
-	public void afterAll(ExtensionContext context) {
-		restoreOriginalEnvironmentVariables(context);
+	protected Function<String, String> getter() {
+		return System::getenv;
 	}
 
-	private void restoreOriginalEnvironmentVariables(ExtensionContext context) {
-		context.getStore(NAMESPACE).get(BACKUP, EnvironmentVariableBackup.class).restoreVariables();
-	}
-
-	/**
-	 * Stores which environment variables need to be cleared or set to their old values after the test.
-	 */
-	private static class EnvironmentVariableBackup {
-
-		private final Map<String, String> variablesToSet;
-		private final Set<String> variablesToUnset;
-
-		public EnvironmentVariableBackup(Collection<String> clearVariables, Collection<String> setVariables) {
-			variablesToSet = new HashMap<>();
-			variablesToUnset = new HashSet<>();
-			Stream.concat(clearVariables.stream(), setVariables.stream()).forEach(variable -> {
-				String backup = System.getenv(variable); //NOSONAR access required to implement the extension
-				if (backup == null)
-					variablesToUnset.add(variable);
-				else
-					variablesToSet.put(variable, backup);
-			});
-		}
-
-		public void restoreVariables() {
-			EnvironmentVariableUtils.set(variablesToSet);
-			EnvironmentVariableUtils.clear(variablesToUnset);
-		}
-
+	@Override
+	protected BiConsumer<String, String> setter() {
+		return EnvironmentVariableUtils::set;
 	}
 
 }

--- a/src/main/java/org/junitpioneer/jupiter/SystemPropertyExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/SystemPropertyExtension.java
@@ -46,12 +46,12 @@ class SystemPropertyExtension extends AbstractEntryBasedExtension<String, String
 	}
 
 	@Override
-	protected String getValue(String key) {
+	protected String getEntry(String key) {
 		return System.getProperty(key);
 	}
 
 	@Override
-	protected void put(String key, String value) {
+	protected void setEntry(String key, String value) {
 		System.setProperty(key, value);
 	}
 

--- a/src/main/java/org/junitpioneer/jupiter/SystemPropertyExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/SystemPropertyExtension.java
@@ -12,131 +12,50 @@ package org.junitpioneer.jupiter;
 
 import static java.util.stream.Collectors.toMap;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Stream;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
-import org.junit.jupiter.api.extension.AfterAllCallback;
-import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.BeforeEachCallback;
-import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 
-class SystemPropertyExtension implements BeforeAllCallback, BeforeEachCallback, AfterAllCallback, AfterEachCallback {
-
-	private static final Namespace NAMESPACE = Namespace.create(SystemPropertyExtension.class);
-	private static final String BACKUP = "Backup";
+class SystemPropertyExtension extends AbstractEntryBasedExtension<String, String> {
 
 	@Override
-	public void beforeAll(ExtensionContext context) throws Exception {
-		clearAndSetSystemProperties(context);
+	protected boolean isAnnotationPresent(ExtensionContext context) {
+		return PioneerAnnotationUtils
+				.isAnyRepeatableAnnotationPresent(context, ClearSystemProperty.class, SetSystemProperty.class);
 	}
 
 	@Override
-	public void beforeEach(ExtensionContext context) throws Exception {
-		clearAndSetSystemProperties(context);
-	}
-
-	private void clearAndSetSystemProperties(ExtensionContext context) {
-		Set<String> propertiesToClear;
-		Map<String, String> propertiesToSet;
-		try {
-			propertiesToClear = PioneerAnnotationUtils
-					.findClosestEnclosingRepeatableAnnotations(context, ClearSystemProperty.class)
-					.map(ClearSystemProperty::key)
-					.collect(PioneerUtils.distinctToSet());
-			propertiesToSet = PioneerAnnotationUtils
-					.findClosestEnclosingRepeatableAnnotations(context, SetSystemProperty.class)
-					.collect(toMap(SetSystemProperty::key, SetSystemProperty::value));
-			preventClearAndSetSameSystemProperties(propertiesToClear, propertiesToSet.keySet());
-		}
-		catch (IllegalStateException ex) {
-			throw new ExtensionConfigurationException("Don't clear/set the same property more than once.", ex);
-		}
-
-		if (propertiesToClear.isEmpty() && propertiesToSet.isEmpty())
-			return;
-
-		storeOriginalSystemProperties(context, propertiesToClear, propertiesToSet.keySet());
-		clearSystemProperties(propertiesToClear);
-		setSystemProperties(propertiesToSet);
-	}
-
-	private void preventClearAndSetSameSystemProperties(Collection<String> propertiesToClear,
-			Collection<String> propertiesToSet) {
-		propertiesToClear
-				.stream()
-				.filter(propertiesToSet::contains)
-				.reduce((k0, k1) -> k0 + ", " + k1)
-				.ifPresent(duplicateKeys -> {
-					throw new IllegalStateException(
-						"Cannot clear and set the following system properties at the same time: " + duplicateKeys);
-				});
-	}
-
-	private void storeOriginalSystemProperties(ExtensionContext context, Collection<String> clearProperties,
-			Collection<String> setProperties) {
-		context.getStore(NAMESPACE).put(BACKUP, new SystemPropertyBackup(clearProperties, setProperties));
-	}
-
-	private void clearSystemProperties(Collection<String> clearProperties) {
-		clearProperties.forEach(System::clearProperty);
-	}
-
-	private void setSystemProperties(Map<String, String> setProperties) {
-		setProperties.forEach(System::setProperty);
+	protected Set<String> entriesToClear(ExtensionContext context) {
+		return PioneerAnnotationUtils
+				.findClosestEnclosingRepeatableAnnotations(context, ClearSystemProperty.class)
+				.map(ClearSystemProperty::key)
+				.collect(PioneerUtils.distinctToSet());
 	}
 
 	@Override
-	public void afterEach(ExtensionContext context) throws Exception {
-		boolean present = PioneerAnnotationUtils
-				.isAnyAnnotationPresent(context, ClearSystemProperty.class,
-					ClearSystemProperty.ClearSystemProperties.class, SetSystemProperty.class,
-					SetSystemProperty.SetSystemProperties.class);
-		if (present) {
-			restoreOriginalSystemProperties(context);
-		}
+	protected Map<String, String> entriesToSet(ExtensionContext context) {
+		return PioneerAnnotationUtils
+				.findClosestEnclosingRepeatableAnnotations(context, SetSystemProperty.class)
+				.collect(toMap(SetSystemProperty::key, SetSystemProperty::value));
 	}
 
 	@Override
-	public void afterAll(ExtensionContext context) throws Exception {
-		restoreOriginalSystemProperties(context);
+	protected Consumer<String> clearer() {
+		return System::clearProperty;
 	}
 
-	private void restoreOriginalSystemProperties(ExtensionContext context) {
-		context.getStore(NAMESPACE).get(BACKUP, SystemPropertyBackup.class).restoreProperties();
+	@Override
+	protected Function<String, String> getter() {
+		return System::getProperty;
 	}
 
-	/**
-	 * Stores which system properties need to be cleared or set to their old values after the test.
-	 */
-	private static class SystemPropertyBackup {
-
-		private final Map<String, String> propertiesToSet;
-		private final Set<String> propertiesToUnset;
-
-		public SystemPropertyBackup(Collection<String> clearProperties, Collection<String> setProperties) {
-			propertiesToSet = new HashMap<>();
-			propertiesToUnset = new HashSet<>();
-			Stream.concat(clearProperties.stream(), setProperties.stream()).forEach(property -> {
-				String backup = System.getProperty(property);
-				if (backup == null)
-					propertiesToUnset.add(property);
-				else
-					propertiesToSet.put(property, backup);
-			});
-		}
-
-		public void restoreProperties() {
-			propertiesToSet.forEach(System::setProperty);
-			propertiesToUnset.forEach(System::clearProperty);
-		}
-
+	@Override
+	protected BiConsumer<String, String> setter() {
+		return System::setProperty;
 	}
 
 }

--- a/src/main/java/org/junitpioneer/jupiter/SystemPropertyExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/SystemPropertyExtension.java
@@ -14,9 +14,6 @@ import static java.util.stream.Collectors.toMap;
 
 import java.util.Map;
 import java.util.Set;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
-import java.util.function.Function;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -44,18 +41,18 @@ class SystemPropertyExtension extends AbstractEntryBasedExtension<String, String
 	}
 
 	@Override
-	protected Consumer<String> clearer() {
-		return System::clearProperty;
+	protected void clearEntry(String key) {
+		System.clearProperty(key);
 	}
 
 	@Override
-	protected Function<String, String> getter() {
-		return System::getProperty;
+	protected String getValue(String key) {
+		return System.getProperty(key);
 	}
 
 	@Override
-	protected BiConsumer<String, String> setter() {
-		return System::setProperty;
+	protected void put(String key, String value) {
+		System.setProperty(key, value);
 	}
 
 }

--- a/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
@@ -236,6 +236,7 @@ class SystemPropertyExtensionTests {
 	static class MethodLevelInitializationFailureTestCase {
 
 		@Test
+		@DisplayName("clearing and setting the same property")
 		@ClearSystemProperty(key = "set prop A")
 		@SetSystemProperty(key = "set prop A", value = "new A")
 		void shouldFailWhenClearAndSetSameSystemProperty() {
@@ -248,7 +249,6 @@ class SystemPropertyExtensionTests {
 		}
 
 		@Test
-		@DisplayName("clearing and setting the same property")
 		@SetSystemProperty(key = "set prop A", value = "new A")
 		@SetSystemProperty(key = "set prop A", value = "new B")
 		void shouldFailWhenSetSameSystemPropertyTwice() {


### PR DESCRIPTION
This is an early draft to fix #180.

In order to reduce the code duplication among `SystemPropertyExtension` and `EnvironmentVariableExtension`, I thought about an abstract base class for entry-based extensions, where entries (i.e. key-value pairs) shall be cleared or set.

As outlined above, this is a draft. There may be still some design flaws, ~the Javadoc is incomplete, no type wildcards~ … I just wanted to get some feedback if you think it is worth to further work on this, use a different approach or leave the extensions as they are. ✌️

Personally, I quite like it because when you look at [`SystemPropertyExtension`](https://github.com/junit-pioneer/junit-pioneer/blob/5a301100f5770ef57b2f1ed601e98f0f18dea700/src/main/java/org/junitpioneer/jupiter/SystemPropertyExtension.java) and [`EnvironmentVariableExtension`](https://github.com/junit-pioneer/junit-pioneer/blob/5a301100f5770ef57b2f1ed601e98f0f18dea700/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java) now, they are dead-simple.

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
