### PR TITLE
Enforce UTF-8 encoding when reading source files (fixes build on Windows)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,6 +84,14 @@ sonarqube {
 
 tasks {
 
+    compileJava {
+        options.encoding = "UTF-8"
+    }
+
+    compileTestJava {
+        options.encoding = "UTF-8"
+    }
+
     test {
         testLogging {
             setExceptionFormat("full")
@@ -107,6 +115,7 @@ tasks {
         // disable the warning for missing comments and tags because they spam the output
         // (it does often not make sense to comment every tag; e.g. the @return tag on annotations)
         (options as CoreJavadocOptions).addStringOption("Xdoclint:accessibility,html,syntax,reference", "-quiet")
+        options.encoding = "UTF-8"
         shouldRunAfter(test)
     }
 


### PR DESCRIPTION
**[EDIT-2]** Here's the error I get: (there's a total of 6 of these errors, all complaining about an unmappable character for the windows-1552 encoding)
```
ReportEntryExtensionTests.java:377: error: unmappable character (0x9D) for encoding windows-1252
	"And the only word there spoken was the whispered word, “Lenore?�?",
```

Due to Gradle using the operating system default encoding, the build failed on Windows. Explicitly telling Gradle to use UTF-8 solves that issue.

**[EDIT]** I don't know why the automatic Windows build was passing without this. Didn't work on my machine. 😅  

I have no idea if this is the preferred way of setting the encoding, but it was the first working thing I could find.

I also found this snippet as a general solution, but it's from a post from 2012, and I have no clue how to translate it to the Gradle Kotlin:

```gradle
tasks.withType(Compile) {
    options.encoding = 'UTF-8'
}
```

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
