### PR TITLE
Add JUnit 5.6.3 to JUnit workflow (#364 / #365)

### DIFF
--- a/.github/workflows/junit5-build.yml
+++ b/.github/workflows/junit5-build.yml
@@ -15,7 +15,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        junit-version: [ '5.5.0', '5.5.1', '5.5.2', '5.6.0', '5.6.1', '5.6.2' ]
+        junit-version: [ '5.5.0', '5.5.1', '5.5.2', '5.6.0', '5.6.1', '5.6.2', '5.6.3' ]
     name: with JUnit ${{ matrix.junit-version }} on ubuntu-latest
     steps:
       - name: Check out repo


### PR DESCRIPTION
```
JUnit 5.6.3 was releases yesterday. As it is a more recent,
but still supported, Jupiter version as the one we use in
Pioneer it has to be added to the JUnit workflow.

closes #364
PR: #365
```