### PR TITLE
Improving and fixing releasing process (#284)

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -8,6 +8,7 @@ on:
     branches: 'master'
     tags-ignore: 
       - 'v**'
+      - 'releaseTrigger'
   pull_request:
     branches: '*'
 
@@ -53,3 +54,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: "61ab2579215aa8a0024a2f9368fc1298fdecfd18"
         run: ./gradlew jacocoTestReport sonarqube --stacktrace -i
+
+  buildDone:
+    name: buildOk
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: buildOk
+        run: echo 'all builds passed'

--- a/.github/workflows/releaseTrigger.yml
+++ b/.github/workflows/releaseTrigger.yml
@@ -11,15 +11,18 @@ jobs:
     runs-on: ubuntu-latest
     name: releasing
     steps:
-      - name: Wait For Other Builds To Succeed
-        # This steps waits for all github actions builds to suceed, before continuing.
-        # Currently we only have our default action, so we can ensure, 
-        # that our codebase builds correctly
-        uses: jitterbit/await-check-suites@v1
-        with:
-          appSlugFilter: 'github-actions'
-          timeoutSeconds: '300'
       - uses: actions/checkout@v2
+        with:
+          ref: master
+      - name: Wait on builds
+        uses: lewagon/wait-on-check-action@v0.1-beta.2
+        with:
+          ref: ${{ github.sha }}
+          check-name: buildOk
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 300
+      - name: Fetch unshallow
+        run: git fetch --prune --unshallow
       - name: Setup java
         uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
```
Improving and fixing releasing process (#284 / #295)

Releasing process was failing, as it could not checkout the ref
'master'. With this changes we bound the releasing process to
the master branch, as we are now checking out the master
specifically.

Furthermore we found issues, with some orders in the releasing
process, which could prevent the deletion of the tag on a failure.

Additionally we added a new last step to our normal build pipeline,
so the releasing process will be blocked by just one action and not
multiple ones. This will be needed in the future, when we start
using multi-version builds.

closes: #284
PR: #295 
```

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
