### PR TITLE
Update copyright to 2021 (#360 / #395)

### DIFF
--- a/.infra/spotless/eclipse-public-license-2.0.java
+++ b/.infra/spotless/eclipse-public-license-2.0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/AbstractEntryBasedExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/AbstractEntryBasedExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/CartesianProductResolver.java
+++ b/src/main/java/org/junitpioneer/jupiter/CartesianProductResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/CartesianProductTest.java
+++ b/src/main/java/org/junitpioneer/jupiter/CartesianProductTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/CartesianProductTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/CartesianProductTestExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/CartesianProductTestInvocationContext.java
+++ b/src/main/java/org/junitpioneer/jupiter/CartesianProductTestInvocationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/CartesianProductTestNameFormatter.java
+++ b/src/main/java/org/junitpioneer/jupiter/CartesianProductTestNameFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/CartesianValueArgumentsProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/CartesianValueArgumentsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/CartesianValueSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/CartesianValueSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/ClearEnvironmentVariable.java
+++ b/src/main/java/org/junitpioneer/jupiter/ClearEnvironmentVariable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/ClearSystemProperty.java
+++ b/src/main/java/org/junitpioneer/jupiter/ClearSystemProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocaleExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocaleExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/DefaultTimeZone.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultTimeZone.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/DefaultTimeZoneExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultTimeZoneExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableUtils.java
+++ b/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/Issue.java
+++ b/src/main/java/org/junitpioneer/jupiter/Issue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/IssueExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/IssueExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/IssueProcessor.java
+++ b/src/main/java/org/junitpioneer/jupiter/IssueProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/IssueTestCase.java
+++ b/src/main/java/org/junitpioneer/jupiter/IssueTestCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/IssueTestSuite.java
+++ b/src/main/java/org/junitpioneer/jupiter/IssueTestSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/PioneerAnnotationUtils.java
+++ b/src/main/java/org/junitpioneer/jupiter/PioneerAnnotationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/PioneerException.java
+++ b/src/main/java/org/junitpioneer/jupiter/PioneerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/PioneerUtils.java
+++ b/src/main/java/org/junitpioneer/jupiter/PioneerUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/ReadsDefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReadsDefaultLocale.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/ReadsDefaultTimeZone.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReadsDefaultTimeZone.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/ReadsEnvironmentVariable.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReadsEnvironmentVariable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/ReadsStdIo.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReadsStdIo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/ReadsSystemProperty.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReadsSystemProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/ReportEntry.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReportEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/ReportEntryExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReportEntryExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTest.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTestInvocationContext.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTestInvocationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/SetEnvironmentVariable.java
+++ b/src/main/java/org/junitpioneer/jupiter/SetEnvironmentVariable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/SetSystemProperty.java
+++ b/src/main/java/org/junitpioneer/jupiter/SetSystemProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/StdIn.java
+++ b/src/main/java/org/junitpioneer/jupiter/StdIn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/StdIo.java
+++ b/src/main/java/org/junitpioneer/jupiter/StdIo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/StdIoExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/StdIoExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/StdOut.java
+++ b/src/main/java/org/junitpioneer/jupiter/StdOut.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/Stopwatch.java
+++ b/src/main/java/org/junitpioneer/jupiter/Stopwatch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/StopwatchExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/StopwatchExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/SystemPropertyExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/SystemPropertyExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/WritesDefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/WritesDefaultLocale.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/WritesDefaultTimeZone.java
+++ b/src/main/java/org/junitpioneer/jupiter/WritesDefaultTimeZone.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/WritesEnvironmentVariable.java
+++ b/src/main/java/org/junitpioneer/jupiter/WritesEnvironmentVariable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/WritesStdIo.java
+++ b/src/main/java/org/junitpioneer/jupiter/WritesStdIo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/WritesSystemProperty.java
+++ b/src/main/java/org/junitpioneer/jupiter/WritesSystemProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/issue/IssueExtensionExecutionListener.java
+++ b/src/main/java/org/junitpioneer/jupiter/issue/IssueExtensionExecutionListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/issue/IssueTestCaseBuilder.java
+++ b/src/main/java/org/junitpioneer/jupiter/issue/IssueTestCaseBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/params/ByteRange.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/ByteRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/params/ByteRangeSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/ByteRangeSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/params/DisableIfDisplayName.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/DisableIfDisplayName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/params/DisableIfNameExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/DisableIfNameExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/params/DoubleRange.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/DoubleRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/params/DoubleRangeSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/DoubleRangeSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/params/FloatRange.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/FloatRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/params/FloatRangeSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/FloatRangeSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/params/IntRange.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/IntRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/params/IntRangeSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/IntRangeSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/params/LongRange.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/LongRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/params/LongRangeSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/LongRangeSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/params/PioneerAnnotationUtils.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/PioneerAnnotationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/params/Range.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/Range.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/params/RangeClass.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/RangeClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/params/RangeSourceArgumentsProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/RangeSourceArgumentsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/params/ShortRange.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/ShortRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/jupiter/params/ShortRangeSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/ShortRangeSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/vintage/ExpectedExceptionExtension.java
+++ b/src/main/java/org/junitpioneer/vintage/ExpectedExceptionExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/vintage/Test.java
+++ b/src/main/java/org/junitpioneer/vintage/Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/main/java/org/junitpioneer/vintage/TimeoutExtension.java
+++ b/src/main/java/org/junitpioneer/vintage/TimeoutExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/jupiter/CartesianProductTestExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/CartesianProductTestExtensionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/jupiter/CartesianProductTestNameFormatterTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/CartesianProductTestNameFormatterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/jupiter/DefaultTimeZoneTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultTimeZoneTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableUtilsTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/jupiter/IssueExtensionIntegrationTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/IssueExtensionIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/jupiter/IssueExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/IssueExtensionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/jupiter/IssueTestCaseTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/IssueTestCaseTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/jupiter/PioneerAnnotationUtilsTestCases.java
+++ b/src/test/java/org/junitpioneer/jupiter/PioneerAnnotationUtilsTestCases.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/jupiter/PioneerAnnotationUtilsTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/PioneerAnnotationUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/jupiter/PioneerUtilsTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/PioneerUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/jupiter/ReportEntryExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/ReportEntryExtensionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/jupiter/RetryingTestTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/RetryingTestTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/jupiter/StdIoExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/StdIoExtensionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/jupiter/StopwatchExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/StopwatchExtensionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/jupiter/issue/IssueExtensionExecutionListenerTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/issue/IssueExtensionExecutionListenerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/jupiter/issue/IssueExtensionIntegrationTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/issue/IssueExtensionIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/jupiter/issue/StoringIssueProcessor.java
+++ b/src/test/java/org/junitpioneer/jupiter/issue/StoringIssueProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/jupiter/issue/TestPlanHelper.java
+++ b/src/test/java/org/junitpioneer/jupiter/issue/TestPlanHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/jupiter/params/DisabledIfNameExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/params/DisabledIfNameExtensionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/jupiter/params/PioneerAnnotationUtilsTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/params/PioneerAnnotationUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/jupiter/params/RangeSourceArgumentsProviderTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/params/RangeSourceArgumentsProviderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/testkit/ExecutionResults.java
+++ b/src/test/java/org/junitpioneer/testkit/ExecutionResults.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/testkit/PioneerTestKit.java
+++ b/src/test/java/org/junitpioneer/testkit/PioneerTestKit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/testkit/PioneerTestKitTests.java
+++ b/src/test/java/org/junitpioneer/testkit/PioneerTestKitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/testkit/assertion/AbstractPioneerAssert.java
+++ b/src/test/java/org/junitpioneer/testkit/assertion/AbstractPioneerAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/testkit/assertion/ExecutionResultAssert.java
+++ b/src/test/java/org/junitpioneer/testkit/assertion/ExecutionResultAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/testkit/assertion/PioneerAssert.java
+++ b/src/test/java/org/junitpioneer/testkit/assertion/PioneerAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/testkit/assertion/ReportEntryAssertBase.java
+++ b/src/test/java/org/junitpioneer/testkit/assertion/ReportEntryAssertBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/testkit/assertion/TestCaseAssertBase.java
+++ b/src/test/java/org/junitpioneer/testkit/assertion/TestCaseAssertBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/testkit/assertion/reportentry/ReportEntryAssert.java
+++ b/src/test/java/org/junitpioneer/testkit/assertion/reportentry/ReportEntryAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/testkit/assertion/reportentry/ReportEntryValueAssert.java
+++ b/src/test/java/org/junitpioneer/testkit/assertion/reportentry/ReportEntryValueAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/testkit/assertion/single/TestCaseAssert.java
+++ b/src/test/java/org/junitpioneer/testkit/assertion/single/TestCaseAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/testkit/assertion/single/TestCaseFailureAssert.java
+++ b/src/test/java/org/junitpioneer/testkit/assertion/single/TestCaseFailureAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/testkit/assertion/single/TestCaseStartedAssert.java
+++ b/src/test/java/org/junitpioneer/testkit/assertion/single/TestCaseStartedAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/testkit/assertion/suite/TestSuiteAssert.java
+++ b/src/test/java/org/junitpioneer/testkit/assertion/suite/TestSuiteAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/testkit/assertion/suite/TestSuiteContainersAssert.java
+++ b/src/test/java/org/junitpioneer/testkit/assertion/suite/TestSuiteContainersAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/testkit/assertion/suite/TestSuiteFailureAssert.java
+++ b/src/test/java/org/junitpioneer/testkit/assertion/suite/TestSuiteFailureAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/testkit/assertion/suite/TestSuiteTestsAssert.java
+++ b/src/test/java/org/junitpioneer/testkit/assertion/suite/TestSuiteTestsAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which

--- a/src/test/java/org/junitpioneer/vintage/TestIntegrationTests.java
+++ b/src/test/java/org/junitpioneer/vintage/TestIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which


### PR DESCRIPTION
closes: #360

```
Update copyright to 2021 (#360 / #395)

The copyright text was vom 2015 to 2020.
As 2021 is there and the project started in 2016 the
text got updated.

closes: #360
PR: #395
```
---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
