### PR TITLE
Do not corrupt ProcessEnvironment.theEnvironment on non-Windows platforms.

### DIFF
--- a/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableUtils.java
+++ b/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableUtils.java
@@ -90,8 +90,11 @@ class EnvironmentVariableUtils {
 	private static void setInProcessEnvironmentClass(Consumer<Map<String, String>> consumer)
 			throws ReflectiveOperationException {
 		Class<?> processEnvironmentClass = Class.forName("java.lang.ProcessEnvironment");
-		consumer.accept(getFieldValue(processEnvironmentClass, null, "theEnvironment"));
-		consumer.accept(getFieldValue(processEnvironmentClass, null, "theCaseInsensitiveEnvironment"));
+		Map<String, String> theEnvironment = getFieldValue(processEnvironmentClass, null, "theEnvironment");
+		Map<String, String> theCaseInsensitiveEnvironment = getFieldValue(processEnvironmentClass, null,
+			"theCaseInsensitiveEnvironment");
+		consumer.accept(theEnvironment);
+		consumer.accept(theCaseInsensitiveEnvironment);
 	}
 
 	/*

--- a/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableUtilsTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableUtilsTests.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junitpioneer.jupiter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("JUnitPioneer system environment utilities")
+class EnvironmentVariableUtilsTests {
+
+	@Test
+	void theEnvironmentIsNotCorruptedAfterSet() {
+		EnvironmentVariableUtils.set("A_VARIABLE", "A value");
+
+		// By using this method, the entire environment is read and copied from the field
+		// ProcessEnvironment.theEnvironment. If that field is corrupted by a String having been stored
+		// as key or value, this copy operation will fail with a ClassCastException.
+		Map<String, String> environmentCopy = new HashMap<>(System.getenv());
+		assertEquals("A value", environmentCopy.get("A_VARIABLE"));
+	}
+
+}


### PR DESCRIPTION
The method EnvironmentVariableUtils.modifyEnvironmentVariables tries first a method which works on Windows and then a method which works on Linux and OS X. The former accesses the field java.lang.ProcessEnvironment.theEnvironment by reflection, assumes it to be a Map<String, String>, and modifies it. On at least some platforms, java.lang.ProcessEnvironment.theEnvironment exists but is a Map<Variable, Value>, so the map is corrupted after being modified. Subsequent calls to fetch data out of System.getenv() result in a ClassCastException.

This change ensures that no changes take place in the Windows variant until all reflection operations have completed. If any reflection operation fails, the alternate Linux/Mac OS approach is used without having modified the environment.

Closes #287 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
