### PR TITLE
Change automatic module name to match other names

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ JUnit Pioneer is released on [GitHub](https://github.com/junit-pioneer/junit-pio
 * group ID: `org.junit-pioneer`
 * artifact ID: `junit-pioneer`
 * version: [![Latest Junit Pioneer on Maven Central](https://maven-badges.herokuapp.com/maven-central/org.junit-pioneer/junit-pioneer/badge.svg?style=flat)](https://mvnrepository.com/artifact/org.junit-pioneer/junit-pioneer)
+* automatic module name: `org.junit-pioneer`
 
 For Maven:
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -137,7 +137,7 @@ tasks {
     jar {
         manifest {
             attributes(
-                    "Automatic-Module-Name" to "org.junitpioneer"
+                    "Automatic-Module-Name" to "org.junit-pioneer"
             )
         }
     }


### PR DESCRIPTION
**Disclaimer**: Not sure if this is all what @nicolaiparlog wanted to do about it, so I marked it as a draft

fixes #251 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
