### PR TITLE
Remove auto-version plugin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -407,8 +407,9 @@ If such a tag was added, _minor_ must increased - if not, it's up for debate (wh
 For contributors that means that when they add members that require such a tag, they should generally put the next _minor_ version next to it.
 
 **A note on Shipkit**:
-Shipkit _can_ detect the version to be released on its own, but it increases the patch versions by number of commits since recent release (hence 1.3.0 ~> 1.3.8), which is not what we want.
-Also note that Shipkit still reads from [`version-properties`](version.properties) but as far as we can tell, that information doesn't apply to us, so we don't update it.
+[Shipkit's _auto-version_ plugin](https://github.com/shipkit/shipkit-auto-version) _can_ detect the version to be released on its own, but it increases the patch versions by number of commits since recent release (hence 1.3.0 ~> 1.3.8), which is not what we want.
+We hence don't use it.
+The other feature it provides is detecting the recent version (needed by [the _changelog_ plugin](https://github.com/shipkit/shipkit-changelog)), which we do by running `git describe --tags --abbrev=0`.
 
 ### Background
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
 	id("at.zierler.yamlvalidator") version "1.5.0"
 	id("org.sonarqube") version "3.1.1"
 	id("org.moditect.gradleplugin") version "1.0.0-rc3"
-	id("org.shipkit.shipkit-auto-version") version "1.1.5"
 	id("org.shipkit.shipkit-changelog") version "1.1.13"
 	id("org.shipkit.shipkit-github-release") version "1.1.13"
 	id("com.github.ben-manes.versions") version "0.38.0"
@@ -250,7 +249,9 @@ tasks {
 	}
 
 	generateChangelog {
-		previousRevision = ext.get("shipkit-auto-version.previous-tag").toString()
+		val gitFetchRecentTag = Runtime.getRuntime().exec("git describe --tags --abbrev=0")
+		val recentTag = gitFetchRecentTag.inputStream.bufferedReader().readText().trim()
+		previousRevision = recentTag
 		githubToken = System.getenv("GITHUB_TOKEN")
 		repository = "junit-pioneer/junit-pioneer"
 	}

--- a/version.properties
+++ b/version.properties
@@ -1,8 +1,0 @@
-# Shipkit auto-versioning-plugin needs this file and `version` property or it
-# can't configure itself and will fail the build. For actual releases, this
-# version is overriden with a Gradle property, so it's not needed then.
-# Hence, we set a bogus value and don't update it.
-#
-# When removing this file, check CONTRIBUTING.md for mentions of it.
-#
-version=1.0.*


### PR DESCRIPTION
Proposed commit message:

```
Remove Shipkit auto-version plugin (#442, #469 / #475)

After #442 configured manual release versioning, it was unclear
whether Shipkit still needed the `version` property in the
`version-properties` file, so I set it to `1.0.0`. The 1.4.0 release
showed that it indeed needs it because it determined 1.0.0 as the
previous version and so the changelog plugin[1] filled the GitHub
release with all commits after 1.0.0.

Maintaining `version.properties` is a hassle, though, (can easily
be forgotten, causes merge conflicts, needs to be documented), so
I'd rather not do that.

Instead this change removes the auto-version plugin[2] altogether and
replaces the determination of the previous version with an execution
of `git describe --tags --abbrev=0`.

[1]: https://github.com/shipkit/shipkit-changelog
[2]: https://github.com/shipkit/shipkit-auto-version

Relates to: #442, #469
PR: #475
```
---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
