### PR TITLE
Fixing gradle-wrapper-validation action

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,4 +1,6 @@
 name: "Validate Gradle Wrapper"
+
+on:
   push:
     branches: 'master'
     tags-ignore:


### PR DESCRIPTION
As i merged this i did not check the actions, but it looks like there was an error within the action, and the `on` directive was missing


---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
