### PR TITLE
Adding JUnit 5.7.0-M1 to GitHub Action

### DIFF
--- a/.github/workflows/experimental-build.yml
+++ b/.github/workflows/experimental-build.yml
@@ -1,4 +1,4 @@
-name: Experimental JUnit 5 build
+name: Experimental build
 
 on:
   push:
@@ -40,8 +40,8 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        gradleVersion: [ 'current', 'rc' ] # we could add here others too, just for the fun of it
-    name: with Gradle Version ${{ matrix.gradleVersion }} on ubuntu-latest
+        gradleVersion: [ 'current' ] # we could add here others too, just for the fun of it
+    name: with Gradle ${{ matrix.gradleVersion }} on ubuntu-latest
     steps:
       - name: Check out repo
         uses: actions/checkout@v2

--- a/.github/workflows/experimental-build.yml
+++ b/.github/workflows/experimental-build.yml
@@ -14,7 +14,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        junit5Minor: [ '5.0', '5.1', '5.2', '6.0', '6.1', '6.2', '7.0-M1' ]
+        junit5Minor: [ '5.0', '5.1', '5.2', '6.0', '6.1', '6.2', '7.0-RC1' ]
     name: with JUnit 5.${{ matrix.junit5Minor }} on ubuntu-latest
     steps:
       - name: Check out repo

--- a/.github/workflows/junit5-build.yml
+++ b/.github/workflows/junit5-build.yml
@@ -60,4 +60,4 @@ jobs:
         with:
           arguments: --refresh-dependencies --stacktrace --scan clean build
           wrapper-cache-enabled: false
-          gradle-version: stable
+          gradle-version: ${{ matrix.gradleVersion }}

--- a/.github/workflows/junit5-build.yml
+++ b/.github/workflows/junit5-build.yml
@@ -14,7 +14,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        junit5Minor: [ '5.0', '5.1', '5.2', '6.0', '6.1', '6.2', '5.7.0-M1' ]
+        junit5Minor: [ '5.0', '5.1', '5.2', '6.0', '6.1', '6.2', '7.0-M1' ]
     name: with JUnit 5.${{ matrix.junit5Minor }} on ubuntu-latest
     steps:
       - name: Check out repo

--- a/.github/workflows/junit5-build.yml
+++ b/.github/workflows/junit5-build.yml
@@ -14,7 +14,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        junit5Minor: [ '5.0', '5.1', '5.2', '6.0', '6.1', '6.2' ]
+        junit5Minor: [ '5.0', '5.1', '5.2', '6.0', '6.1', '6.2', '5.7.0-M1' ]
     name: with JUnit 5.${{ matrix.junit5Minor }} on ubuntu-latest
     steps:
       - name: Check out repo

--- a/.github/workflows/junit5-build.yml
+++ b/.github/workflows/junit5-build.yml
@@ -34,3 +34,30 @@ jobs:
         with:
           arguments: --refresh-dependencies --stacktrace --scan clean build -PjunitMinorVersion=${{ matrix.junit5Minor }}
           wrapper-cache-enabled: false
+          
+  gradle:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        gradleVersion: [ 'current', 'rc' ] # we could add here others too, just for the fun of it
+    name: with Gradle Version ${{ matrix.gradleVersion }} on ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v2
+      - name: Set up java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache Gradle
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches/
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: ${{ runner.os }}-gradle-
+      - name: Gradle build
+        uses: eskatos/gradle-command-action@v1
+        with:
+          arguments: --refresh-dependencies --stacktrace --scan clean build
+          wrapper-cache-enabled: false
+          gradle-version: stable


### PR DESCRIPTION
---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style (see #265)

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks (see #164)
* [ ] Tests use [AssertJ](https://joel-costigliola.github.io/assertj/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [ ] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
