### PR TITLE
Add note in documentation to use JUnit's BOM (#343 / #351)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ testCompile group: 'org.junit-pioneer', name: 'junit-pioneer', version: /*...*/
 JUnit Pioneer is built against Java 8, but comes as a module (i.e. with a `module-info.class`) named _org.junitpioneer_.
 That means it can be used on all Java versions 8 and higher on class path and module path.
 
+Pioneer does not only use JUnit 5's API, but also other artifacts from its ecosystem such as [`junit-platform-commons`](https://mvnrepository.com/artifact/org.junit.platform/junit-platform-commons).
+To avoid dependency issues (e.g. in [junit-pioneer#343](https://github.com/junit-pioneer/junit-pioneer/issues/343)), you should add the JUnit 5 BOM ([`junit-bom`](https://mvnrepository.com/artifact/org.junit/junit-bom)) to your project instead of defining all dependency versions manually.
+
 To not add to user's [JAR hell](https://blog.codefx.org/java/jar-hell/), JUnit Pioneer is not taking on any runtime dependencies besides JUnit 5.
 Pioneer always depends on the lowest JUnit 5 version that supports its feature set, but that should not keep you from using 5's latest and greatest.
-
-Pioneer does not only use JUnit 5's API, but also other artifacts from its ecosystem such as [`junit-platform-commons`](https://mvnrepository.com/artifact/org.junit.platform/junit-platform-commons).
-To avoid dependency issues, you should add the JUnit 5 BOM ([`junit-bom`](https://mvnrepository.com/artifact/org.junit/junit-bom)) to your project instead of defining all dependency versions manually.
 
 For our own infrastructure, we rely on the following compile and test dependencies:
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ That means it can be used on all Java versions 8 and higher on class path and mo
 To not add to user's [JAR hell](https://blog.codefx.org/java/jar-hell/), JUnit Pioneer is not taking on any runtime dependencies besides JUnit 5.
 Pioneer always depends on the lowest JUnit 5 version that supports its feature set, but that should not keep you from using 5's latest and greatest.
 
+Pioneer does not only use JUnit 5's API, but also other artefacts of the ecosystem, e.g. the `junit-platform-commons`.
+To avoid dependency troubles you should use the JUnit 5's BOM (the artefact is called [`junit-bom`](https://mvnrepository.com/artifact/org.junit/junit-bom)) in your project instead defining all of their dependency versions by hand.
+
+
 For our own infrastructure, we rely on the following compile and test dependencies:
 
 * JSR-305 (for static analysis)

--- a/README.md
+++ b/README.md
@@ -54,9 +54,8 @@ That means it can be used on all Java versions 8 and higher on class path and mo
 To not add to user's [JAR hell](https://blog.codefx.org/java/jar-hell/), JUnit Pioneer is not taking on any runtime dependencies besides JUnit 5.
 Pioneer always depends on the lowest JUnit 5 version that supports its feature set, but that should not keep you from using 5's latest and greatest.
 
-Pioneer does not only use JUnit 5's API, but also other artefacts of the ecosystem, e.g. the `junit-platform-commons`.
-To avoid dependency troubles you should use the JUnit 5's BOM (the artefact is called [`junit-bom`](https://mvnrepository.com/artifact/org.junit/junit-bom)) in your project instead defining all of their dependency versions by hand.
-
+Pioneer does not only use JUnit 5's API, but also other artifacts from its ecosystem such as [`junit-platform-commons`](https://mvnrepository.com/artifact/org.junit.platform/junit-platform-commons).
+To avoid dependency issues, you should add the JUnit 5 BOM ([`junit-bom`](https://mvnrepository.com/artifact/org.junit/junit-bom)) to your project instead of defining all dependency versions manually.
 
 For our own infrastructure, we rely on the following compile and test dependencies:
 


### PR DESCRIPTION
related to #343

```
Add note in documentation to use JUnit's BOM (#343 / #351)

With this PR a note to the documentation is added, that users should
use the JUnit Jupiters BOM instead of declaring each version on their
own.

related to #343
PR: #351
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style (see #265)

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks (see #164)
* [ ] Tests use [AssertJ](https://joel-costigliola.github.io/assertj/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [ ] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
