### PR TITLE
Update contribution guidelines to non-zero major versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -337,11 +337,11 @@ This is how JUnit Pioneer handles versioning:
 
 * _patch_: automatically increased by Shipkit on each release
 * _minor_: manually increased for each substantial change/feature
-* _major_: stays at 0 for now
+* _major_: manually increased after team decision 
 
-That means, for now, contributors only have to care about _minor_.
-Since each non-trivial change is developed in a PR, this is the place to discuss whether the minor version should be increased, i.e. whether a change or feature is "substantial".
-If it is, the PR needs to update `version-properties` to the next minor version.
+That means, contributors only have to care about _minor_, but maintainers need to consider increasing _major_.
+Since each non-trivial change is developed in a PR, this is the place to discuss whether the version should be increased, i.e. whether a change or feature is "substantial".
+If it is, the PR needs to update `version-properties` to the next version.
 Note that the feature's Javadoc needs to reference the same version in its `@since` tag.
 
 ### Background


### PR DESCRIPTION
Closes #225.

Proposed commit message:

```
Update contribution guideline to non-zero major versions (#225 / #319)

The contribution guidelines mentioned that the major version "stays
at 0 for now". Change that to account for the looming 1.0 release,
after which new major version increases will be decided by the
maintainer.
```

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
