### PR TITLE
Update dependency on JUnit to 5.5.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,12 +21,12 @@ repositories {
 }
 
 dependencies {
-    implementation(group = "org.junit.jupiter", name = "junit-jupiter-api", version = "5.4.2")
-    implementation(group = "org.junit.jupiter", name = "junit-jupiter-params", version = "5.4.2")
+    implementation(group = "org.junit.jupiter", name = "junit-jupiter-api", version = "5.5.2")
+    implementation(group = "org.junit.jupiter", name = "junit-jupiter-params", version = "5.5.2")
 
-    testImplementation(group = "org.junit.jupiter", name = "junit-jupiter-engine", version = "5.4.2")
-    testImplementation(group = "org.junit.platform", name = "junit-platform-launcher", version = "1.4.2")
-    testImplementation(group = "org.junit.platform", name = "junit-platform-testkit", version = "1.4.2")
+    testImplementation(group = "org.junit.jupiter", name = "junit-jupiter-engine", version = "5.5.2")
+    testImplementation(group = "org.junit.platform", name = "junit-platform-launcher", version = "1.5.2")
+    testImplementation(group = "org.junit.platform", name = "junit-platform-testkit", version = "1.5.2")
 
     testImplementation(group = "org.assertj", name = "assertj-core", version = "3.15.0")
     testImplementation(group = "org.mockito", name = "mockito-core", version = "3.3.3")


### PR DESCRIPTION
Closes #278 with an update to 5.5.2, highest patch of lowest minor that contains `InvocationInterceptor`. No changes to Pioneer code were necessary.

Proposed commit message:

```
Update dependency on JUnit to 5.5.2 (#278 / #279)

Update the dependency to get access to the new
`InvocationInterceptor`, so that #10 can be fixed.

Closes: #278
Related: #10 
PR: #279
```

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
