### PR TITLE
Bugfix for `null` support

### DIFF
--- a/src/main/java/org/junitpioneer/jupiter/CartesianProductResolver.java
+++ b/src/main/java/org/junitpioneer/jupiter/CartesianProductResolver.java
@@ -38,10 +38,14 @@ class CartesianProductResolver implements ParameterResolver {
 			return false;
 
 		Object parameter = parameters.get(parameterContext.getIndex());
+		Class<?> parameterType = parameterContext.getParameter().getType();
 		// need to go from primitives to wrapper class or `isAssignableFrom` returns false for primitive parameters
-		Class<?> parameterClass = wrap(parameterContext.getParameter().getType());
-		// parameter with correct type
-		return parameterClass.isAssignableFrom(parameter.getClass());
+		Class<?> parameterClass = wrap(parameterType);
+		// if parameter is primitive, we do not support `null` values
+		if (parameterType.isPrimitive())
+			return parameter != null && parameterClass.isAssignableFrom(parameter.getClass());
+		// parameter with correct type (or `null`)
+		return parameter == null || parameterClass.isAssignableFrom(parameter.getClass());
 	}
 
 	@Override

--- a/src/main/java/org/junitpioneer/jupiter/ReportEntryExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReportEntryExtension.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.extension.InvocationInterceptor;
 import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
 import org.junit.jupiter.api.extension.TestWatcher;
 import org.junitpioneer.internal.PioneerAnnotationUtils;
+import org.junitpioneer.internal.PioneerUtils;
 
 class ReportEntryExtension implements TestWatcher, BeforeEachCallback, InvocationInterceptor {
 
@@ -127,7 +128,7 @@ class ReportEntryExtension implements TestWatcher, BeforeEachCallback, Invocatio
 		String parsed = value;
 		List<?> list = context.getStore(NAMESPACE).get(KEY, List.class);
 		for (int i = 0; i < list.size(); i++) {
-			parsed = parsed.replaceAll("\\{" + i + "}", list.get(i).toString());
+			parsed = parsed.replaceAll("\\{" + i + "}", PioneerUtils.nullSafeToString(list.get(i)));
 		}
 
 		return parsed;

--- a/src/test/java/org/junitpioneer/jupiter/CartesianProductTestExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/CartesianProductTestExtensionTests.java
@@ -311,6 +311,17 @@ public class CartesianProductTestExtensionTests {
 						"d:1.7,l:1,s:5", "d:1.2,l:2,s:5", "d:1.7,l:2,s:5");
 		}
 
+		@Test
+		@DisplayName("works with `null` values on non-primitive parameters")
+		void nullWithNonPrimitive() {
+			ExecutionResults results = PioneerTestKit
+					.executeTestMethodWithParameterTypes(BasicConfigurationTestCases.class, "withNulls", TimeUnit.class,
+						int.class);
+
+			assertThat(results).hasNumberOfDynamicallyRegisteredTests(2).hasNumberOfSucceededTests(2);
+			assertThat(results).hasNumberOfReportEntries(2).withValues("null,1", "null,2");
+		}
+
 		@Nested
 		@DisplayName("removes redundant parameters from input sets")
 		class CartesianProductRedundancyTests {
@@ -678,6 +689,19 @@ public class CartesianProductTestExtensionTests {
 					.hasMessageContaining("argument array must not be null");
 		}
 
+		@Test
+		@DisplayName("primitive parameter is supplied with `null`")
+		void primitiveNull() {
+			ExecutionResults results = PioneerTestKit
+					.executeTestMethodWithParameterTypes(BadConfigurationTestCases.class, "withNulls", int.class,
+						int.class);
+
+			assertThat(results)
+					.hasNumberOfFailedTests(2)
+					.withExceptionInstancesOf(ParameterResolutionException.class)
+					.allMatch(exceptionMessage -> exceptionMessage.contains("No ParameterResolver registered"));
+		}
+
 	}
 
 	@Nested
@@ -755,6 +779,15 @@ public class CartesianProductTestExtensionTests {
 			assertThat(unit.name()).endsWith("S");
 		}
 
+		@CartesianProductTest(factory = "withNulls")
+		@ReportEntry("{0},{1}")
+		void withNulls(TimeUnit unit, int i) {
+		}
+
+	}
+
+	static CartesianProductTest.Sets withNulls() {
+		return new CartesianProductTest.Sets().add(new Object[] { null }).add(1, 2);
 	}
 
 	static class BadConfigurationTestCases {
@@ -835,6 +868,10 @@ public class CartesianProductTestExtensionTests {
 		@CartesianValueSource(strings = { "0", "1" })
 		void conflictValueSourceAndFactory(int a, String b) {
 
+		}
+
+		@CartesianProductTest(factory = "withNulls")
+		void withNulls(int i, int j) {
 		}
 
 	}

--- a/src/test/java/org/junitpioneer/jupiter/ReportEntryExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/ReportEntryExtensionTests.java
@@ -17,13 +17,17 @@ import static org.junitpioneer.jupiter.ReportEntry.PublishCondition.ON_FAILURE;
 import static org.junitpioneer.jupiter.ReportEntry.PublishCondition.ON_SUCCESS;
 import static org.junitpioneer.testkit.assertion.PioneerAssert.assertThat;
 
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junitpioneer.testkit.ExecutionResults;
 import org.junitpioneer.testkit.PioneerTestKit;
@@ -388,6 +392,19 @@ public class ReportEntryExtensionTests {
 						"2 - 2: Then this ebony bird beguiling my sad fancy into smiling,");
 		}
 
+		@Test
+		@DisplayName("can publish null arguments")
+		void parameterized_with_nulls() {
+			ExecutionResults results = PioneerTestKit
+					.executeTestMethodWithParameterTypes(ReportEntriesTest.class, "parameterized_with_nulls",
+						String.class, String.class);
+
+			assertThat(results).hasSingleSucceededTest();
+			assertThat(results)
+					.hasNumberOfReportEntries(1)
+					.withValues("null,By the grave and stern decorum of the countenance it wore,");
+		}
+
 	}
 
 	static class ReportEntriesTest {
@@ -570,6 +587,16 @@ public class ReportEntryExtensionTests {
 				"Then this ebony bird beguiling my sad fancy into smiling,; 2" }, delimiter = ';')
 		@ReportEntry("{1} - {1}: {0}")
 		void parameterized_multiple(String line, int number) {
+		}
+
+		@ParameterizedTest
+		@MethodSource("withNulls")
+		@ReportEntry("{1},{0}")
+		void parameterized_with_nulls(String line, String value) {
+		}
+
+		private static Stream<Arguments> withNulls() {
+			return Stream.of(Arguments.of("By the grave and stern decorum of the countenance it wore,", null));
 		}
 
 	}


### PR DESCRIPTION
Closes #420 

Proposed commit message:

```
Support `null` values (#420 / #425)

This commit fixes two small bugs where JUnit Pioneer threw an
exception for null values (in CartesianProductTest and 
ReportEntry).

Closes: #420
PR: #425
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [x] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [x] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [x] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [x] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [x] The `package-info.java` contains information about the new extension

Code
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [x] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://joel-costigliola.github.io/assertj/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
