### PR TITLE
Configure Git to normalize line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# all end-of-lines are normalized to LF when written to the repository
+# https://git-scm.com/docs/gitattributes#_text
+* text=auto
+
+# force all text files on the working dir to have LF line endings
+# https://git-scm.com/docs/gitattributes#_eol
+* text eol=lf

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ This is true for such diverse areas as a firm legal foundation or a sensible and
 	* [Code Organization](#code-organization)
 	* [Code Style](#code-style)
 	* [Documentation](#documentation)
+	* [Git](#git)
 * [Fixing Bugs, Developing Features](#fixing-bugs-developing-features)
 	* [Branching Strategy](#branching-strategy)
 	* [Commits](#commits)
@@ -36,6 +37,7 @@ The guidelines apply to maintainers as well as contributors!
   This means that if you are employed you have received the necessary permissions from your employer to make the contributions.
 * Whatever content you contribute will be provided under the project license(s).
 
+
 ## If you're new to Open Source
 
 First of all, welcome!
@@ -60,6 +62,7 @@ With (some of) the basics covered, let's turn to JUnit Pioneer:
 For information on how to use it, see [GitHub's documentation](https://guides.github.com/features/mastering-markdown/).
 * The [feature documentation](#documentation) is written in AsciiDoctor.
 For information on how to use it, check its [user manual](https://asciidoctor.org/docs/user-manual/) and [writer's guide](https://asciidoctor.org/docs/asciidoc-writers-guide/).
+
 
 ## Writing Code
 
@@ -186,6 +189,17 @@ One aspect that's relevant to contributors is the list of contributions at the e
 Do **not** update the `release-notes.md` file!
 This file is generated automatically.
 
+### Git
+
+#### Line Endings
+
+We [mind the end of our lines](http://adaptivepatchwork.com/2012/03/01/mind-the-end-of-your-line/) and have [instructed](.gitattributes) Git to replace all line endings with `LF` (the non-Windows variant) when writing files to the working directory.
+If you're on Windows and prefer `CRLF` line endings, consider setting `core.autocrlf` to `true`:
+
+```bash
+git config --global core.autocrlf true
+```
+
 
 ## Fixing Bugs, Developing Features
 
@@ -294,6 +308,7 @@ the other points, particularly the last one.
 Closes: #30
 Closes: #31
 ```
+
 
 ## Updating Dependency on JUnit 5
 


### PR DESCRIPTION
This closes #341 

Proposed commit message:

```
Configure Git to normalize line endings to LF (#341 / #347)

As observed in #341, without further configuration, Git uses the OS
default line ending (LF on Unix, CRLF on Windows) when writing files
to the working directory, e.g. during checkout. If other tools aren't
aware of that and edit line endings, the resulting diff is noisy.

Specifically this happened in #341, where Pioneer was checked out on
Windows (~> CRLF) and Spotless changed all line endings (to LF).

This change creates a `.gitattributes` file with the following
settings:

# all end-of-lines are normalized to LF when written to the repository
# https://git-scm.com/docs/gitattributes#_text
* text=auto

# force all text files on the working dir to have LF line endings
# https://git-scm.com/docs/gitattributes#_eol
* text eol=lf

Closes: #341
PR: #347
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [x] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [x] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [x] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style (see #265)

Documentation (new extension)
* [x] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [x] The `package-info.java` contains information about the new extension

Code
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [x] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks (see #164)
* [x] Tests use [AssertJ](https://joel-costigliola.github.io/assertj/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [x] The list of contributions inside `README.md` mentions the new contribution (real name optional) 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
