### PR TITLE
Update dependabot to set our own labels (#396 / #399)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,14 @@ updates:
     interval: monthly
   ignore:
     - dependency-name: "org.junit.*"
+  labels:
+    - "📖 theme: build"
+    - "🛸 3rd-party: Gradle"
 
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: monthly
+  labels:
+    - "📖 theme: infrastructure"
+    - "🛸 3rd-party: Github Actions"


### PR DESCRIPTION
related to #396 

```
Update dependabot to set our own labels (#396 / #399)

This PR updates the dependabot config in a way that it
uses our own labels instead of the default ones.

The config was validated using the official validator:
https://dependabot.com/docs/config-file/validator/

See official documentation here:
https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/customizing-dependency-updates

#related: #396
PR: #399
```

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
