### PR TITLE
Reinstate rule that requires issue and PR number in title

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,7 +212,7 @@ To make the single commit expressive, its message must be detailed and [good]((h
 Furthermore, it must follow this structure:
 
 ```
-${action}
+${action} (${issues} / ${pull-request})
 
 ${body}
 
@@ -221,26 +221,21 @@ PR: ${pull-request}
 ```
 
 `${action}` should succinctly describe what the PR does in good Git style.
-Ideally, this title line should not exceed 50 characters - 70 is the absolute maximum.
+Ideally, this title line (without issue and PR numbers) should not exceed 50 characters - 70 is the absolute maximum.
+It is followed, in parenthesis, by a comma-separated list of all related issues, a slash, and the pull request (to make all of them easy to find from a look at the log).
 
 `${body}` should outline the problem the pull request was solving - it should focus on _why_ the code was written, not on _how_ it works.
 This can usually be a summary of the issue description and discussion as well as commit messages.
 Markdown syntax can be used and lines should usually not exceed 70 characters (exceptions are possible, e.g. to include stack traces).
 
-The message ends with a list of related issues and the PR that merges the change:
-
-* `${references}` is usually _Closes_, _Fixes_, or _Resolves_, but if none of that is the case, can also be _Issue(s)_
-* `${issues}` is a comma-separated list of all related issues
-* `${pull-request}` is the pull request
-
 This makes the related issues and pull request easy to find from a look at the log.
 
 Once a pull request is ready to be merged, the contributor will be asked to propose an action and body for the squashed commit and the maintainer will refine them when merging.
 
-As an example, the squashed commit 22996a2, which created this documentation, should have had the following message:
+As an example, the squashed commit 22996a2, which created this documentation, had the following message:
 
 ```
-Document branching and merging
+Document branching and merging (#30, #31 / #40)
 
 To make sure the project has a sensible and helpful commit history and
 interacts well with GitHub's features the strategy used for branching,
@@ -257,12 +252,7 @@ The chosen approach to squash and merge fulfills all of them except
 the detailed history, which will be more coarse than with merge commits
 or fast-forward merges. This was deemed acceptable in order to achieve
 the other points, particularly the last one.
-
-Closes: #30, #31
-PR: #40
 ```
-
-(The actual message is slightly different because the guideline for location of the issue and pull request numbers was later changed and the example above was updated to reflect that.)
 
 ## Updating Dependency on JUnit 5
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,11 +228,16 @@ It is followed, in parenthesis, by a comma-separated list of all related issues,
 This can usually be a summary of the issue description and discussion as well as commit messages.
 Markdown syntax can be used and lines should usually not exceed 70 characters (exceptions are possible, e.g. to include stack traces).
 
+Optionally, the message ends with a list of related issues:
+
+* `${references}` is usually _Closes_, _Fixes_, or _Resolves_, but if none of that is the case, can also be _Issue(s)_
+* `${issues}` is a comma-separated list of all related issues
+
 This makes the related issues and pull request easy to find from a look at the log.
 
 Once a pull request is ready to be merged, the contributor will be asked to propose an action and body for the squashed commit and the maintainer will refine them when merging.
 
-As an example, the squashed commit 22996a2, which created this documentation, had the following message:
+As an example, the squashed commit 22996a2, which created this documentation, could have had the following message:
 
 ```
 Document branching and merging (#30, #31 / #40)
@@ -252,6 +257,9 @@ The chosen approach to squash and merge fulfills all of them except
 the detailed history, which will be more coarse than with merge commits
 or fast-forward merges. This was deemed acceptable in order to achieve
 the other points, particularly the last one.
+
+Closes: #30
+Closes: #31
 ```
 
 ## Updating Dependency on JUnit 5


### PR DESCRIPTION
Proposed commit message:

```
Require issue and PR number in commit title (#264 / #273)

This was the rule until #79 / #86 changed it. We now consider that a
bad decision and want to start doing it again. An important factor
was that IDEs can make issue and PR numbers clickable links, which
adds additional value to making them easily accessible.
```

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
