### PR TITLE
Creating IDE Specific configuration with gradle

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     jacoco
     checkstyle
     `maven-publish`
-    id("com.diffplug.gradle.spotless") version "3.27.1"
+    id("com.diffplug.gradle.spotless") version "4.0.0"
     id("org.shipkit.java") version "2.3.1"
     id("at.zierler.yamlvalidator") version "1.5.0"
     id("org.sonarqube") version "2.8"

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,27 @@
+import groovy.xml.XmlUtil
+
+build {
+    doLast {
+        def ideaFolder = new File('.idea');
+        if(ideaFolder.exists() && ideaFolder.isDirectory()) {
+            def xmlFile = new File(".idea/vcs.xml")
+            def xml = new XmlSlurper().parse(xmlFile)
+            xml.component.find {it.@name == 'IssueNavigationConfiguration'}.replaceNode {}
+            xml.appendNode {
+                component(name: "IssueNavigationConfiguration") {
+                    option(name: 'links') {
+                        list {
+                            IssueNavigationLink {
+                                option(name: "issueRegexp", value: '#(\\d+)')
+                                option(name: "linkRegexp", value: 'https://github.com/junit-pioneer/junit-pioneer/issues/$1')
+                            }
+                        }
+                    }
+                }
+            }
+            xmlFile.withWriter {out->
+                XmlUtil.serialize(xml, out)
+            }
+        }
+    }
+}


### PR DESCRIPTION
I added a small build.gradle file, which uses gradle dsl, as i found it
easiert to manipulate xml with. This snippet will add the issue link to
idea on each sync.

The questions to answer is, if we want to stick to groovy and mix kotlin
and groovy dsl. Which might be a bad idea. Sadly i have not had the time
to check if there is a convenient way to do so.

I just want to show this, and cross check if that might be suitable for
our cause or not. (i think at least for now it is)

closes: #229


---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
