### PR TITLE
Inherit entry-based annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The least we can do is to thank them and list some of their accomplishments here
 
 #### 2021
 
-* [Daniel Kraus](https://github.com/beatngu13) fixed a bug in `AbstractEntryBasedExtension` (#432)
+* [Daniel Kraus](https://github.com/beatngu13) fixed bugs in the environment variable and system property extensions (#432 / #433 and #448 / #449)
 * [Slawomir Jaranowski](https://github.com/slawekjaranowski) Migrate to new Shipkit plugins (#410 / #419)
 * [Stefano Cordio](https://github.com/scordio) contributed [the Cartesian Enum source](https://junit-pioneer.org/docs/cartesian-product/#cartesianenumsource) (#379 / #409)
 * [Cory Thomas](https://github.com/dump247) contributed the minSuccess attribute in RetryingTest (#408 / #430)

--- a/src/main/java/org/junitpioneer/jupiter/ClearEnvironmentVariable.java
+++ b/src/main/java/org/junitpioneer/jupiter/ClearEnvironmentVariable.java
@@ -11,6 +11,7 @@
 package org.junitpioneer.jupiter;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -52,6 +53,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE })
+@Inherited
 @Repeatable(ClearEnvironmentVariable.ClearEnvironmentVariables.class)
 @WritesEnvironmentVariable
 @ExtendWith(EnvironmentVariableExtension.class)
@@ -67,6 +69,7 @@ public @interface ClearEnvironmentVariable {
 	 */
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target({ ElementType.METHOD, ElementType.TYPE })
+	@Inherited
 	@WritesEnvironmentVariable
 	@ExtendWith(EnvironmentVariableExtension.class)
 	@interface ClearEnvironmentVariables {

--- a/src/main/java/org/junitpioneer/jupiter/ClearSystemProperty.java
+++ b/src/main/java/org/junitpioneer/jupiter/ClearSystemProperty.java
@@ -11,6 +11,7 @@
 package org.junitpioneer.jupiter;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -44,6 +45,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE })
+@Inherited
 @Repeatable(ClearSystemProperty.ClearSystemProperties.class)
 @WritesSystemProperty
 @ExtendWith(SystemPropertyExtension.class)
@@ -59,6 +61,7 @@ public @interface ClearSystemProperty {
 	 */
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target({ ElementType.METHOD, ElementType.TYPE })
+	@Inherited
 	@WritesSystemProperty
 	@ExtendWith(SystemPropertyExtension.class)
 	@interface ClearSystemProperties {

--- a/src/main/java/org/junitpioneer/jupiter/SetEnvironmentVariable.java
+++ b/src/main/java/org/junitpioneer/jupiter/SetEnvironmentVariable.java
@@ -11,6 +11,7 @@
 package org.junitpioneer.jupiter;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -53,6 +54,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE })
+@Inherited
 @Repeatable(SetEnvironmentVariable.SetEnvironmentVariables.class)
 @WritesEnvironmentVariable
 @ExtendWith(EnvironmentVariableExtension.class)
@@ -73,6 +75,7 @@ public @interface SetEnvironmentVariable {
 	 */
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target({ ElementType.METHOD, ElementType.TYPE })
+	@Inherited
 	@WritesEnvironmentVariable
 	@ExtendWith(EnvironmentVariableExtension.class)
 	@interface SetEnvironmentVariables {

--- a/src/main/java/org/junitpioneer/jupiter/SetSystemProperty.java
+++ b/src/main/java/org/junitpioneer/jupiter/SetSystemProperty.java
@@ -11,6 +11,7 @@
 package org.junitpioneer.jupiter;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -45,6 +46,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE })
+@Inherited
 @Repeatable(SetSystemProperty.SetSystemProperties.class)
 @WritesSystemProperty
 @ExtendWith(SystemPropertyExtension.class)
@@ -65,6 +67,7 @@ public @interface SetSystemProperty {
 	 */
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target({ ElementType.METHOD, ElementType.TYPE })
+	@Inherited
 	@WritesSystemProperty
 	@ExtendWith(SystemPropertyExtension.class)
 	@interface SetSystemProperties {

--- a/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
@@ -32,24 +32,24 @@ class EnvironmentVariableExtensionTests {
 
 	@BeforeAll
 	static void globalSetUp() {
-		EnvironmentVariableUtils.set("set prop A", "old A");
-		EnvironmentVariableUtils.set("set prop B", "old B");
-		EnvironmentVariableUtils.set("set prop C", "old C");
+		EnvironmentVariableUtils.set("set envvar A", "old A");
+		EnvironmentVariableUtils.set("set envvar B", "old B");
+		EnvironmentVariableUtils.set("set envvar C", "old C");
 
-		EnvironmentVariableUtils.clear("clear prop D");
-		EnvironmentVariableUtils.clear("clear prop E");
-		EnvironmentVariableUtils.clear("clear prop F");
+		EnvironmentVariableUtils.clear("clear envvar D");
+		EnvironmentVariableUtils.clear("clear envvar E");
+		EnvironmentVariableUtils.clear("clear envvar F");
 	}
 
 	@AfterAll
 	static void globalTearDown() {
-		assertThat(systemEnvironmentVariable("set prop A")).isEqualTo("old A");
-		assertThat(systemEnvironmentVariable("set prop B")).isEqualTo("old B");
-		assertThat(systemEnvironmentVariable("set prop C")).isEqualTo("old C");
+		assertThat(systemEnvironmentVariable("set envvar A")).isEqualTo("old A");
+		assertThat(systemEnvironmentVariable("set envvar B")).isEqualTo("old B");
+		assertThat(systemEnvironmentVariable("set envvar C")).isEqualTo("old C");
 
-		assertThat(systemEnvironmentVariable("clear prop D")).isNull();
-		assertThat(systemEnvironmentVariable("clear prop E")).isNull();
-		assertThat(systemEnvironmentVariable("clear prop F")).isNull();
+		assertThat(systemEnvironmentVariable("clear envvar D")).isNull();
+		assertThat(systemEnvironmentVariable("clear envvar E")).isNull();
+		assertThat(systemEnvironmentVariable("clear envvar F")).isNull();
 	}
 
 	private static String systemEnvironmentVariable(String variable) {
@@ -58,111 +58,111 @@ class EnvironmentVariableExtensionTests {
 
 	@Nested
 	@DisplayName("used with ClearEnvironmentVariable")
-	@ClearEnvironmentVariable(key = "set prop A")
+	@ClearEnvironmentVariable(key = "set envvar A")
 	class ClearEnvironmentVariableTests {
 
 		@Test
 		@DisplayName("should clear environment variable")
-		@ClearEnvironmentVariable(key = "set prop B")
+		@ClearEnvironmentVariable(key = "set envvar B")
 		void shouldClearEnvironmentVariable() {
-			assertThat(systemEnvironmentVariable("set prop A")).isNull();
-			assertThat(systemEnvironmentVariable("set prop B")).isNull();
-			assertThat(systemEnvironmentVariable("set prop C")).isEqualTo("old C");
+			assertThat(systemEnvironmentVariable("set envvar A")).isNull();
+			assertThat(systemEnvironmentVariable("set envvar B")).isNull();
+			assertThat(systemEnvironmentVariable("set envvar C")).isEqualTo("old C");
 
-			assertThat(systemEnvironmentVariable("clear prop D")).isNull();
-			assertThat(systemEnvironmentVariable("clear prop E")).isNull();
-			assertThat(systemEnvironmentVariable("clear prop F")).isNull();
+			assertThat(systemEnvironmentVariable("clear envvar D")).isNull();
+			assertThat(systemEnvironmentVariable("clear envvar E")).isNull();
+			assertThat(systemEnvironmentVariable("clear envvar F")).isNull();
 		}
 
 		@Test
 		@DisplayName("should be repeatable")
-		@ClearEnvironmentVariable(key = "set prop B")
-		@ClearEnvironmentVariable(key = "set prop C")
+		@ClearEnvironmentVariable(key = "set envvar B")
+		@ClearEnvironmentVariable(key = "set envvar C")
 		void shouldBeRepeatable() {
-			assertThat(systemEnvironmentVariable("set prop A")).isNull();
-			assertThat(systemEnvironmentVariable("set prop B")).isNull();
-			assertThat(systemEnvironmentVariable("set prop C")).isNull();
+			assertThat(systemEnvironmentVariable("set envvar A")).isNull();
+			assertThat(systemEnvironmentVariable("set envvar B")).isNull();
+			assertThat(systemEnvironmentVariable("set envvar C")).isNull();
 
-			assertThat(systemEnvironmentVariable("clear prop D")).isNull();
-			assertThat(systemEnvironmentVariable("clear prop E")).isNull();
-			assertThat(systemEnvironmentVariable("clear prop F")).isNull();
+			assertThat(systemEnvironmentVariable("clear envvar D")).isNull();
+			assertThat(systemEnvironmentVariable("clear envvar E")).isNull();
+			assertThat(systemEnvironmentVariable("clear envvar F")).isNull();
 		}
 
 	}
 
 	@Nested
 	@DisplayName("used with SetEnvironmentVariable")
-	@SetEnvironmentVariable(key = "set prop A", value = "new A")
+	@SetEnvironmentVariable(key = "set envvar A", value = "new A")
 	class SetEnvironmentVariableTests {
 
 		@Test
 		@DisplayName("should set environment variable to value")
-		@SetEnvironmentVariable(key = "set prop B", value = "new B")
+		@SetEnvironmentVariable(key = "set envvar B", value = "new B")
 		void shouldSetEnvironmentVariableToValue() {
-			assertThat(systemEnvironmentVariable("set prop A")).isEqualTo("new A");
-			assertThat(systemEnvironmentVariable("set prop B")).isEqualTo("new B");
-			assertThat(systemEnvironmentVariable("set prop C")).isEqualTo("old C");
+			assertThat(systemEnvironmentVariable("set envvar A")).isEqualTo("new A");
+			assertThat(systemEnvironmentVariable("set envvar B")).isEqualTo("new B");
+			assertThat(systemEnvironmentVariable("set envvar C")).isEqualTo("old C");
 
-			assertThat(systemEnvironmentVariable("clear prop D")).isNull();
-			assertThat(systemEnvironmentVariable("clear prop E")).isNull();
-			assertThat(systemEnvironmentVariable("clear prop F")).isNull();
+			assertThat(systemEnvironmentVariable("clear envvar D")).isNull();
+			assertThat(systemEnvironmentVariable("clear envvar E")).isNull();
+			assertThat(systemEnvironmentVariable("clear envvar F")).isNull();
 		}
 
 		@Test
 		@DisplayName("should be repeatable")
-		@SetEnvironmentVariable(key = "set prop B", value = "new B")
-		@SetEnvironmentVariable(key = "clear prop D", value = "new D")
+		@SetEnvironmentVariable(key = "set envvar B", value = "new B")
+		@SetEnvironmentVariable(key = "clear envvar D", value = "new D")
 		void shouldBeRepeatable() {
-			assertThat(systemEnvironmentVariable("set prop A")).isEqualTo("new A");
-			assertThat(systemEnvironmentVariable("set prop B")).isEqualTo("new B");
-			assertThat(systemEnvironmentVariable("set prop C")).isEqualTo("old C");
+			assertThat(systemEnvironmentVariable("set envvar A")).isEqualTo("new A");
+			assertThat(systemEnvironmentVariable("set envvar B")).isEqualTo("new B");
+			assertThat(systemEnvironmentVariable("set envvar C")).isEqualTo("old C");
 
-			assertThat(systemEnvironmentVariable("clear prop D")).isEqualTo("new D");
-			assertThat(systemEnvironmentVariable("clear prop E")).isNull();
-			assertThat(systemEnvironmentVariable("clear prop F")).isNull();
+			assertThat(systemEnvironmentVariable("clear envvar D")).isEqualTo("new D");
+			assertThat(systemEnvironmentVariable("clear envvar E")).isNull();
+			assertThat(systemEnvironmentVariable("clear envvar F")).isNull();
 		}
 
 	}
 
 	@Nested
 	@DisplayName("used with both ClearEnvironmentVariable and SetEnvironmentVariable")
-	@ClearEnvironmentVariable(key = "set prop A")
-	@SetEnvironmentVariable(key = "clear prop D", value = "new D")
+	@ClearEnvironmentVariable(key = "set envvar A")
+	@SetEnvironmentVariable(key = "clear envvar D", value = "new D")
 	class CombinedEnvironmentVariableTests {
 
 		@Test
 		@DisplayName("should be combinable")
-		@ClearEnvironmentVariable(key = "set prop B")
-		@SetEnvironmentVariable(key = "clear prop E", value = "new E")
+		@ClearEnvironmentVariable(key = "set envvar B")
+		@SetEnvironmentVariable(key = "clear envvar E", value = "new E")
 		void clearAndSetEnvironmentVariableShouldBeCombinable() {
-			assertThat(systemEnvironmentVariable("set prop A")).isNull();
-			assertThat(systemEnvironmentVariable("set prop B")).isNull();
-			assertThat(systemEnvironmentVariable("set prop C")).isEqualTo("old C");
+			assertThat(systemEnvironmentVariable("set envvar A")).isNull();
+			assertThat(systemEnvironmentVariable("set envvar B")).isNull();
+			assertThat(systemEnvironmentVariable("set envvar C")).isEqualTo("old C");
 
-			assertThat(systemEnvironmentVariable("clear prop D")).isEqualTo("new D");
-			assertThat(systemEnvironmentVariable("clear prop E")).isEqualTo("new E");
-			assertThat(systemEnvironmentVariable("clear prop F")).isNull();
+			assertThat(systemEnvironmentVariable("clear envvar D")).isEqualTo("new D");
+			assertThat(systemEnvironmentVariable("clear envvar E")).isEqualTo("new E");
+			assertThat(systemEnvironmentVariable("clear envvar F")).isNull();
 		}
 
 		@Test
 		@DisplayName("method level should overwrite class level")
-		@ClearEnvironmentVariable(key = "clear prop D")
-		@SetEnvironmentVariable(key = "set prop A", value = "new A")
+		@ClearEnvironmentVariable(key = "clear envvar D")
+		@SetEnvironmentVariable(key = "set envvar A", value = "new A")
 		void methodLevelShouldOverwriteClassLevel() {
-			assertThat(systemEnvironmentVariable("set prop A")).isEqualTo("new A");
-			assertThat(systemEnvironmentVariable("set prop B")).isEqualTo("old B");
-			assertThat(systemEnvironmentVariable("set prop C")).isEqualTo("old C");
+			assertThat(systemEnvironmentVariable("set envvar A")).isEqualTo("new A");
+			assertThat(systemEnvironmentVariable("set envvar B")).isEqualTo("old B");
+			assertThat(systemEnvironmentVariable("set envvar C")).isEqualTo("old C");
 
-			assertThat(systemEnvironmentVariable("clear prop D")).isNull();
-			assertThat(systemEnvironmentVariable("clear prop E")).isNull();
-			assertThat(systemEnvironmentVariable("clear prop F")).isNull();
+			assertThat(systemEnvironmentVariable("clear envvar D")).isNull();
+			assertThat(systemEnvironmentVariable("clear envvar E")).isNull();
+			assertThat(systemEnvironmentVariable("clear envvar F")).isNull();
 		}
 
 	}
 
 	@DisplayName("with nested classes")
-	@ClearEnvironmentVariable(key = "set prop A")
-	@SetEnvironmentVariable(key = "set prop B", value = "new B")
+	@ClearEnvironmentVariable(key = "set envvar A")
+	@SetEnvironmentVariable(key = "set envvar B", value = "new B")
 	@Nested
 	class NestedEnvironmentVariableTests {
 
@@ -174,14 +174,14 @@ class EnvironmentVariableExtensionTests {
 			@ReadsEnvironmentVariable
 			@DisplayName("environment variables should be set from enclosed class when they are not provided in nested")
 			public void shouldSetEnvironmentVariableFromEnclosedClass() {
-				assertThat(systemEnvironmentVariable("set prop A")).isNull();
-				assertThat(systemEnvironmentVariable("set prop B")).isEqualTo("new B");
+				assertThat(systemEnvironmentVariable("set envvar A")).isNull();
+				assertThat(systemEnvironmentVariable("set envvar B")).isEqualTo("new B");
 			}
 
 		}
 
 		@Nested
-		@SetEnvironmentVariable(key = "set prop B", value = "newer B")
+		@SetEnvironmentVariable(key = "set envvar B", value = "newer B")
 		@DisplayName("with SetEnvironmentVariable annotation")
 		class AnnotatedNestedClass {
 
@@ -189,14 +189,14 @@ class EnvironmentVariableExtensionTests {
 			@ReadsEnvironmentVariable
 			@DisplayName("environment variable should be set from nested class when it is provided")
 			public void shouldSetEnvironmentVariableFromNestedClass() {
-				assertThat(systemEnvironmentVariable("set prop B")).isEqualTo("newer B");
+				assertThat(systemEnvironmentVariable("set envvar B")).isEqualTo("newer B");
 			}
 
 			@Test
-			@SetEnvironmentVariable(key = "set prop B", value = "newest B")
+			@SetEnvironmentVariable(key = "set envvar B", value = "newest B")
 			@DisplayName("environment variable should be set from method when it is provided")
 			public void shouldSetEnvironmentVariableFromMethodOfNestedClass() {
-				assertThat(systemEnvironmentVariable("set prop B")).isEqualTo("newest B");
+				assertThat(systemEnvironmentVariable("set envvar B")).isEqualTo("newest B");
 			}
 
 		}
@@ -288,12 +288,12 @@ class EnvironmentVariableExtensionTests {
 		}
 
 		@Test
-		@ClearEnvironmentVariable(key = "set prop A")
+		@ClearEnvironmentVariable(key = "set envvar A")
 		void testWithExtension() {
 		}
 
 		@Test
-		@ClearEnvironmentVariable(key = "set prop A")
+		@ClearEnvironmentVariable(key = "set envvar A")
 		void anotherTestWithExtension() {
 		}
 
@@ -303,20 +303,20 @@ class EnvironmentVariableExtensionTests {
 
 		@Test
 		@DisplayName("clearing and setting the same variable")
-		@ClearEnvironmentVariable(key = "set prop A")
-		@SetEnvironmentVariable(key = "set prop A", value = "new A")
+		@ClearEnvironmentVariable(key = "set envvar A")
+		@SetEnvironmentVariable(key = "set envvar A", value = "new A")
 		void shouldFailWhenClearAndSetSameEnvironmentVariable() {
 		}
 
 		@Test
-		@ClearEnvironmentVariable(key = "set prop A")
-		@ClearEnvironmentVariable(key = "set prop A")
+		@ClearEnvironmentVariable(key = "set envvar A")
+		@ClearEnvironmentVariable(key = "set envvar A")
 		void shouldFailWhenClearSameEnvironmentVariableTwice() {
 		}
 
 		@Test
-		@SetEnvironmentVariable(key = "set prop A", value = "new A")
-		@SetEnvironmentVariable(key = "set prop A", value = "new B")
+		@SetEnvironmentVariable(key = "set envvar A", value = "new A")
+		@SetEnvironmentVariable(key = "set envvar A", value = "new B")
 		void shouldFailWhenSetSameEnvironmentVariableTwice() {
 		}
 
@@ -329,18 +329,18 @@ class EnvironmentVariableExtensionTests {
 		@Test
 		@DisplayName("should inherit clear and set annotations")
 		void shouldInheritClearAndSetProperty() {
-			assertThat(systemEnvironmentVariable("set prop A")).isNull();
-			assertThat(systemEnvironmentVariable("set prop B")).isNull();
-			assertThat(systemEnvironmentVariable("clear prop D")).isEqualTo("new D");
-			assertThat(systemEnvironmentVariable("clear prop E")).isEqualTo("new E");
+			assertThat(systemEnvironmentVariable("set envvar A")).isNull();
+			assertThat(systemEnvironmentVariable("set envvar B")).isNull();
+			assertThat(systemEnvironmentVariable("clear envvar D")).isEqualTo("new D");
+			assertThat(systemEnvironmentVariable("clear envvar E")).isEqualTo("new E");
 		}
 
 	}
 
-	@ClearEnvironmentVariable(key = "set prop A")
-	@ClearEnvironmentVariable(key = "set prop B")
-	@SetEnvironmentVariable(key = "clear prop D", value = "new D")
-	@SetEnvironmentVariable(key = "clear prop E", value = "new E")
+	@ClearEnvironmentVariable(key = "set envvar A")
+	@ClearEnvironmentVariable(key = "set envvar B")
+	@SetEnvironmentVariable(key = "clear envvar D", value = "new D")
+	@SetEnvironmentVariable(key = "clear envvar E", value = "new E")
 	static class InheritanceBaseTest {
 
 	}

--- a/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
@@ -322,4 +322,27 @@ class EnvironmentVariableExtensionTests {
 
 	}
 
+	@Nested
+	@DisplayName("used with inheritance")
+	class InheritanceTests extends InheritanceBaseTest {
+
+		@Test
+		@DisplayName("should inherit clear and set annotations")
+		void shouldInheritClearAndSetProperty() {
+			assertThat(systemEnvironmentVariable("set prop A")).isNull();
+			assertThat(systemEnvironmentVariable("set prop B")).isNull();
+			assertThat(systemEnvironmentVariable("clear prop D")).isEqualTo("new D");
+			assertThat(systemEnvironmentVariable("clear prop E")).isEqualTo("new E");
+		}
+
+	}
+
+	@ClearEnvironmentVariable(key = "set prop A")
+	@ClearEnvironmentVariable(key = "set prop B")
+	@SetEnvironmentVariable(key = "clear prop D", value = "new D")
+	@SetEnvironmentVariable(key = "clear prop E", value = "new E")
+	static class InheritanceBaseTest {
+
+	}
+
 }

--- a/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
@@ -210,7 +210,7 @@ class EnvironmentVariableExtensionTests {
 		@Test
 		@DisplayName("should fail when clear and set same environment variable")
 		void shouldFailWhenClearAndSetSameEnvironmentVariable() {
-			ExecutionResults results = executeTestMethod(MethodLevelInitializationFailureTestCase.class,
+			ExecutionResults results = executeTestMethod(MethodLevelInitializationFailureTestCases.class,
 				"shouldFailWhenClearAndSetSameEnvironmentVariable");
 
 			assertThat(results).hasSingleFailedTest().withExceptionInstanceOf(ExtensionConfigurationException.class);
@@ -222,7 +222,7 @@ class EnvironmentVariableExtensionTests {
 				+ "deduplicates identical annotations like the ones required for this test: "
 				+ "https://github.com/junit-team/junit5/issues/2131")
 		void shouldFailWhenClearSameEnvironmentVariableTwice() {
-			ExecutionResults results = executeTestMethod(MethodLevelInitializationFailureTestCase.class,
+			ExecutionResults results = executeTestMethod(MethodLevelInitializationFailureTestCases.class,
 				"shouldFailWhenClearSameEnvironmentVariableTwice");
 
 			assertThat(results).hasSingleFailedTest().withExceptionInstanceOf(ExtensionConfigurationException.class);
@@ -231,7 +231,7 @@ class EnvironmentVariableExtensionTests {
 		@Test
 		@DisplayName("should fail when set same environment variable twice")
 		void shouldFailWhenSetSameEnvironmentVariableTwice() {
-			ExecutionResults results = executeTestMethod(MethodLevelInitializationFailureTestCase.class,
+			ExecutionResults results = executeTestMethod(MethodLevelInitializationFailureTestCases.class,
 				"shouldFailWhenSetSameEnvironmentVariableTwice");
 
 			assertThat(results).hasSingleFailedTest().withExceptionInstanceOf(ExtensionConfigurationException.class);
@@ -299,7 +299,7 @@ class EnvironmentVariableExtensionTests {
 
 	}
 
-	static class MethodLevelInitializationFailureTestCase {
+	static class MethodLevelInitializationFailureTestCases {
 
 		@Test
 		@DisplayName("clearing and setting the same variable")

--- a/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
@@ -256,4 +256,27 @@ class SystemPropertyExtensionTests {
 
 	}
 
+	@Nested
+	@DisplayName("used with inheritance")
+	class InheritanceTests extends InheritanceBaseTest {
+
+		@Test
+		@DisplayName("should inherit clear and set annotations")
+		void shouldInheritClearAndSetProperty() {
+			assertThat(System.getProperty("set prop A")).isNull();
+			assertThat(System.getProperty("set prop B")).isNull();
+			assertThat(System.getProperty("clear prop D")).isEqualTo("new D");
+			assertThat(System.getProperty("clear prop E")).isEqualTo("new E");
+		}
+
+	}
+
+	@ClearSystemProperty(key = "set prop A")
+	@ClearSystemProperty(key = "set prop B")
+	@SetSystemProperty(key = "clear prop D", value = "new D")
+	@SetSystemProperty(key = "clear prop E", value = "new E")
+	static class InheritanceBaseTest {
+
+	}
+
 }

--- a/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
@@ -203,7 +203,7 @@ class SystemPropertyExtensionTests {
 		@DisplayName("should fail when clear and set same system property")
 		void shouldFailWhenClearAndSetSameSystemProperty() {
 			ExecutionResults results = PioneerTestKit
-					.executeTestMethod(MethodLevelInitializationFailureTestCase.class,
+					.executeTestMethod(MethodLevelInitializationFailureTestCases.class,
 						"shouldFailWhenClearAndSetSameSystemProperty");
 
 			assertThat(results).hasSingleFailedTest().withExceptionInstanceOf(ExtensionConfigurationException.class);
@@ -216,7 +216,7 @@ class SystemPropertyExtensionTests {
 				+ "https://github.com/junit-team/junit5/issues/2131")
 		void shouldFailWhenClearSameSystemPropertyTwice() {
 			ExecutionResults results = PioneerTestKit
-					.executeTestMethod(MethodLevelInitializationFailureTestCase.class,
+					.executeTestMethod(MethodLevelInitializationFailureTestCases.class,
 						"shouldFailWhenClearSameSystemPropertyTwice");
 
 			assertThat(results).hasSingleFailedTest().withExceptionInstanceOf(ExtensionConfigurationException.class);
@@ -226,14 +226,14 @@ class SystemPropertyExtensionTests {
 		@DisplayName("should fail when set same system property twice")
 		void shouldFailWhenSetSameSystemPropertyTwice() {
 			ExecutionResults results = PioneerTestKit
-					.executeTestMethod(MethodLevelInitializationFailureTestCase.class,
+					.executeTestMethod(MethodLevelInitializationFailureTestCases.class,
 						"shouldFailWhenSetSameSystemPropertyTwice");
 			assertThat(results).hasSingleFailedTest().withExceptionInstanceOf(ExtensionConfigurationException.class);
 		}
 
 	}
 
-	static class MethodLevelInitializationFailureTestCase {
+	static class MethodLevelInitializationFailureTestCases {
 
 		@Test
 		@DisplayName("clearing and setting the same property")


### PR DESCRIPTION
Closes #448.

Proposed commit message:

```
Inherit entry-based annotations (#448 / #449)

The following entry-based annotations can now be inherited:

* `ClearEnvironmentVariable`
* `SetEnvironmentVariable`
* `ClearSystemProperty`
* `SetSystemProperty`

This also includes the corresponding repeatable annotations.

Closes: #448
PR: #449
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://joel-costigliola.github.io/assertj/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [x] The list of contributions inside `README.md` mentions the new contribution (real name optional) 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
