### PR TITLE
Add Junit 5.7.0 to junit5-build.yml

### DIFF
--- a/.github/workflows/junit5-build.yml
+++ b/.github/workflows/junit5-build.yml
@@ -15,7 +15,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        junit5Minor: [ '5.0', '5.1', '5.2', '6.0', '6.1', '6.2' ]
+        junit5Minor: [ '5.0', '5.1', '5.2', '6.0', '6.1', '6.2', '7.0' ]
     name: with JUnit 5.${{ matrix.junit5Minor }} on ubuntu-latest
     steps:
       - name: Check out repo


### PR DESCRIPTION
On 2020-09-13 Junit 5.7.0 was released.
This PR adds the release to the JUnit5 workflow.

PR: #344
---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
