### PR TITLE
GithubAction to manually start a release (#309)

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -8,7 +8,6 @@ on:
     branches: 'master'
     tags-ignore: 
       - 'v**'
-      - 'releaseTrigger'
   pull_request:
     branches: '*'
 

--- a/.github/workflows/experimentalJUnitVersion.yml
+++ b/.github/workflows/experimentalJUnitVersion.yml
@@ -8,7 +8,6 @@ on:
     branches: 'master'
     tags-ignore:
       - 'v**'
-      - 'releaseTrigger'
   pull_request:
     branches: '*'
 

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -5,7 +5,6 @@ on:
     branches: 'master'
     tags-ignore:
       - 'v**'
-      - 'releaseTrigger'
   pull_request:
     branches: '*'
 

--- a/.github/workflows/releaseTrigger.yml
+++ b/.github/workflows/releaseTrigger.yml
@@ -2,9 +2,7 @@
 name: Release
 
 on:
-  create:
-    tags:
-      - 'releaseTrigger'
+  workflow_dispatch:
 
 jobs:
   deploy:
@@ -12,8 +10,6 @@ jobs:
     name: releasing
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: master
       - name: Wait on builds
         uses: lewagon/wait-on-check-action@v0.1-beta.2
         with:
@@ -41,9 +37,6 @@ jobs:
           NEXUS_TOKEN_PASSWORD: ${{ secrets.NEXUS_TOKEN_PASSWORD }}
         with:
           arguments: ciPerformRelease
-      - name: Delete Tag
-        if: ${{ always() }}
-        run: git push --delete origin releaseTrigger
       - name: Trigger Website Build
         uses: peter-evans/repository-dispatch@v1
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -299,7 +299,7 @@ JUnit Pioneer uses [Shipkit](http://shipkit.org/) and [GitHub Actions](https://g
 Instead, releases must be triggered manually:
 
 1. make sure that the file [`version-properties`](version.properties) defines the correct version (see next section)
-2. push a tag `releaseTrigger` to `master`
+2. trigger the [`Release` GitHub Action](https://github.com/junit-pioneer/junit-pioneer/actions?query=workflow%3ARelease) manually for the master branch.
 
 GitHub Actions will then tell Shipkit to do its thing and afterwards delete the tag.
 The tag is always deleted, even if the release fails, so it is easy to trigger another one.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -301,8 +301,7 @@ Instead, releases must be triggered manually:
 1. make sure that the file [`version-properties`](version.properties) defines the correct version (see next section)
 2. trigger the [`Release` GitHub Action](https://github.com/junit-pioneer/junit-pioneer/actions?query=workflow%3ARelease) manually for the master branch.
 
-GitHub Actions will then tell Shipkit to do its thing and afterwards delete the tag.
-The tag is always deleted, even if the release fails, so it is easy to trigger another one.
+GitHub Actions will then tell Shipkit to do its thing.
 
 Every new version is published to the `junit-pioneer/maven` Bintray repository as well as to Maven Central and JCenter.
 This also triggers a website build - [see its `README.md`](https://github.com/junit-pioneer/junit-pioneer.github.io) for more information.


### PR DESCRIPTION
```
GithubAction to manually start a release (#309)

Adding possibility to manually trigger a release with a
workflow dispatch from GitHub Actions instead of a 
wandering tag.

closes: #309
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [x] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [x] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [x] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style (see #265)

Documentation (new extension)
* [x] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [x] The `package-info.java` contains information about the new extension

Code
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks (see #164)
* [x] Tests use [AssertJ](https://joel-costigliola.github.io/assertj/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [] The list of contributions inside `README.md` mentions the new contribution (real name optional) 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
