### PR TITLE
Migrate eskatos/gradle-command-action -> burrunan/gradle-cache-action

### DIFF
--- a/.github/workflows/junit5-build.yml
+++ b/.github/workflows/junit5-build.yml
@@ -23,14 +23,8 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
-      - name: Cache Gradle
-        uses: actions/cache@v2
+      - uses: burrunan/gradle-cache-action@v1
+        name: Gradle build
         with:
-          path: ~/.gradle/caches/
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
-          restore-keys: ${{ runner.os }}-gradle-
-      - name: Gradle build
-        uses: eskatos/gradle-command-action@v1
-        with:
+          job-id: jdk11
           arguments: --refresh-dependencies --stacktrace --scan clean build -PjunitMinorVersion=${{ matrix.junit5Minor }}
-          wrapper-cache-enabled: false

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -28,29 +28,26 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      - name: Cache Gradle
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/caches/
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
-          restore-keys: ${{ runner.os }}-gradle-
       - name: Cache Sonar
         uses: actions/cache@v2
         if: matrix.java == '11' && matrix.os == 'ubuntu'
         with:
           path: ~/.sonar/cache/
           key: ${{ runner.os }}-sonar
-      - name: Gradle build
-        uses: eskatos/gradle-command-action@v1
+      - uses: burrunan/gradle-cache-action@v1
+        name: Gradle build
         with:
+          job-id: jdk${{ matrix.java }}
           arguments: --refresh-dependencies --stacktrace --scan clean build
-          wrapper-cache-enabled: false
-      - name: Sonar analysis
+      - uses: burrunan/gradle-cache-action@v1
+        name: Sonar analysis
         if: matrix.java == '11' && matrix.os == 'ubuntu'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: "61ab2579215aa8a0024a2f9368fc1298fdecfd18"
-        run: ./gradlew jacocoTestReport sonarqube --stacktrace -i
+        with:
+          job-id: jdk${{ matrix.java }}
+          arguments: jacocoTestReport sonarqube --stacktrace -i
 
   buildDone:
     name: buildOk

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           java-version: 8
       - name: Perform release
-        uses: eskatos/gradle-command-action@v1
+        uses: burrunan/gradle-cache-action@v1
         env:
           # shipkit does not support GitHub Actions for now, hence that we simulate to be Travis CI
           TRAVIS_BRANCH: master
@@ -34,6 +34,7 @@ jobs:
           NEXUS_TOKEN_USERNAME: ${{ secrets.NEXUS_TOKEN_USERNAME }}
           NEXUS_TOKEN_PASSWORD: ${{ secrets.NEXUS_TOKEN_PASSWORD }}
         with:
+          job-id: jdk8
           arguments: ciPerformRelease
       - name: Trigger website build
         uses: peter-evans/repository-dispatch@v1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionSha256Sum=038794feef1f4745c6347107b6726279d1c824f3fc634b60f86ace1e9fbd1768
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
It unlocks fine-grained remote build cache with GitHub Actions backend
(=faster builds), and it adds error markers
(e.g. compilation errors right in the commit diffs)

See https://github.com/burrunan/gradle-cache-action#gradle-cache-action


---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [x] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [x] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [x] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style (see #265)

Documentation (new extension)
* [x] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [x] The `package-info.java` contains information about the new extension

Code
* [x] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [x] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks (see #164)
* [x] Tests use [AssertJ](https://joel-costigliola.github.io/assertj/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
