### PR TITLE
Adding experimental build for multiple JUnit5 versions (#296)

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,7 +1,7 @@
 # This workflow will build a Java project with Gradle
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
-name: JUnit Pioneer
+name: Build
 
 on:
   push:
@@ -19,7 +19,7 @@ jobs:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
         java: [ 8, 11, 14 ]
         os: [ubuntu, windows, macos]
-    name: Build on ${{ matrix.os }} with Java ${{ matrix.java }}
+    name: on ${{ matrix.os }} with Java ${{ matrix.java }}
     steps:
       - name: Check out repo
         uses: actions/checkout@v2

--- a/.github/workflows/experimentalJUnitVersion.yml
+++ b/.github/workflows/experimentalJUnitVersion.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup java
         uses: actions/setup-java@v1
         with:
-          java-version: 14
+          java-version: 11
       - name: Cache Gradle
         uses: actions/cache@v2
         with:
@@ -36,5 +36,5 @@ jobs:
       - name: Gradle build
         uses: eskatos/gradle-command-action@v1
         with:
-          arguments: --refresh-dependencies --stacktrace --scan clean build -PjunitVersion=${{ matrix.junit5 }}
+          arguments: --refresh-dependencies --stacktrace --scan clean build -PjunitMinorVersion=${{ matrix.junit5 }}
           wrapper-cache-enabled: false

--- a/.github/workflows/experimentalJUnitVersion.yml
+++ b/.github/workflows/experimentalJUnitVersion.yml
@@ -18,8 +18,8 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        junit5: [ 5.5.0, 5.5.1, 5.5.2, 5.6.0, 5.6.1, 5.6.2 ]
-    name: build with ${{ matrix.junit5 }}
+        junit5: [ 5.0, 5.1, 5.2, 6.0, 6.1, 6.2 ]
+    name: build with 5.${{ matrix.junit5 }}
     steps:
       - name: Check out repo
         uses: actions/checkout@v2

--- a/.github/workflows/experimentalJUnitVersion.yml
+++ b/.github/workflows/experimentalJUnitVersion.yml
@@ -18,8 +18,8 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        junit5: [ '5.0', '5.1', '5.2', '6.0', '6.1', '6.2' ]
-    name: with 5.${{ matrix.junit5 }}
+        junit5Minor: [ '5.0', '5.1', '5.2', '6.0', '6.1', '6.2' ]
+    name: with 5.${{ matrix.junit5Minor }}
     steps:
       - name: Check out repo
         uses: actions/checkout@v2
@@ -36,5 +36,5 @@ jobs:
       - name: Gradle build
         uses: eskatos/gradle-command-action@v1
         with:
-          arguments: --refresh-dependencies --stacktrace --scan clean build -PjunitMinorVersion=${{ matrix.junit5 }}
+          arguments: --refresh-dependencies --stacktrace --scan clean build -PjunitMinorVersion=${{ matrix.junit5Minor }}
           wrapper-cache-enabled: false

--- a/.github/workflows/experimentalJUnitVersion.yml
+++ b/.github/workflows/experimentalJUnitVersion.yml
@@ -5,12 +5,12 @@ name: Experimental JUnit5 build
 
 on:
   push:
-    branches: 'issue/296-multiversion'
+    branches: 'master'
     tags-ignore:
       - 'v**'
       - 'releaseTrigger'
-#  pull_request:
-#    branches: '*'
+  pull_request:
+    branches: '*'
 
 jobs:
   build:

--- a/.github/workflows/experimentalJUnitVersion.yml
+++ b/.github/workflows/experimentalJUnitVersion.yml
@@ -18,7 +18,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        junit5: [ 5.0, 5.1, 5.2, 6.0, 6.1, 6.2 ]
+        junit5: [ '5.0', '5.1', '5.2', '6.0', '6.1', '6.2' ]
     name: build with 5.${{ matrix.junit5 }}
     steps:
       - name: Check out repo

--- a/.github/workflows/experimentalJUnitVersion.yml
+++ b/.github/workflows/experimentalJUnitVersion.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         junit5: [ '5.0', '5.1', '5.2', '6.0', '6.1', '6.2' ]
-    name: build with 5.${{ matrix.junit5 }}
+    name: with 5.${{ matrix.junit5 }}
     steps:
       - name: Check out repo
         uses: actions/checkout@v2

--- a/.github/workflows/experimentalJUnitVersion.yml
+++ b/.github/workflows/experimentalJUnitVersion.yml
@@ -1,0 +1,40 @@
+# This workflow will build a Java project with Gradle
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Experimental JUnit5 build
+
+on:
+  push:
+    branches: 'issue/296-multiversion'
+    tags-ignore:
+      - 'v**'
+      - 'releaseTrigger'
+#  pull_request:
+#    branches: '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        junit5: [ 5.5.0, 5.5.1, 5.5.2, 5.6.0, 5.6.1, 5.6.2 ]
+    name: build with ${{ matrix.junit5 }}
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v2
+      - name: Setup java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 14
+      - name: Cache Gradle
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches/
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: ${{ runner.os }}-gradle-
+      - name: Gradle build
+        uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: --refresh-dependencies --stacktrace --scan clean build -PjunitVersion=${{ matrix.junit5 }}
+          wrapper-cache-enabled: false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,18 +20,18 @@ repositories {
     mavenCentral()
 }
 
-val junitVersion : String by project
+val junitMinorVersion : String by project
 
 // TODO remove debug messge :)
-println("using Junit5 version 5.$junitVersion")
+println("using Junit5 version 5.$junitMinorVersion")
 
 dependencies {
-    implementation(group = "org.junit.jupiter", name = "junit-jupiter-api", version = "5.$junitVersion")
-    implementation(group = "org.junit.jupiter", name = "junit-jupiter-params", version = "5.$junitVersion")
+    implementation(group = "org.junit.jupiter", name = "junit-jupiter-api", version = "5.$junitMinorVersion")
+    implementation(group = "org.junit.jupiter", name = "junit-jupiter-params", version = "5.$junitMinorVersion")
 
-    testImplementation(group = "org.junit.jupiter", name = "junit-jupiter-engine", version = "5.$junitVersion")
-    testImplementation(group = "org.junit.platform", name = "junit-platform-launcher", version = "1.$junitVersion")
-    testImplementation(group = "org.junit.platform", name = "junit-platform-testkit", version = "1.$junitVersion")
+    testImplementation(group = "org.junit.jupiter", name = "junit-jupiter-engine", version = "5.$junitMinorVersion")
+    testImplementation(group = "org.junit.platform", name = "junit-platform-launcher", version = "1.$junitMinorVersion")
+    testImplementation(group = "org.junit.platform", name = "junit-platform-testkit", version = "1.$junitMinorVersion")
 
     testImplementation(group = "org.assertj", name = "assertj-core", version = "3.15.0")
     testImplementation(group = "org.mockito", name = "mockito-core", version = "3.3.3")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,13 +20,18 @@ repositories {
     mavenCentral()
 }
 
-dependencies {
-    implementation(group = "org.junit.jupiter", name = "junit-jupiter-api", version = "5.5.2")
-    implementation(group = "org.junit.jupiter", name = "junit-jupiter-params", version = "5.5.2")
+val junitVersion : String by project
 
-    testImplementation(group = "org.junit.jupiter", name = "junit-jupiter-engine", version = "5.5.2")
-    testImplementation(group = "org.junit.platform", name = "junit-platform-launcher", version = "1.5.2")
-    testImplementation(group = "org.junit.platform", name = "junit-platform-testkit", version = "1.5.2")
+// TODO remove debug messge :)
+println("using Junit5 version 5.$junitVersion")
+
+dependencies {
+    implementation(group = "org.junit.jupiter", name = "junit-jupiter-api", version = "5.$junitVersion")
+    implementation(group = "org.junit.jupiter", name = "junit-jupiter-params", version = "5.$junitVersion")
+
+    testImplementation(group = "org.junit.jupiter", name = "junit-jupiter-engine", version = "5.$junitVersion")
+    testImplementation(group = "org.junit.platform", name = "junit-platform-launcher", version = "1.$junitVersion")
+    testImplementation(group = "org.junit.platform", name = "junit-platform-testkit", version = "1.$junitVersion")
 
     testImplementation(group = "org.assertj", name = "assertj-core", version = "3.15.0")
     testImplementation(group = "org.mockito", name = "mockito-core", version = "3.3.3")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+junitVersion=5.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,4 @@
-junitVersion=5.2
+# JUnit5 jupiter uses version 5.5.2 and JUnit Platform uses version 1.5.2
+# and the minor version is always in sync. Due to that fact, we just set
+# the minor verison.
+junitMinorVersion=5.2

--- a/src/main/java/org/junitpioneer/jupiter/params/DisableIfDisplayName.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/DisableIfDisplayName.java
@@ -16,7 +16,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.condition.DisabledIf;
 import org.junit.jupiter.api.extension.ExecutionCondition;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -28,9 +27,9 @@ import org.junit.jupiter.params.ParameterizedTest;
  * {@link ExtensionContext#getDisplayName() display name}.
  *
  * <p>The extension is an {@link ExecutionCondition} that validates dynamically registered tests.
- * Unlike {@link Disabled} or {@link DisabledIf} annotations, this extension doesn't disable
- * the whole test method. With {@code DisableIfDisplayName}, it is possible to selectively disable
- * tests out of the plethora of dynamically registered parameterized tests.</p>
+ * Unlike {@link Disabled} annotations, this extension doesn't disable the whole test method.
+ * With {@code DisableIfDisplayName}, it is possible to selectively disable tests out of the plethora
+ * of dynamically registered parameterized tests.</p>
  *
  * <p>If neither {@link DisableIfDisplayName#contains() contains} nor
  * {@link DisableIfDisplayName#matches() matches} is configured, the extension will throw an exception.


### PR DESCRIPTION
There are still some things to discuss, or things which imho are not that great within that solution.

1. JUnitVersion actually is just the patch.minor version and not the whole version. This is due to the fact that JUnit platform and JUnit jupiter are using the same patch.minor version, but sadly not the major one. We could think of changing this to some logic in the build.gradle.kts. Nevertheless it will be a good solution in any case, in my opinion. Providing two properties is also not a good idea.
2. When to run, is it overkill to run this on pull request? i think we do not gain a lot by doing so. but it could be quiet interesting :)

Commit Message:
```
Adding experimental build for multiple JUnit5 versions (#296)

Adding additional GitHub Action Workflow to check our compatibility with past and future
versions of JUnit5. Currently we are supporting 5.5.0, 5.5.1, 5.5.2, 5.6.0, 5.6.1 and 5.6.2
in this workflow.

closes: #296 
```

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
