### PR TITLE
Add `minSuccess` to RetryingTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ The least we can do is to thank them and list some of their accomplishments here
 #### 2021
 
 * [Stefano Cordio](https://github.com/scordio) contributed [the Cartesian Enum source](https://junit-pioneer.org/docs/cartesian-product/#cartesianenumsource) (#379 / #409)
+* [Cory Thomas](https://github.com/dump247) contributed [the minSuccess attribute in RetryingTest]()
 
 #### 2020
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The least we can do is to thank them and list some of their accomplishments here
 #### 2021
 
 * [Stefano Cordio](https://github.com/scordio) contributed [the Cartesian Enum source](https://junit-pioneer.org/docs/cartesian-product/#cartesianenumsource) (#379 / #409)
-* [Cory Thomas](https://github.com/dump247) contributed [the minSuccess attribute in RetryingTest]()
+* [Cory Thomas](https://github.com/dump247) contributed the minSuccess attribute in RetryingTest (#408 / #430)
 
 #### 2020
 

--- a/docs/retrying-test.adoc
+++ b/docs/retrying-test.adoc
@@ -57,6 +57,27 @@ The test `aborted` is aborted before (or during) its first execution.
 The first execution is marked as aborted/skipped, containing the underlying cause.
 The test suite as a whole is also marked as aborted/skipped.
 
+[source,java]
+----
+@RetryingTest(maxAttempts = 4, minSuccess = 2)
+void requiresTwoSuccesses() {
+	// test code that must complete successfully twice
+}
+----
+
+The test `requiresTwoSuccesses` must run at least two times without raising
+an exception. However, it will not run more than four times.
+
+[source,java]
+----
+@RetryingTest(minSuccess = 2)
+void runsTwice() {
+	// test code that must complete successfully twice
+}
+----
+
+The test `runsTwice` must run at least two times without raising an exception.
+
 == Combining `@RetryingTest` with `@Test` et al
 
 If `@RetryingTest` is combined with `@Test` or `TestTemplate`-based mechanisms (like `@RepeatedTest` or `@ParameterizedTest`), the test engine will execute it according to each annotation (i.e. more than once).

--- a/docs/retrying-test.adoc
+++ b/docs/retrying-test.adoc
@@ -68,16 +68,6 @@ void requiresTwoSuccesses() {
 The test `requiresTwoSuccesses` must run at least two times without raising an exception.
 However, it will not run more than four times.
 
-[source,java]
-----
-@RetryingTest(minSuccess = 2)
-void runsTwice() {
-	// test code that must complete successfully twice
-}
-----
-
-The test `runsTwice` must run at least two times without raising an exception.
-
 == Combining `@RetryingTest` with `@Test` et al
 
 If `@RetryingTest` is combined with `@Test` or `TestTemplate`-based mechanisms (like `@RepeatedTest` or `@ParameterizedTest`), the test engine will execute it according to each annotation (i.e. more than once).

--- a/docs/retrying-test.adoc
+++ b/docs/retrying-test.adoc
@@ -5,6 +5,27 @@ Some tests, e.g. those depending on external systems, may fail through no fault 
 Such tests make a suite fragile and it makes sense to try and avoid them, but if that's infeasible, it may help to retry a number of times before eventually assuming actual failure.
 `RetryingTest` provides that functionality.
 
+== Attributes
+
+=== maxAttempts (alias: value) [required]
+
+The `maxAttempts` attribute specifies the maximum number of times to execute the test function.
+If the test function throws an exception, the test will be executed again, up to this limit.
+
+The `value` attribute is an alias for `maxAttempts`. The attribute can be set either
+with `@RetryingTest(N)` or `@RetryingTest(maxAttempts=N)`.
+
+This attribute is required and must be a value greater than `minSuccess`. Only one of
+`maxAttempts` or `value` can be set, but not both.
+
+=== minSuccess [optional]
+
+The `minSuccess` attribute specifies the number of times the test function must complete
+successfully (i.e. without throwing an exception). The test function will be executed,
+up to `maxAttempts`, until it completes successfully this number of times.
+
+The default for `minSuccess` is 1. The value must be greater than or equal to 1.
+
 == Basic Use
 
 `@RetryingTest(n)` is used _instead_ of `@Test` or other such annotations (e.g. `@RepeatedTest`).

--- a/docs/retrying-test.adoc
+++ b/docs/retrying-test.adoc
@@ -12,17 +12,16 @@ Such tests make a suite fragile and it makes sense to try and avoid them, but if
 The `maxAttempts` attribute specifies the maximum number of times to execute the test function.
 If the test function throws an exception, the test will be executed again, up to this limit.
 
-The `value` attribute is an alias for `maxAttempts`. The attribute can be set either
-with `@RetryingTest(N)` or `@RetryingTest(maxAttempts=N)`.
+The `value` attribute is an alias for `maxAttempts`.
+The attribute can be set either with `@RetryingTest(N)` or `@RetryingTest(maxAttempts=N)`.
 
-This attribute is required and must be a value greater than `minSuccess`. Only one of
-`maxAttempts` or `value` can be set, but not both.
+This attribute is required and must be a value greater than `minSuccess`.
+Only one of `maxAttempts` or `value` can be set, but not both.
 
 === minSuccess [optional]
 
-The `minSuccess` attribute specifies the number of times the test function must complete
-successfully (i.e. without throwing an exception). The test function will be executed,
-up to `maxAttempts`, until it completes successfully this number of times.
+The `minSuccess` attribute specifies the number of times the test function must complete successfully (i.e. without throwing an exception).
+The test function will be executed, up to `maxAttempts`, until it completes successfully this number of times.
 
 The default for `minSuccess` is 1. The value must be greater than or equal to 1.
 

--- a/docs/retrying-test.adoc
+++ b/docs/retrying-test.adoc
@@ -65,8 +65,8 @@ void requiresTwoSuccesses() {
 }
 ----
 
-The test `requiresTwoSuccesses` must run at least two times without raising
-an exception. However, it will not run more than four times.
+The test `requiresTwoSuccesses` must run at least two times without raising an exception.
+However, it will not run more than four times.
 
 [source,java]
 ----

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTest.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTest.java
@@ -81,8 +81,8 @@ public @interface RetryingTest {
 	/**
 	 * Specifies how often the test is executed at most.
 	 *
-	 * If the value is zero, the value defaults to {@link #minSuccess()}. Otherwise, the
-	 * value must be greater than or equal to {@link #minSuccess()}.
+	 * Either this or {@link #value()} are required.
+ 	 * The value must be greater than {@link #minSuccess()}.
 	 */
 	int maxAttempts() default 0;
 

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTest.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTest.java
@@ -73,7 +73,27 @@ public @interface RetryingTest {
 
 	/**
 	 * Specifies how often the test is executed at most.
+	 *
+	 * Alias for {@link #maxAttempts()}.
 	 */
-	int value();
+	int value() default 0;
+
+	/**
+	 * Specifies how often the test is executed at most.
+	 *
+	 * If the value is zero, the value defaults to {@link #minSuccess()}. Otherwise, the
+	 * value must be greater than or equal to {@link #minSuccess()}.
+	 */
+	int maxAttempts() default 0;
+
+	/**
+	 * Specifies the minimum number of successful executions of the test.
+	 *
+	 * The test will be executed at least this number of times. If the test does not complete
+	 * successfully the given number of times, the test will fail.
+	 *
+	 * Value must be greater than or equal to 1.
+	 */
+	int minSuccess() default 1;
 
 }

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTest.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTest.java
@@ -82,7 +82,7 @@ public @interface RetryingTest {
 	 * Specifies how often the test is executed at most.
 	 *
 	 * Either this or {@link #value()} are required.
- 	 * The value must be greater than {@link #minSuccess()}.
+	 * The value must be greater than {@link #minSuccess()}.
 	 */
 	int maxAttempts() default 0;
 

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
@@ -121,11 +121,7 @@ public class RetryingTestExtension implements TestTemplateInvocationContextProvi
 
 			exceptionsSoFar++;
 
-			int successfulExecutionCount = retriesSoFar - exceptionsSoFar;
-			int remainingExecutionCount = maxRetries - retriesSoFar;
-			int requiredSuccessCount = minSuccess - successfulExecutionCount;
-
-			if (remainingExecutionCount < requiredSuccessCount)
+			if (!hasNext())
 				throw new AssertionError(
 					format("Test execution #%d (of up to %d with at least %d successes) failed ~> test fails - see cause for details",
 							retriesSoFar, maxRetries, minSuccess),

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
@@ -126,12 +126,12 @@ public class RetryingTestExtension implements TestTemplateInvocationContextProvi
 
 			if (hasNext())
 				throw new TestAbortedException(
-						format("Test execution #%d (of up to %d) failed ~> will retry...", retriesSoFar, maxRetries),
-						exception);
+					format("Test execution #%d (of up to %d) failed ~> will retry...", retriesSoFar, maxRetries),
+					exception);
 			else
 				throw new AssertionError(format(
-						"Test execution #%d (of up to %d with at least %d successes) failed ~> test fails - see cause for details",
-						retriesSoFar, maxRetries, minSuccess), exception);
+					"Test execution #%d (of up to %d with at least %d successes) failed ~> test fails - see cause for details",
+					retriesSoFar, maxRetries, minSuccess), exception);
 		}
 
 		@Override

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
@@ -100,8 +100,7 @@ public class RetryingTestExtension implements TestTemplateInvocationContextProvi
 			}
 
 			if (maxAttempts == 0) {
-				// maxAttempts defaults to minSuccess
-				maxAttempts = minSuccess;
+				throw new IllegalStateException("@RetryTest requires that one of `value` or `maxAttempts` be set.");
 			}
 
 			if (minSuccess < 1) {
@@ -121,14 +120,14 @@ public class RetryingTestExtension implements TestTemplateInvocationContextProvi
 
 			exceptionsSoFar++;
 
-			if (!hasNext())
-				throw new AssertionError(format(
-					"Test execution #%d (of up to %d with at least %d successes) failed ~> test fails - see cause for details",
-					retriesSoFar, maxRetries, minSuccess), exception);
-			else
+			if (hasNext())
 				throw new TestAbortedException(
-					format("Test execution #%d (of up to %d) failed ~> will retry...", retriesSoFar, maxRetries),
-					exception);
+						format("Test execution #%d (of up to %d) failed ~> will retry...", retriesSoFar, maxRetries),
+						exception);
+			else
+				throw new AssertionError(format(
+						"Test execution #%d (of up to %d with at least %d successes) failed ~> test fails - see cause for details",
+						retriesSoFar, maxRetries, minSuccess), exception);
 		}
 
 		@Override

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
@@ -86,7 +86,6 @@ public class RetryingTestExtension implements TestTemplateInvocationContextProvi
 					.orElseThrow(() -> new IllegalStateException("@RetryingTest is missing."));
 
 			int maxAttempts = retryingTest.maxAttempts();
-			String maxAttemptsField = "maxAttempts";
 			int minSuccess = retryingTest.minSuccess();
 
 			if (retryingTest.value() != 0) {
@@ -96,7 +95,6 @@ public class RetryingTestExtension implements TestTemplateInvocationContextProvi
 				}
 
 				maxAttempts = retryingTest.value();
-				maxAttemptsField = "value";
 			}
 
 			if (maxAttempts == 0) {
@@ -110,8 +108,8 @@ public class RetryingTestExtension implements TestTemplateInvocationContextProvi
 						? " Using @RepeatedTest is recommended as a replacement."
 						: "";
 
-				throw new IllegalStateException(format("@RetryTest requires that `%s` be greater than %s.%s",
-					maxAttemptsField, minSuccess == 1 ? "1" : "`minSuccess`", additionalMessage));
+				throw new IllegalStateException(format("@RetryTest requires that `maxAttempts` be greater than %s.%s",
+					minSuccess == 1 ? "1" : "`minSuccess`", additionalMessage));
 			}
 
 			return new FailedTestRetrier(maxAttempts, minSuccess);

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
@@ -105,9 +105,13 @@ public class RetryingTestExtension implements TestTemplateInvocationContextProvi
 
 			if (minSuccess < 1) {
 				throw new IllegalStateException("@RetryTest requires that `minSuccess` be greater than or equal to 1.");
-			} else if (maxAttempts < minSuccess) {
-				throw new IllegalStateException(format("@RetryTest requires that `%s` be greater than or equal to %s.",
-					maxAttemptsField, minSuccess == 1 ? "1" : "`minSuccess`"));
+			} else if (maxAttempts <= minSuccess) {
+				String additionalMessage = maxAttempts == minSuccess
+						? " Using @RepeatedTest is recommended as a replacement."
+						: "";
+
+				throw new IllegalStateException(format("@RetryTest requires that `%s` be greater than %s.%s",
+					maxAttemptsField, minSuccess == 1 ? "1" : "`minSuccess`", additionalMessage));
 			}
 
 			return new FailedTestRetrier(maxAttempts, minSuccess);

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
@@ -91,7 +91,8 @@ public class RetryingTestExtension implements TestTemplateInvocationContextProvi
 
 			if (retryingTest.value() != 0) {
 				if (retryingTest.maxAttempts() != 0) {
-					throw new IllegalStateException("@RetryTest requires that one of `value` or `maxAttempts` be set, but not both.");
+					throw new IllegalStateException(
+						"@RetryTest requires that one of `value` or `maxAttempts` be set, but not both.");
 				}
 
 				maxAttempts = retryingTest.value();
@@ -106,9 +107,8 @@ public class RetryingTestExtension implements TestTemplateInvocationContextProvi
 			if (minSuccess < 1) {
 				throw new IllegalStateException("@RetryTest requires that `minSuccess` be greater than or equal to 1.");
 			} else if (maxAttempts < minSuccess) {
-				throw new IllegalStateException(String.format(
-						"@RetryTest requires that `%s` be greater than or equal to %s.",
-						maxAttemptsField, minSuccess == 1 ? "1" : "`minSuccess`"));
+				throw new IllegalStateException(format("@RetryTest requires that `%s` be greater than or equal to %s.",
+					maxAttemptsField, minSuccess == 1 ? "1" : "`minSuccess`"));
 			}
 
 			return new FailedTestRetrier(maxAttempts, minSuccess);
@@ -122,10 +122,9 @@ public class RetryingTestExtension implements TestTemplateInvocationContextProvi
 			exceptionsSoFar++;
 
 			if (!hasNext())
-				throw new AssertionError(
-					format("Test execution #%d (of up to %d with at least %d successes) failed ~> test fails - see cause for details",
-							retriesSoFar, maxRetries, minSuccess),
-					exception);
+				throw new AssertionError(format(
+					"Test execution #%d (of up to %d with at least %d successes) failed ~> test fails - see cause for details",
+					retriesSoFar, maxRetries, minSuccess), exception);
 			else
 				throw new TestAbortedException(
 					format("Test execution #%d (of up to %d) failed ~> will retry...", retriesSoFar, maxRetries),

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
@@ -103,14 +103,16 @@ public class RetryingTestExtension implements TestTemplateInvocationContextProvi
 			}
 
 			if (minSuccess < 1) {
-				throw new IllegalStateException("@RetryingTest requires that `minSuccess` be greater than or equal to 1.");
+				throw new IllegalStateException(
+					"@RetryingTest requires that `minSuccess` be greater than or equal to 1.");
 			} else if (maxAttempts <= minSuccess) {
 				String additionalMessage = maxAttempts == minSuccess
 						? " Using @RepeatedTest is recommended as a replacement."
 						: "";
 
-				throw new IllegalStateException(format("@RetryingTest requires that `maxAttempts` be greater than %s.%s",
-					minSuccess == 1 ? "1" : "`minSuccess`", additionalMessage));
+				throw new IllegalStateException(
+					format("@RetryingTest requires that `maxAttempts` be greater than %s.%s",
+						minSuccess == 1 ? "1" : "`minSuccess`", additionalMessage));
 			}
 
 			return new FailedTestRetrier(maxAttempts, minSuccess);

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
@@ -91,24 +91,24 @@ public class RetryingTestExtension implements TestTemplateInvocationContextProvi
 			if (retryingTest.value() != 0) {
 				if (retryingTest.maxAttempts() != 0) {
 					throw new IllegalStateException(
-						"@RetryTest requires that one of `value` or `maxAttempts` be set, but not both.");
+						"@RetryingTest requires that one of `value` or `maxAttempts` be set, but not both.");
 				}
 
 				maxAttempts = retryingTest.value();
 			}
 
 			if (maxAttempts == 0) {
-				throw new IllegalStateException("@RetryTest requires that one of `value` or `maxAttempts` be set.");
+				throw new IllegalStateException("@RetryingTest requires that one of `value` or `maxAttempts` be set.");
 			}
 
 			if (minSuccess < 1) {
-				throw new IllegalStateException("@RetryTest requires that `minSuccess` be greater than or equal to 1.");
+				throw new IllegalStateException("@RetryingTest requires that `minSuccess` be greater than or equal to 1.");
 			} else if (maxAttempts <= minSuccess) {
 				String additionalMessage = maxAttempts == minSuccess
 						? " Using @RepeatedTest is recommended as a replacement."
 						: "";
 
-				throw new IllegalStateException(format("@RetryTest requires that `maxAttempts` be greater than %s.%s",
+				throw new IllegalStateException(format("@RetryingTest requires that `maxAttempts` be greater than %s.%s",
 					minSuccess == 1 ? "1" : "`minSuccess`", additionalMessage));
 			}
 

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
@@ -92,8 +92,8 @@ public class RetryingTestExtension implements TestTemplateInvocationContextProvi
 			if (maxAttempts == 0)
 				throw new IllegalStateException("@RetryingTest requires that one of `value` or `maxAttempts` be set.");
 			if (retryingTest.value() != 0 && retryingTest.maxAttempts() != 0)
-					throw new IllegalStateException(
-						"@RetryingTest requires that one of `value` or `maxAttempts` be set, but not both.");
+				throw new IllegalStateException(
+					"@RetryingTest requires that one of `value` or `maxAttempts` be set, but not both.");
 
 			if (minSuccess < 1)
 				throw new IllegalStateException(

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
 import org.junit.platform.commons.support.AnnotationSupport;
 import org.junitpioneer.internal.PioneerAnnotationUtils;
+import org.opentest4j.AssertionFailedError;
 import org.opentest4j.TestAbortedException;
 
 public class RetryingTestExtension implements TestTemplateInvocationContextProvider, TestExecutionExceptionHandler {
@@ -127,7 +128,7 @@ public class RetryingTestExtension implements TestTemplateInvocationContextProvi
 					format("Test execution #%d (of up to %d) failed ~> will retry...", retriesSoFar, maxRetries),
 					exception);
 			else
-				throw new AssertionError(format(
+				throw new AssertionFailedError(format(
 					"Test execution #%d (of up to %d with at least %d successes) failed ~> test fails - see cause for details",
 					retriesSoFar, maxRetries, minSuccess), exception);
 		}

--- a/src/test/java/org/junitpioneer/jupiter/RetryingTestExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/RetryingTestExtensionTests.java
@@ -262,7 +262,7 @@ class RetryingTestExtensionTests {
 		}
 
 		@RetryingTest(maxAttempts = 0)
-		void maxAttemptsThanOne() {
+		void maxAttemptsLessThanOne() {
 			// Do nothing
 		}
 

--- a/src/test/java/org/junitpioneer/jupiter/RetryingTestExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/RetryingTestExtensionTests.java
@@ -94,7 +94,8 @@ class RetryingTestExtensionTests {
 
 	@Test
 	void executesTwiceWithTwoFails_succeeds() {
-		ExecutionResults results = PioneerTestKit.executeTestMethod(RetryingTestTestCase.class, "executesTwiceWithTwoFails");
+		ExecutionResults results = PioneerTestKit
+				.executeTestMethod(RetryingTestTestCase.class, "executesTwiceWithTwoFails");
 
 		assertThat(results)
 				.hasNumberOfDynamicallyRegisteredTests(4)
@@ -105,7 +106,8 @@ class RetryingTestExtensionTests {
 
 	@Test
 	void executesOnceWithThreeFails_fails() {
-		ExecutionResults results = PioneerTestKit.executeTestMethod(RetryingTestTestCase.class, "executesOnceWithThreeFails");
+		ExecutionResults results = PioneerTestKit
+				.executeTestMethod(RetryingTestTestCase.class, "executesOnceWithThreeFails");
 
 		assertThat(results)
 				.hasNumberOfDynamicallyRegisteredTests(4)
@@ -127,7 +129,8 @@ class RetryingTestExtensionTests {
 
 	@Test
 	void executesTwiceDefaultMax_succeeds() {
-		ExecutionResults results = PioneerTestKit.executeTestMethod(RetryingTestTestCase.class, "executesTwiceDefaultMax");
+		ExecutionResults results = PioneerTestKit
+				.executeTestMethod(RetryingTestTestCase.class, "executesTwiceDefaultMax");
 
 		assertThat(results)
 				.hasNumberOfDynamicallyRegisteredTests(2)
@@ -225,6 +228,7 @@ class RetryingTestExtensionTests {
 		void failsOnceDefaultMax() {
 			throw new IllegalArgumentException();
 		}
+
 	}
 
 	@Target({ METHOD, ANNOTATION_TYPE })

--- a/src/test/java/org/junitpioneer/jupiter/RetryingTestExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/RetryingTestExtensionTests.java
@@ -127,29 +127,6 @@ class RetryingTestExtensionTests {
 				.hasNumberOfSucceededTests(0);
 	}
 
-	@Test
-	void executesTwiceDefaultMax_succeeds() {
-		ExecutionResults results = PioneerTestKit
-				.executeTestMethod(RetryingTestTestCase.class, "executesTwiceDefaultMax");
-
-		assertThat(results)
-				.hasNumberOfDynamicallyRegisteredTests(2)
-				.hasNumberOfAbortedTests(0)
-				.hasNumberOfFailedTests(0)
-				.hasNumberOfSucceededTests(2);
-	}
-
-	@Test
-	void failsOnceDefaultMax_fails() {
-		ExecutionResults results = PioneerTestKit.executeTestMethod(RetryingTestTestCase.class, "failsOnceDefaultMax");
-
-		assertThat(results)
-				.hasNumberOfDynamicallyRegisteredTests(1)
-				.hasNumberOfAbortedTests(0)
-				.hasNumberOfFailedTests(1)
-				.hasNumberOfSucceededTests(0);
-	}
-
 	// TEST CASES -------------------------------------------------------------------
 
 	// Some tests require state to keep track of the number of test executions.
@@ -217,15 +194,6 @@ class RetryingTestExtensionTests {
 
 		@RetryingTest(maxAttempts = 4, minSuccess = 2)
 		void failsThreeTimes() {
-			throw new IllegalArgumentException();
-		}
-
-		@RetryingTest(minSuccess = 2)
-		void executesTwiceDefaultMax() {
-		}
-
-		@RetryingTest(minSuccess = 2)
-		void failsOnceDefaultMax() {
 			throw new IllegalArgumentException();
 		}
 

--- a/src/test/java/org/junitpioneer/jupiter/RetryingTestExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/RetryingTestExtensionTests.java
@@ -127,6 +127,37 @@ class RetryingTestExtensionTests {
 				.hasNumberOfSucceededTests(0);
 	}
 
+	@Test
+	void missingMaxAttempts_fails() {
+		ExecutionResults results = PioneerTestKit.executeTestMethod(RetryingTestTestCase.class, "missingMaxAttempts");
+
+		assertThat(results).hasNumberOfDynamicallyRegisteredTests(0);
+	}
+
+	@Test
+	void maxAttemptsAndValueSet_fails() {
+		ExecutionResults results = PioneerTestKit
+				.executeTestMethod(RetryingTestTestCase.class, "maxAttemptsAndValueSet");
+
+		assertThat(results).hasNumberOfDynamicallyRegisteredTests(0);
+	}
+
+	@Test
+	void maxAttemptsEqualsMinSuccess_fails() {
+		ExecutionResults results = PioneerTestKit
+				.executeTestMethod(RetryingTestTestCase.class, "maxAttemptsEqualsMinSuccess");
+
+		assertThat(results).hasNumberOfDynamicallyRegisteredTests(0);
+	}
+
+	@Test
+	void minSuccessLessThanOne_fails() {
+		ExecutionResults results = PioneerTestKit
+				.executeTestMethod(RetryingTestTestCase.class, "minSuccessLessThanOne");
+
+		assertThat(results).hasNumberOfDynamicallyRegisteredTests(0);
+	}
+
 	// TEST CASES -------------------------------------------------------------------
 
 	// Some tests require state to keep track of the number of test executions.
@@ -195,6 +226,26 @@ class RetryingTestExtensionTests {
 		@RetryingTest(maxAttempts = 4, minSuccess = 2)
 		void failsThreeTimes() {
 			throw new IllegalArgumentException();
+		}
+
+		@RetryingTest
+		void missingMaxAttempts() {
+			// Do nothing
+		}
+
+		@RetryingTest(value = 1, maxAttempts = 1)
+		void maxAttemptsAndValueSet() {
+			// Do nothing
+		}
+
+		@RetryingTest(maxAttempts = 1, minSuccess = 1)
+		void maxAttemptsEqualsMinSuccess() {
+			// Do nothing
+		}
+
+		@RetryingTest(maxAttempts = 2, minSuccess = 0)
+		void minSuccessLessThanOne() {
+			// Do nothing
 		}
 
 	}

--- a/src/test/java/org/junitpioneer/jupiter/RetryingTestExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/RetryingTestExtensionTests.java
@@ -135,6 +135,20 @@ class RetryingTestExtensionTests {
 	}
 
 	@Test
+	void valueLessThanOne_fails() {
+		ExecutionResults results = PioneerTestKit.executeTestMethod(RetryingTestTestCase.class, "valueLessThanOne");
+
+		assertThat(results).hasNumberOfDynamicallyRegisteredTests(0);
+	}
+
+	@Test
+	void maxAttemptsLessThanOne_fails() {
+		ExecutionResults results = PioneerTestKit.executeTestMethod(RetryingTestTestCase.class, "maxAttemptsLessThanOne");
+
+		assertThat(results).hasNumberOfDynamicallyRegisteredTests(0);
+	}
+
+	@Test
 	void maxAttemptsAndValueSet_fails() {
 		ExecutionResults results = PioneerTestKit
 				.executeTestMethod(RetryingTestTestCase.class, "maxAttemptsAndValueSet");
@@ -146,6 +160,14 @@ class RetryingTestExtensionTests {
 	void maxAttemptsEqualsMinSuccess_fails() {
 		ExecutionResults results = PioneerTestKit
 				.executeTestMethod(RetryingTestTestCase.class, "maxAttemptsEqualsMinSuccess");
+
+		assertThat(results).hasNumberOfDynamicallyRegisteredTests(0);
+	}
+
+	@Test
+	void maxAttemptsLessThanMinSuccess_fails() {
+		ExecutionResults results = PioneerTestKit
+				.executeTestMethod(RetryingTestTestCase.class, "maxAttemptsLessThanMinSuccess");
 
 		assertThat(results).hasNumberOfDynamicallyRegisteredTests(0);
 	}
@@ -233,6 +255,16 @@ class RetryingTestExtensionTests {
 			// Do nothing
 		}
 
+		@RetryingTest(value = 0)
+		void valueLessThanOne() {
+			// Do nothing
+		}
+
+		@RetryingTest(maxAttempts = 0)
+		void maxAttemptsThanOne() {
+			// Do nothing
+		}
+
 		@RetryingTest(value = 1, maxAttempts = 1)
 		void maxAttemptsAndValueSet() {
 			// Do nothing
@@ -240,6 +272,11 @@ class RetryingTestExtensionTests {
 
 		@RetryingTest(maxAttempts = 1, minSuccess = 1)
 		void maxAttemptsEqualsMinSuccess() {
+			// Do nothing
+		}
+
+		@RetryingTest(maxAttempts = -1, minSuccess = 1)
+		void maxAttemptsLessThanMinSuccess() {
 			// Do nothing
 		}
 

--- a/src/test/java/org/junitpioneer/jupiter/RetryingTestExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/RetryingTestExtensionTests.java
@@ -143,7 +143,8 @@ class RetryingTestExtensionTests {
 
 	@Test
 	void maxAttemptsLessThanOne_fails() {
-		ExecutionResults results = PioneerTestKit.executeTestMethod(RetryingTestTestCase.class, "maxAttemptsLessThanOne");
+		ExecutionResults results = PioneerTestKit
+				.executeTestMethod(RetryingTestTestCase.class, "maxAttemptsLessThanOne");
 
 		assertThat(results).hasNumberOfDynamicallyRegisteredTests(0);
 	}


### PR DESCRIPTION
The `minSuccess` field specifies the minimum number of times the test must
complete without an error.

Added a `maxAttempts` field as an alias for `value` so that the intent
is clearer. Only one of `maxAttempts` or `value` can be set. This does
change the behavior slightly in that the max attempt count is no longer
required. The change should be backward compatible
with existing usages though. If `maxAttempts` or `value` is not set,
the max attempts will default to `minSuccess`.

Closes: #408 

Proposed commit message:

```
${action} (${issues} / ${pull-request}) [max 70 characters]

${body} [max 70 characters per line]

${references}: ${issues}
PR: ${pull-request}
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://joel-costigliola.github.io/assertj/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [ ] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
