### PR TITLE
Bump cache action from v1 to v2

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -31,13 +31,13 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: Cache Gradle
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.gradle/caches/
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
           restore-keys: ${{ runner.os }}-gradle-
       - name: Cache Sonar
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         if: matrix.java == '11' && matrix.os == 'ubuntu'
         with:
           path: ~/.sonar/cache/


### PR DESCRIPTION
Cache action [v2](https://github.com/actions/cache/releases/tag/v2.0.0) has been released yesterday. Using the new version has several advantages, such as increased performance and improved cache sizes.

While there is also support for [multipe paths](https://github.com/actions/cache/issues/16), I don't think we can leverage this feature since the Sonar and Gradle caches should be invalidated upon different events.

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
