### PR TITLE
New behaviour for RetryingTest for Assumptions

### DIFF
--- a/docs/retrying-test.adoc
+++ b/docs/retrying-test.adoc
@@ -48,8 +48,9 @@ void aborted() {
 ```
 
 If a test is aborted (e.g.: because of a failed Assumption) `@RetryingTest` won't try again after that.
-The test `aborted` is executed once (because it is aborted).
-The test suite is marked as aborted/skipped, containing the underlying cause.
+The test `aborted` is aborted before (or during) its first execution.
+The first execution is marked as aborted/skipped, containing the underlying cause.
+The test suite as a whole is also marked as aborted/skipped.
 
 == Combining `@RetryingTest` with `@Test` et al
 

--- a/docs/retrying-test.adoc
+++ b/docs/retrying-test.adoc
@@ -40,6 +40,17 @@ void failsAlways() {
 The test `failsAlways` is executed three times (all of which fail).
 The first two executions are marked as ignored/aborted, while the last as failed - each contains the underlying exception.
 
+```java
+@RetryingTest(3)
+void aborted() {
+    // test code that is aborted e.g. because of an Assumption.
+}
+```
+
+If a test is aborted (e.g.: because of a failed Assumption) `@RetryingTest` won't try again after that.
+The test `aborted` is executed once (because it is aborted).
+The test suite is marked as aborted/skipped, containing the underlying cause.
+
 == Combining `@RetryingTest` with `@Test` et al
 
 If `@RetryingTest` is combined with `@Test` or `TestTemplate`-based mechanisms (like `@RepeatedTest` or `@ParameterizedTest`), the test engine will execute it according to each annotation (i.e. more than once).

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
@@ -85,6 +85,9 @@ public class RetryingTestExtension implements TestTemplateInvocationContextProvi
 		}
 
 		void failed(Throwable exception) {
+			if (exception instanceof TestAbortedException)
+				throw new TestAbortedException("Test did not execute, did an assumption fail?");
+
 			exceptionsSoFar++;
 
 			boolean allRetriesFailed = exceptionsSoFar == maxRetries;

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
@@ -86,7 +86,7 @@ public class RetryingTestExtension implements TestTemplateInvocationContextProvi
 
 		void failed(Throwable exception) {
 			if (exception instanceof TestAbortedException)
-				throw new TestAbortedException("Test did not execute, did an assumption fail?");
+				throw new TestAbortedException("Test execution was skipped, possibly because of a failed assumption.");
 
 			exceptionsSoFar++;
 

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
@@ -86,7 +86,8 @@ public class RetryingTestExtension implements TestTemplateInvocationContextProvi
 
 		void failed(Throwable exception) {
 			if (exception instanceof TestAbortedException)
-				throw new TestAbortedException("Test execution was skipped, possibly because of a failed assumption.", exception);
+				throw new TestAbortedException("Test execution was skipped, possibly because of a failed assumption.",
+					exception);
 
 			exceptionsSoFar++;
 

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
@@ -86,7 +86,7 @@ public class RetryingTestExtension implements TestTemplateInvocationContextProvi
 
 		void failed(Throwable exception) {
 			if (exception instanceof TestAbortedException)
-				throw new TestAbortedException("Test execution was skipped, possibly because of a failed assumption.");
+				throw new TestAbortedException("Test execution was skipped, possibly because of a failed assumption.", exception);
 
 			exceptionsSoFar++;
 

--- a/src/test/java/org/junitpioneer/jupiter/RetryingTestTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/RetryingTestTests.java
@@ -19,6 +19,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.parallel.Execution;
@@ -74,6 +75,14 @@ class RetryingTestTests {
 		assertThat(results.numberOfFailedTests()).isEqualTo(1);
 	}
 
+	@Test
+	void skipByAssumption_executedOnce_skipped() {
+		ExecutionResults results = PioneerTestKit.executeTestMethod(RetryingTestTestCase.class, "skipByAssumption");
+
+		assertThat(results.numberOfDynamicRegisteredTests()).isEqualTo(1);
+		assertThat(results.numberOfAbortedTests()).isEqualTo(1);
+	}
+
 	// TEST CASES -------------------------------------------------------------------
 
 	static class RetryingTestTestCase {
@@ -105,6 +114,11 @@ class RetryingTestTests {
 		@RetryingTest(3)
 		void failsAlways() {
 			throw new IllegalArgumentException();
+		}
+
+		@RetryingTest(3)
+		void skipByAssumption() {
+			Assumptions.assumeFalse(true);
 		}
 
 	}


### PR DESCRIPTION
Closes #291.

Proposed commit message:
```
Skip test execution on @RetryingTest when Assumption fails (#291)

Tests that do not meet the Assumptions of those tests should be skipped.
Ensures that RetryingTest tests are skipped after the first test executes if 
an assumption is not met.

Issue: #291
```
---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
