### PR TITLE
Modules, modules, everywhere...

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,6 +90,23 @@ tasks {
 		options.encoding = "UTF-8"
 	}
 
+	val compileModule by registering(JavaCompile::class) {
+		dependsOn(classes)
+		source = fileTree(file("src/main/module/module-info.java"))
+
+		destinationDir = file("$buildDir/classes/java/module")
+		sourceCompatibility = "9"
+		targetCompatibility = "9"
+		classpath = sourceSets.getByName("main").output.classesDirs
+		options.release.set(9)
+		options.sourcepath = files(file("src/main/java"), file("src/main/module"))
+		options.compilerArgs.addAll(listOf(
+				"-verbose",
+				"--module-version", "${project.version}",
+				"--module-path", configurations.compileClasspath.get().asPath
+		))
+	}
+
 	compileTestJava {
 		options.encoding = "UTF-8"
 	}
@@ -135,6 +152,7 @@ tasks {
 
 	// the manifest needs to declare the future module name
 	jar {
+		dependsOn(compileModule)
 		manifest {
 			attributes(
 					"Automatic-Module-Name" to "org.junitpioneer"
@@ -146,6 +164,9 @@ tasks {
 		from(projectDir) {
 			include("LICENSE.md")
 			into("META-INF")
+		}
+		from("$buildDir/classes/java/module") {
+			include("module-info.class")
 		}
 	}
 }

--- a/src/main/module/module-info.java
+++ b/src/main/module/module-info.java
@@ -1,0 +1,10 @@
+module org.junitpioneer.junitpioneer {
+  requires org.junit.jupiter.api;
+  requires org.junit.jupiter.params;
+  requires org.junit.platform.commons;
+
+
+  exports org.junitpioneer.vintage;
+  exports org.junitpioneer.jupiter;
+  exports org.junitpioneer.jupiter.params;
+}


### PR DESCRIPTION
Copy & paste (read: hack & slay) Kotlin configuration to compile and package a Java module descriptor.

- Requires JDK 9+ to compile
- Needs a polishing pass from a Gradle/Kotlin expert ... @marcphilipp ;)

Addresses #314 -- provides ideas for #326 

Proof of concept:

```
jar --describe-module --file ...junit-pioneer-0.9.1.jar
org.junitpioneer.junitpioneer@0.9.1 jar:file:///.../junit-pioneer/build/libs/junit-pioneer-0.9.1.jar/!module-info.class
exports org.junitpioneer.jupiter
exports org.junitpioneer.jupiter.params
exports org.junitpioneer.vintage
requires java.base mandated
requires org.junit.jupiter.api
requires org.junit.jupiter.params
requires org.junit.platform.commons
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style (see #265)

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks (see #164)
* [ ] Tests use [AssertJ](https://joel-costigliola.github.io/assertj/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [ ] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
