### PR TITLE
Run SonarCloud analysis with Java 11

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -38,7 +38,7 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle-
       - name: Cache Sonar
         uses: actions/cache@v1
-        if: matrix.java == '8' && matrix.os == 'ubuntu'
+        if: matrix.java == '11' && matrix.os == 'ubuntu'
         with:
           path: ~/.sonar/cache/
           key: ${{ runner.os }}-sonar
@@ -47,7 +47,7 @@ jobs:
         with:
           arguments: --refresh-dependencies --stacktrace --scan clean build
       - name: Sonarqube
-        if: matrix.java == '8' && matrix.os == 'ubuntu'
+        if: matrix.java == '11' && matrix.os == 'ubuntu'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: "61ab2579215aa8a0024a2f9368fc1298fdecfd18"


### PR DESCRIPTION
As pointed in issue #267, SonarCloud will drop support for Java 8 by October 2020. This PR will run the SonarCloud analysis with Java 11, while still using Java 8 source level. At least this is how I interpret the docs:

https://docs.sonarqube.org/latest/analysis/scan/sonarscanner-for-gradle/

Here it says `sonar.java.source` defaults to `${project.sourceCompatibility}`, which we have set to 8 here:

https://github.com/junit-pioneer/junit-pioneer/blob/master/build.gradle.kts#L16

Proposed commit message:

```
Run SonarCloud analysis with Java 11

As pointed in issue #267, SonarCloud will drop support for Java 8 by
October 2020. This PR will run the SonarCloud analysis with Java 11,
while still using Java 8 source level.

Closes: #267
PR: #268
```

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
