### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/default-locale-timezone.adoc
+++ b/docs/default-locale-timezone.adoc
@@ -14,7 +14,7 @@ The default `Locale` can be specified using an https://docs.oracle.com/javase/8/
 @Test
 @DefaultLocale("zh-Hant-TW")
 void test_with_lanuage() {
-	assertThat(Locale.getDefault()).isEqualsTo(Locale.forLanguageTag("zh-Hant-TW"));
+	assertThat(Locale.getDefault()).isEqualTo(Locale.forLanguageTag("zh-Hant-TW"));
 }
 ----
 
@@ -29,19 +29,19 @@ Alternatively the default `Locale` can be specified according to https://docs.or
 @Test
 @DefaultLocale(language = "en")
 void test_with_lanuage() {
-	assertThat(Locale.getDefault()).isEqualsTo(new Locale("en"));
+	assertThat(Locale.getDefault()).isEqualTo(new Locale("en"));
 }
 
 @Test
 @DefaultLocale(language = "en", country = "EN")
 void test_with_lanuage_and_country() {
-	assertThat(Locale.getDefault()).isEqualsTo(new Locale("en", "EN"));
+	assertThat(Locale.getDefault()).isEqualTo(new Locale("en", "EN"));
 }
 
 @Test
 @DefaultLocale(language = "en", country = "EN", variant = "gb")
 void test_with_lanuage_and_country_and_vairant() {
-	assertThat(Locale.getDefault()).isEqualsTo(new Locale("en", "EN", "gb"));
+	assertThat(Locale.getDefault()).isEqualTo(new Locale("en", "EN", "gb"));
 }
 ----
 
@@ -58,13 +58,13 @@ class MyLocaleTests {
 
 	@Test
 	void test_with_class_level_configuration() {
-		assertThat(Locale.getDefault()).isEqualsTo(new Locale("fr"));
+		assertThat(Locale.getDefault()).isEqualTo(new Locale("fr"));
 	}
 
 	@Test
 	@DefaultLocale(language = "en")
 	void test_with_method_level_configuration() {
-		assertThat(Locale.getDefault()).isEqualsTo(new Locale("en"));
+		assertThat(Locale.getDefault()).isEqualTo(new Locale("en"));
 	}
 }
 ----
@@ -78,13 +78,13 @@ The default `TimeZone` is specified according to the https://docs.oracle.com/jav
 @Test
 @DefaulTimeZone("CET")
 void test_with_short_zone_id() {
-	assertThat(TimeZone.getDefault()).isEqualsTo(TimeZone.getTimeZone("CET"));
+	assertThat(TimeZone.getDefault()).isEqualTo(TimeZone.getTimeZone("CET"));
 }
 
 @Test
 @DefaultTimeZone("America/Los_Angeles")
 void test_with_long_zone_id() {
-	assertThat(TimeZone.getDefault()).isEqualsTo(TimeZone.getTimeZone("America/Los_Angeles"));
+	assertThat(TimeZone.getDefault()).isEqualTo(TimeZone.getTimeZone("America/Los_Angeles"));
 }
 ----
 
@@ -97,13 +97,13 @@ class MyTimeZoneTests {
 
 	@Test
 	void test_with_class_level_configuration() {
-		assertThat(TimeZone.getDefault()).isEqualsTo(TimeZone.getTimeZone("CET"));
+		assertThat(TimeZone.getDefault()).isEqualTo(TimeZone.getTimeZone("CET"));
 	}
 
 	@Test
 	@DefaultTimeZone("America/Los_Angeles")
 	void test_with_method_level_configuration() {
-        assertThat(TimeZone.getDefault()).isEqualsTo(TimeZone.getTimeZone("America/Los_Angeles"));
+        assertThat(TimeZone.getDefault()).isEqualTo(TimeZone.getTimeZone("America/Los_Angeles"));
 	}
 }
 ----

--- a/docs/environment-variables.adoc
+++ b/docs/environment-variables.adoc
@@ -29,7 +29,7 @@ And setting a environment variable for a test execution:
 @Test
 @SetEnvironmentVariable(key = "some variable", value = "new value")
 void test() {
-	assertThat(System.getenv("some variable")).isEqualsTo("new value");
+	assertThat(System.getenv("some variable")).isEqualTo("new value");
 }
 ----
 
@@ -44,7 +44,7 @@ As mentioned before, both annotations are repeatable and they can also be combin
 void test() {
 	assertThat(System.getenv("1st variable")).isNull();
 	assertThat(System.getenv("2nd variable")).isNull();
-	assertThat(System.getenv("3rd variable")).isEqualsTo("new value");
+	assertThat(System.getenv("3rd variable")).isEqualTo("new value");
 }
 ----
 
@@ -57,7 +57,7 @@ class MyEnvironmentVariableTest {
 	@Test
 	@SetEnvironmentVariable(key = "some variable", value = "new value")
 	void test() {
-		assertThat(System.getenv("some variable")).isEqualsTo("new value");
+		assertThat(System.getenv("some variable")).isEqualTo("new value");
 	}
 }
 ----

--- a/docs/range-sources.adoc
+++ b/docs/range-sources.adoc
@@ -52,7 +52,7 @@ void illegalRange(byte arg) {
 @LongRangeSource(from = 0L, to = 0L, closed = true)
 void legalRrange(long arg) {
 	// But this is fine
-	assertThat(arg).isEqualsTo(0L);
+	assertThat(arg).isEqualTo(0L);
 }
 ----
 

--- a/docs/system-properties.adoc
+++ b/docs/system-properties.adoc
@@ -24,7 +24,7 @@ And setting a system property for a test execution:
 @Test
 @SetSystemProperty(key = "some property", value = "new value")
 void test() {
-	assertThat(System.getProperty("some property")).isEqualsTo("new value");
+	assertThat(System.getProperty("some property")).isEqualTo("new value");
 }
 ----
 
@@ -39,7 +39,7 @@ As mentioned before, both annotations are repeatable and they can also be combin
 void test() {
 	assertThat(System.getProperty("1st property")).isNull();
 	assertThat(System.getProperty("2nd property")).isNull();
-	assertThat(System.getProperty("3rd property")).isEqualsTo("new value");
+	assertThat(System.getProperty("3rd property")).isEqualTo("new value");
 }
 ----
 
@@ -52,7 +52,7 @@ class MySystemPropertyTest {
 	@Test
 	@SetSystemProperty(key = "some property", value = "new value")
 	void test() {
-		assertThat(System.getProperty("some property")).isEqualsTo("new value");
+		assertThat(System.getProperty("some property")).isEqualTo("new value");
 	}
 }
 ----


### PR DESCRIPTION
As pointed in issue #263, the correct AssertJ method is `isEqualTo` instead of `isEqualsTo`. This PR fixes all occurrences in the Pioneer documentation and, therefore, closes #263.

Proposed commit message:

```
Fix typo in docs

As pointed in issue #263, the correct AssertJ method is `isEqualTo`
instead of `isEqualsTo`. This PR fixes all occurrences in the Pioneer
documentation.

Closes: #263
PR: #266
```

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
