### PR TITLE
Update log4j-dependencies (NA / #398)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,8 +51,8 @@ dependencies {
 	testImplementation(group = "org.mockito", name = "mockito-core", version = "3.6.28")
 	testImplementation(group = "com.google.jimfs", name = "jimfs", version = "1.1")
 
-	testRuntimeOnly(group = "org.apache.logging.log4j", name = "log4j-core", version = "2.12.1")
-	testRuntimeOnly(group = "org.apache.logging.log4j", name = "log4j-jul", version = "2.12.1")
+	testRuntimeOnly(group = "org.apache.logging.log4j", name = "log4j-core", version = "2.14.0")
+	testRuntimeOnly(group = "org.apache.logging.log4j", name = "log4j-jul", version = "2.14.0")
 }
 
 spotless {


### PR DESCRIPTION
```
Updating log4j dependencies to 2.14.0 (NA / #398)

This is a combined PR of those from dependabot to update the connected dependencies in a single commit.

See #390 and #392

PR: #398

```

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
