### PR TITLE
Temporarily disable windows builds (#324 / #342)

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
         java: [ 8, 11, 14 ]
-        os: [ubuntu, windows, macos]
+        os: [ubuntu, macos]
     name: with Java ${{ matrix.java }} on ${{ matrix.os }}
     steps:
       - name: Check out repo

--- a/.github/workflows/module-build.yml
+++ b/.github/workflows/module-build.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         # test against latest update of each major Java 11+ version, as well as specific updates of LTS versions:
         java: [ 11, 14 ]
-        os: [ubuntu, windows, macos]
+        os: [ubuntu, macos]
     name: with Java ${{ matrix.java }} on ${{ matrix.os }}
     steps:
       - name: Check out repo


### PR DESCRIPTION
In #324 it is stated out that quite often
the builds on Windows time out, most probably
because of some kind of deadlock when executing
tests in parallel, not because there are errors.

When a build fails, the release workflow is
blocked, preventing us to release.

We decided to disable the Windows build temporarily
to enable releases.

related to: #324
PR: #342
---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
