### PR TITLE
Improve PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,13 @@
+Proposed commit message:
+
+```
+${action} (${issues} / ${pull-request})
+
+${body}
+
+${references}: ${issues}
+PR: ${pull-request}
+```
 
 ---
 **PR checklist**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,9 @@
 Proposed commit message:
 
 ```
-${action} (${issues} / ${pull-request})
+${action} (${issues} / ${pull-request}) [max 70 characters]
 
-${body}
+${body} [max 70 characters per line]
 
 ${references}: ${issues}
 PR: ${pull-request}

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ Documentation (general)
 * [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
 * [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
 * [ ] Only one sentence per line (especially in `.adoc` files)
-* [ ] Javadoc uses formal style, while sites documentation may use informal style (see #265)
+* [ ] Javadoc uses formal style, while sites documentation may use informal style
 
 Documentation (new extension)
 * [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
@@ -21,7 +21,7 @@ Documentation (new extension)
 Code
 * [ ] Code adheres to code style, naming conventions etc.
 * [ ] Successful tests cover all changes
-* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks (see #164)
+* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
 * [ ] Tests use [AssertJ](https://joel-costigliola.github.io/assertj/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#assertions) (which are based on AssertJ)
 
 Contributing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -259,9 +259,9 @@ To make the single commit expressive, its message must be detailed and [good]((h
 Furthermore, it must follow this structure:
 
 ```
-${action} (${issues} / ${pull-request})
+${action} (${issues} / ${pull-request}) [max 70 characters]
 
-${body}
+${body} [max 70 characters per line]
 
 ${references}: ${issues}
 PR: ${pull-request}


### PR DESCRIPTION
This PR improves our PR template in several ways (please refer to the separate commit messages for more details).

Closes #370. Closes #371.

Proposed commit message:

```
Improve PR template (#370, #371 / #357)

This commit removes unnecessary references in issues that have been
used within the PR template. In addition, the PR template now
includes the commit message template (with max character hints).

Closes: #370
Closes: #371
PR: #357
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style (see #265)

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks (see #164)
* [ ] Tests use [AssertJ](https://joel-costigliola.github.io/assertj/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
