### PR TITLE
Fix SetEnvironmentVariable and SetSystemProperty interference

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ The least we can do is to thank them and list some of their accomplishments here
 
 #### 2021
 
+* [Daniel Kraus](https://github.com/beatngu13) fixed a bug in `AbstractEntryBasedExtension` (#432)
 * [Stefano Cordio](https://github.com/scordio) contributed [the Cartesian Enum source](https://junit-pioneer.org/docs/cartesian-product/#cartesianenumsource) (#379 / #409)
 
 #### 2020

--- a/src/main/java/org/junitpioneer/jupiter/AbstractEntryBasedExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/AbstractEntryBasedExtension.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.ExtensionContext.Store;
 
 /**
  * An abstract base class for entry-based extensions, where entries (key-value
@@ -35,7 +36,6 @@ import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 abstract class AbstractEntryBasedExtension<K, V>
 		implements BeforeAllCallback, BeforeEachCallback, AfterAllCallback, AfterEachCallback {
 
-	private static final Namespace NAMESPACE = Namespace.create(AbstractEntryBasedExtension.class);
 	private static final String BACKUP = "Backup";
 
 	/**
@@ -124,7 +124,7 @@ abstract class AbstractEntryBasedExtension<K, V>
 
 	private void storeOriginalEntries(ExtensionContext context, Collection<K> entriesToClear,
 			Collection<K> entriesToSet) {
-		context.getStore(NAMESPACE).put(BACKUP, new EntriesBackup(entriesToClear, entriesToSet));
+		getStore(context).put(BACKUP, new EntriesBackup(entriesToClear, entriesToSet));
 	}
 
 	private void clearEntries(Collection<K> entriesToClear) {
@@ -147,7 +147,11 @@ abstract class AbstractEntryBasedExtension<K, V>
 	}
 
 	private void restoreOriginalEntries(ExtensionContext context) {
-		context.getStore(NAMESPACE).get(BACKUP, EntriesBackup.class).restoreBackup();
+		getStore(context).get(BACKUP, EntriesBackup.class).restoreBackup();
+	}
+
+	private Store getStore(ExtensionContext context) {
+		return context.getStore(Namespace.create(getClass()));
 	}
 
 	private class EntriesBackup {

--- a/src/test/java/org/junitpioneer/jupiter/AbstractEntryBasedExtensionTest.java
+++ b/src/test/java/org/junitpioneer/jupiter/AbstractEntryBasedExtensionTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junitpioneer.jupiter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.testkit.PioneerTestKit;
+
+@DisplayName("Abstract entry-based extension")
+class AbstractEntryBasedExtensionTest {
+
+	private static final String ENVIRONMENT_VARIABLE_KEY = "environment variable A";
+	private static final String ENVIRONMENT_VARIABLE_VALUE = "old A";
+	private static final String SYSTEM_PROPERTY_KEY = "system property B";
+	private static final String SYSTEM_PROPERTY_VALUE = "old B";
+
+	@BeforeAll
+	static void globalSetUp() {
+		EnvironmentVariableUtils.set(ENVIRONMENT_VARIABLE_KEY, ENVIRONMENT_VARIABLE_VALUE);
+		System.setProperty(SYSTEM_PROPERTY_KEY, SYSTEM_PROPERTY_VALUE);
+	}
+
+	@Test
+	@DisplayName("should not mix backups of different extensions")
+	void shouldNotMixBackupsOfDifferentExtensions() {
+		PioneerTestKit.executeTestMethod(MixBackupsTestCases.class, "settingEnvironmentVariableAndSystemProperty");
+
+		assertThat(System.getenv(ENVIRONMENT_VARIABLE_KEY)).isEqualTo(ENVIRONMENT_VARIABLE_VALUE);
+		assertThat(System.getProperty(SYSTEM_PROPERTY_KEY)).isEqualTo(SYSTEM_PROPERTY_VALUE);
+	}
+
+	static class MixBackupsTestCases {
+
+		@Test
+		@DisplayName("setting environment variable and system property")
+		@SetEnvironmentVariable(key = ENVIRONMENT_VARIABLE_KEY, value = "new A")
+		@SetSystemProperty(key = SYSTEM_PROPERTY_KEY, value = "new B")
+		void settingEnvironmentVariableAndSystemProperty() {
+		}
+
+	}
+
+}

--- a/src/test/java/org/junitpioneer/jupiter/AbstractEntryBasedExtensionTest.java
+++ b/src/test/java/org/junitpioneer/jupiter/AbstractEntryBasedExtensionTest.java
@@ -12,7 +12,7 @@ package org.junitpioneer.jupiter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.testkit.PioneerTestKit;
@@ -20,33 +20,87 @@ import org.junitpioneer.testkit.PioneerTestKit;
 @DisplayName("Abstract entry-based extension")
 class AbstractEntryBasedExtensionTest {
 
-	private static final String ENVIRONMENT_VARIABLE_KEY = "environment variable A";
-	private static final String ENVIRONMENT_VARIABLE_VALUE = "old A";
-	private static final String SYSTEM_PROPERTY_KEY = "system property B";
-	private static final String SYSTEM_PROPERTY_VALUE = "old B";
+	private static final String CLEAR_ENVVAR_KEY = "clear envvar";
+	private static final String SET_ENVVAR_KEY = "set envvar";
+	private static final String SET_ENVVAR_ORIGINAL_VALUE = "original envvar value";
 
-	@BeforeAll
-	static void globalSetUp() {
-		EnvironmentVariableUtils.set(ENVIRONMENT_VARIABLE_KEY, ENVIRONMENT_VARIABLE_VALUE);
-		System.setProperty(SYSTEM_PROPERTY_KEY, SYSTEM_PROPERTY_VALUE);
+	private static final String CLEAR_SYSPROP_KEY = "clear sysprop";
+	private static final String SET_SYSPROP_KEY = "set sysprop";
+	private static final String SET_SYSPROP_ORIGINAL_VALUE = "original sysprop value";
+
+	@BeforeEach
+	void setUp() {
+		EnvironmentVariableUtils.clear(CLEAR_ENVVAR_KEY);
+		EnvironmentVariableUtils.set(SET_ENVVAR_KEY, SET_ENVVAR_ORIGINAL_VALUE);
+
+		System.clearProperty(CLEAR_SYSPROP_KEY);
+		System.setProperty(SET_SYSPROP_KEY, SET_SYSPROP_ORIGINAL_VALUE);
 	}
 
 	@Test
-	@DisplayName("should not mix backups of different extensions")
-	void shouldNotMixBackupsOfDifferentExtensions() {
-		PioneerTestKit.executeTestMethod(MixBackupsTestCases.class, "settingEnvironmentVariableAndSystemProperty");
+	@DisplayName("should not mix backups of different extensions on clear environment variable and clear system property")
+	void shouldNotMixBackupsOfDifferentExtensionsOnClearEnvironmentVariableAndClearSystemProperty() {
+		PioneerTestKit.executeTestMethod(MixBackupsTestCases.class, "clearEnvironmentVariableAndClearSystemProperty");
 
-		assertThat(System.getenv(ENVIRONMENT_VARIABLE_KEY)).isEqualTo(ENVIRONMENT_VARIABLE_VALUE);
-		assertThat(System.getProperty(SYSTEM_PROPERTY_KEY)).isEqualTo(SYSTEM_PROPERTY_VALUE);
+		assertThat(System.getenv(CLEAR_ENVVAR_KEY)).isNull();
+		assertThat(System.getProperty(CLEAR_SYSPROP_KEY)).isNull();
+	}
+
+	@Test
+	@DisplayName("should not mix backups of different extensions on set environment variable and set system property")
+	void shouldNotMixBackupsOfDifferentExtensionsOnSetEnvironmentVariableAndSetSystemProperty() {
+		PioneerTestKit.executeTestMethod(MixBackupsTestCases.class, "setEnvironmentVariableAndSetSystemProperty");
+
+		assertThat(System.getenv(SET_ENVVAR_KEY)).isEqualTo(SET_ENVVAR_ORIGINAL_VALUE);
+		assertThat(System.getProperty(SET_SYSPROP_KEY)).isEqualTo(SET_SYSPROP_ORIGINAL_VALUE);
+	}
+
+	@Test
+	@DisplayName("should not mix backups of different extensions on clear environment variable and set system property")
+	void shouldNotMixBackupsOfDifferentExtensionsOnClearEnvironmentVariableAndSetSystemProperty() {
+		PioneerTestKit.executeTestMethod(MixBackupsTestCases.class, "clearEnvironmentVariableAndSetSystemProperty");
+
+		assertThat(System.getenv(CLEAR_ENVVAR_KEY)).isNull();
+		assertThat(System.getProperty(SET_SYSPROP_KEY)).isEqualTo(SET_SYSPROP_ORIGINAL_VALUE);
+	}
+
+	@Test
+	@DisplayName("should not mix backups of different extensions on set environment variable and clear system property")
+	void shouldNotMixBackupsOfDifferentExtensionsOnSetEnvironmentVariableAndClearSystemProperty() {
+		PioneerTestKit.executeTestMethod(MixBackupsTestCases.class, "setEnvironmentVariableAndClearSystemProperty");
+
+		assertThat(System.getenv(SET_ENVVAR_KEY)).isEqualTo(SET_ENVVAR_ORIGINAL_VALUE);
+		assertThat(System.getProperty(CLEAR_SYSPROP_KEY)).isNull();
 	}
 
 	static class MixBackupsTestCases {
 
 		@Test
-		@DisplayName("setting environment variable and system property")
-		@SetEnvironmentVariable(key = ENVIRONMENT_VARIABLE_KEY, value = "new A")
-		@SetSystemProperty(key = SYSTEM_PROPERTY_KEY, value = "new B")
-		void settingEnvironmentVariableAndSystemProperty() {
+		@DisplayName("clear environment variable and clear system property")
+		@ClearEnvironmentVariable(key = CLEAR_ENVVAR_KEY)
+		@ClearSystemProperty(key = CLEAR_SYSPROP_KEY)
+		void clearEnvironmentVariableAndClearSystemProperty() {
+		}
+
+		@Test
+		@DisplayName("set environment variable and set system property")
+		@SetEnvironmentVariable(key = SET_ENVVAR_KEY, value = "foo")
+		@SetSystemProperty(key = SET_SYSPROP_KEY, value = "bar")
+		void setEnvironmentVariableAndSetSystemProperty() {
+		}
+
+		@Test
+		@DisplayName("clear environment variable and set system property")
+		@ClearEnvironmentVariable(key = CLEAR_ENVVAR_KEY)
+		@SetSystemProperty(key = SET_SYSPROP_KEY, value = "bar")
+		void clearEnvironmentVariableAndSetSystemProperty() {
+		}
+
+		@Test
+		@DisplayName("set environment variable and clear system property")
+		@SetEnvironmentVariable(key = SET_ENVVAR_KEY, value = "foo")
+		@ClearSystemProperty(key = SET_SYSPROP_KEY)
+		void setEnvironmentVariableAndClearSystemProperty() {
 		}
 
 	}


### PR DESCRIPTION
Closes #432.

Proposed commit message:

```
Create namespace per entry-based extension (#432 / #433)

Instead of creating a single namespace based on
`AbstractEntryBasedExtension.class` for all entry-based extensions,
using `getClass()` ensures per-extension namespaces via the runtime
class (i.e. the actual extension).

Closes: #432
PR: #433
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://joel-costigliola.github.io/assertj/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [x] The list of contributions inside `README.md` mentions the new contribution (real name optional) 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/master/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
