### PR TITLE
Replace deprecated checkstyle setDir with new one

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,7 @@ spotless {
 
 checkstyle {
     toolVersion = "7.8.2"
-    configDir = rootProject.file(".infra/checkstyle")
+    configDirectory.set(rootProject.file(".infra/checkstyle"))
 }
 
 yamlValidator {


### PR DESCRIPTION
Fixes the checkstyle deprecation warnings, which is one of two warnings causing #246 

```
The CheckstyleExtension.setConfigDir() method has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use the CheckstyleExtension.getConfigDirectory().set() method instead. See https://docs.gradle.org/6.3/dsl/org.
gradle.api.plugins.quality.CheckstyleExtension.html#org.gradle.api.plugins.quality.CheckstyleExtension:configDir for more details.
        at Build_gradle$5.execute(build.gradle.kts:77)
```
---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
