### PR TITLE
Improve documentation/logging of reflective warning for environment variable extensions

### DIFF
--- a/docs/environment-variables.adoc
+++ b/docs/environment-variables.adoc
@@ -9,7 +9,7 @@ Other environment variables that are changed during the test, are *not* restored
 WARNING: Java considers environment variables to be immutable, so this extension uses reflection to change them.
 This requires that the `SecurityManager` allows modifications and can potentially break on different operating systems and Java versions.
 Be aware that this is a fragile solution and consider finding a better one for your specific situation.
-If you're running on Java 9 or later, you may have to add `--add-opens=java.base/java.util=ALL-UNNAMED` to your test execution to prevent warnings or even errors.
+For more details, see <<Warnings for Reflective Access>>.
 
 For example, clearing a environment variable for a test execution can be done as follows:
 
@@ -71,6 +71,36 @@ class MyEnvironmentVariableTest {
 
 }
 ----
+
+== Warnings for Reflective Access
+
+As explained above, this extension uses reflective access to change the otherwise immutable environment variables.
+On Java 9 to 16, this leads to a warning like the following:
+
+[source]
+----
+[ERROR] WARNING: An illegal reflective access operation has occurred
+[ERROR] WARNING: Illegal reflective access by org.junitpioneer.jupiter.EnvironmentVariableUtils [...] to field [...]
+[ERROR] WARNING: Please consider reporting this to the maintainers of org.junitpioneer.jupiter.EnvironmentVariableUtils
+[ERROR] WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
+[ERROR] WARNING: All illegal access operations will be denied in a future release
+----
+
+On Java 17 and later, you get this error instead:
+
+[source]
+----
+java.lang.reflect.InaccessibleObjectException: Unable to make field [...] accessible:
+module java.base does not "opens java.lang" to unnamed module [...]
+----
+
+The best way to prevent these warnings/errors, is to change the code under test, so this extension is no longer needed.
+The next best thing is to allow access to that specific package with `--add-opens=java.base/java.util=ALL-UNNAMED` (if you place JUnit Pioneer on the class path) or ``--add-opens=java.base/java.util=org.junitpioneer` (if you place it on the module path).
+
+These command line options need to be added to the JVM that executes the tests:
+
+* https://docs.gradle.org/current/dsl/org.gradle.api.tasks.testing.Test.html[Gradle]
+* http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#argLine[Maven basics] and https://nipafx.dev/maven-on-java-9/[advanced]
 
 == Thread-Safety
 

--- a/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
@@ -50,8 +50,12 @@ class EnvironmentVariableExtension extends AbstractEntryBasedExtension<String, S
 	@Override
 	protected void reportWarning(ExtensionContext context) {
 		boolean wasReported = REPORTED_WARNING.getAndSet(true);
-		if (!wasReported)
-			context.publishReportEntry(WARNING_KEY, WARNING_VALUE);
+		if (wasReported)
+			return;
+
+		// log report entry and to System.out - check docs for reasons
+		context.publishReportEntry(WARNING_KEY, WARNING_VALUE);
+		System.out.println(WARNING_KEY + ": " + WARNING_VALUE);
 	}
 
 	@Override

--- a/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
@@ -59,7 +59,7 @@ class EnvironmentVariableExtension extends AbstractEntryBasedExtension<String, S
 		// print a warning and hence it's only Pioneer polluting System.err - not good).
 		// System.out seemed like a good compromise.
 		context.publishReportEntry(WARNING_KEY, WARNING_VALUE);
-		System.out.println(WARNING_KEY + ": " + WARNING_VALUE);
+		System.out.println(WARNING_KEY + ": " + WARNING_VALUE); //NOSONAR
 	}
 
 	@Override

--- a/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
@@ -53,7 +53,11 @@ class EnvironmentVariableExtension extends AbstractEntryBasedExtension<String, S
 		if (wasReported)
 			return;
 
-		// log report entry and to System.out - check docs for reasons
+		// Log as report entry and to System.out - check docs for reasons, but why System.out?
+		// Because report entries lack tool support and are easily lost and System.err is
+		// too invasive (particularly since, with good configuration, the module system won't
+		// print a warning and hence it's only Pioneer polluting System.err - not good).
+		// System.out seemed like a good compromise.
 		context.publishReportEntry(WARNING_KEY, WARNING_VALUE);
 		System.out.println(WARNING_KEY + ": " + WARNING_VALUE);
 	}

--- a/src/main/java/org/junitpioneer/jupiter/SetEnvironmentVariable.java
+++ b/src/main/java/org/junitpioneer/jupiter/SetEnvironmentVariable.java
@@ -35,9 +35,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * uses reflection to change them. This requires that the {@link SecurityManager}
  * allows modifications and can potentially break on different operating systems and
  * Java versions. Be aware that this is a fragile solution and consider finding a
- * better one for your specific situation. If you're running on Java 9 or later, you
- * may have to add {@code --add-opens=java.base/java.util=ALL-UNNAMED} to your test
- * execution to prevent warnings or even errors.</p>
+ * better one for your specific situation. If you're running on Java 9 or later and
+ * are encountering warnings or errors, check
+ * <a href="https://junit-pioneer.org/docs/environment-variables/">the documentation</a>.</p>
  *
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,

--- a/src/main/java/org/junitpioneer/jupiter/SetEnvironmentVariable.java
+++ b/src/main/java/org/junitpioneer/jupiter/SetEnvironmentVariable.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * Java versions. Be aware that this is a fragile solution and consider finding a
  * better one for your specific situation. If you're running on Java 9 or later and
  * are encountering warnings or errors, check
- * <a href="https://junit-pioneer.org/docs/environment-variables/">the documentation</a>.</p>
+ * <a href="https://junit-pioneer.org/docs/environment-variables/#warnings-for-reflective-access">the documentation</a>.</p>
  *
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,

--- a/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
@@ -255,17 +255,21 @@ class EnvironmentVariableExtensionTests {
 		}
 
 		@Test
-		void shouldNotReportWarningIfExtensionNotUsed() {
+		@StdIo
+		void shouldNotReportWarningIfExtensionNotUsed(StdOut out) {
 			ExecutionResults results = executeTestMethod(ReportWarningTestCases.class, "testWithoutExtension");
 
 			assertThat(results).hasNoReportEntries();
+			assertThat((out.capturedLines())).containsExactly("");
 		}
 
 		@Test
-		void shouldReportWarningIfExtensionUsed() {
+		@StdIo
+		void shouldReportWarningIfExtensionUsed(StdOut out) {
 			ExecutionResults results = executeTestMethod(ReportWarningTestCases.class, "testWithExtension");
 
 			assertThat(results).hasSingleReportEntry().withKeyAndValue(WARNING_KEY, WARNING_VALUE);
+			assertThat((out.capturedLines())).containsExactly(WARNING_KEY + ": " + WARNING_VALUE);
 		}
 
 		@Test

--- a/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
@@ -260,7 +260,7 @@ class EnvironmentVariableExtensionTests {
 			ExecutionResults results = executeTestMethod(ReportWarningTestCases.class, "testWithoutExtension");
 
 			assertThat(results).hasNoReportEntries();
-			assertThat((out.capturedLines())).containsExactly("");
+			assertThat(out.capturedLines()).containsExactly("");
 		}
 
 		@Test
@@ -269,7 +269,7 @@ class EnvironmentVariableExtensionTests {
 			ExecutionResults results = executeTestMethod(ReportWarningTestCases.class, "testWithExtension");
 
 			assertThat(results).hasSingleReportEntry().withKeyAndValue(WARNING_KEY, WARNING_VALUE);
-			assertThat((out.capturedLines())).containsExactly(WARNING_KEY + ": " + WARNING_VALUE);
+			assertThat(out.capturedLines()).containsExactly(WARNING_KEY + ": " + WARNING_VALUE);
 		}
 
 		@Test


### PR DESCRIPTION
Proposed commit message:

```
More clearly document/log env. var. reflective warning (#387 / #404)

The environment variable extension uses reflection to change the
otherwise immutable variables. On Java 9+, this leads to warnings or
errors and this change makes it easier for users to understand the
reason behind that:

* Before this change, we printed a related warning via report entries,
  but those are often lost in the wild. We now log an additional
  warning to `System.out`. While we initially considered `System.err`
  it is rather invasive, particularly since, with good configuration,
  the module system won't emit a warning and hence it's only Pioneer
  polluting `System.err` - not good.
* This change also expands the documentation by including the exact
  warning/error messages, how to prevent them, and links to build tool
  solutions.

Closes: #387
PR: #404
```

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
