### PR TITLE
Update Gradle to 6.7 and latest Java to 15 (#359 / #363)

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
-        java: [ 8, 11, 14 ]
+        java: [ 8, 11, 15 ]
         os: [ubuntu, macos]
     name: with Java ${{ matrix.java }} on ${{ matrix.os }}
     steps:

--- a/.github/workflows/module-build.yml
+++ b/.github/workflows/module-build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # test against latest update of each major Java 11+ version, as well as specific updates of LTS versions:
-        java: [ 11, 14 ]
+        java: [ 11, 15 ]
         os: [ubuntu, macos]
     name: with Java ${{ matrix.java }} on ${{ matrix.os }}
     steps:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,6 +90,10 @@ yamlValidator {
 	isSearchRecursive = true
 }
 
+jacoco {
+	toolVersion = "0.8.6"
+}
+
 sonarqube {
 	// If you want to use this logcally a sonarLogin has to be provide, either via Username and Password
 	// or via token, https://docs.sonarqube.org/latest/analysis/analysis-parameters/
@@ -154,7 +158,6 @@ tasks {
 		options.encoding = "UTF-8"
 		shouldRunAfter(test)
 	}
-
 	jacocoTestReport {
 		reports {
 			xml.isEnabled = true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,7 +91,7 @@ yamlValidator {
 }
 
 jacoco {
-	toolVersion = "0.8.7"
+	toolVersion = "0.8.6"
 }
 
 sonarqube {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -158,6 +158,7 @@ tasks {
 		options.encoding = "UTF-8"
 		shouldRunAfter(test)
 	}
+
 	jacocoTestReport {
 		reports {
 			xml.isEnabled = true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,7 +91,7 @@ yamlValidator {
 }
 
 jacoco {
-	toolVersion = "0.8.6"
+	toolVersion = "0.8.7"
 }
 
 sonarqube {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
@beatngu13 Please don't get mad at me, I was bored 👼 

```
Update Gradle to 6.7 and latest Java to 15 (#359 / #362)

This PR also updates the JaCoCo plugin to version 0.8.6,
which adds experimental support for Java 15.
The official support for Java 15 comes with version 0.8.7,
but as of today (2020-10-22) there is only a four days old
snapshot release, which Gradle can't pick up, as it's not
on Maven central.

closes #359 
PR: #363
```