### PR TITLE
Fix annotation lookup in AbstractEntryBasedExtension

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The least we can do is to thank them and list some of their accomplishments here
 #### 2021
 
 * [Cory Thomas](https://github.com/dump247) contributed the `minSuccess` attribute in [retrying tests](https://junit-pioneer.org/docs/retrying-test/) (#408 / #430)
-* [Daniel Kraus](https://github.com/beatngu13) fixed bugs in the environment variable and system property extensions (#432 / #433, #448 / #449 and #473 / #476)
+* [Daniel Kraus](https://github.com/beatngu13) fixed bugs in the environment variable and system property extensions (#432 / #433, #448 / #449, and #473 / #476)
 * [Slawomir Jaranowski](https://github.com/slawekjaranowski) Migrate to new Shipkit plugins (#410 / #419)
 * [Stefano Cordio](https://github.com/scordio) contributed [the Cartesian Enum source](https://junit-pioneer.org/docs/cartesian-product/#cartesianenumsource) (#379 / #409 and #414 / #453)
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The least we can do is to thank them and list some of their accomplishments here
 #### 2021
 
 * [Cory Thomas](https://github.com/dump247) contributed the `minSuccess` attribute in [retrying tests](https://junit-pioneer.org/docs/retrying-test/) (#408 / #430)
-* [Daniel Kraus](https://github.com/beatngu13) fixed bugs in the environment variable and system property extensions (#432 / #433 and #448 / #449)
+* [Daniel Kraus](https://github.com/beatngu13) fixed bugs in the environment variable and system property extensions (#432 / #433, #448 / #449 and #473 / #476)
 * [Slawomir Jaranowski](https://github.com/slawekjaranowski) Migrate to new Shipkit plugins (#410 / #419)
 * [Stefano Cordio](https://github.com/scordio) contributed [the Cartesian Enum source](https://junit-pioneer.org/docs/cartesian-product/#cartesianenumsource) (#379 / #409 and #414 / #453)
 

--- a/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.support.AnnotationSupport;
 import org.junitpioneer.internal.PioneerAnnotationUtils;
 import org.junitpioneer.internal.PioneerUtils;
 
@@ -36,16 +37,18 @@ class EnvironmentVariableExtension extends AbstractEntryBasedExtension<String, S
 
 	@Override
 	protected Set<String> entriesToClear(ExtensionContext context) {
-		return PioneerAnnotationUtils
-				.findClosestEnclosingRepeatableAnnotations(context, ClearEnvironmentVariable.class)
+		return AnnotationSupport
+				.findRepeatableAnnotations(context.getElement(), ClearEnvironmentVariable.class)
+				.stream()
 				.map(ClearEnvironmentVariable::key)
 				.collect(PioneerUtils.distinctToSet());
 	}
 
 	@Override
 	protected Map<String, String> entriesToSet(ExtensionContext context) {
-		return PioneerAnnotationUtils
-				.findClosestEnclosingRepeatableAnnotations(context, SetEnvironmentVariable.class)
+		return AnnotationSupport
+				.findRepeatableAnnotations(context.getElement(), SetEnvironmentVariable.class)
+				.stream()
 				.collect(toMap(SetEnvironmentVariable::key, SetEnvironmentVariable::value));
 	}
 

--- a/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
@@ -38,6 +38,10 @@ class EnvironmentVariableExtension extends AbstractEntryBasedExtension<String, S
 	@Override
 	protected Set<String> entriesToClear(ExtensionContext context) {
 		return AnnotationSupport
+				// This extension implements `BeforeAllCallback` and `BeforeEachCallback` and so if an outer class
+				// (i.e. a class that the test class is @Nested within) uses this extension, this method will be
+				// called on those extension points and discover the variables to set/clear. That means we don't need
+				// to search for enclosing annotations here.
 				.findRepeatableAnnotations(context.getElement(), ClearEnvironmentVariable.class)
 				.stream()
 				.map(ClearEnvironmentVariable::key)
@@ -47,6 +51,10 @@ class EnvironmentVariableExtension extends AbstractEntryBasedExtension<String, S
 	@Override
 	protected Map<String, String> entriesToSet(ExtensionContext context) {
 		return AnnotationSupport
+				// This extension implements `BeforeAllCallback` and `BeforeEachCallback` and so if an outer class
+				// (i.e. a class that the test class is @Nested within) uses this extension, this method will be
+				// called on those extension points and discover the variables to set/clear. That means we don't need
+				// to search for enclosing annotations here.
 				.findRepeatableAnnotations(context.getElement(), SetEnvironmentVariable.class)
 				.stream()
 				.collect(toMap(SetEnvironmentVariable::key, SetEnvironmentVariable::value));

--- a/src/main/java/org/junitpioneer/jupiter/SystemPropertyExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/SystemPropertyExtension.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.commons.support.AnnotationSupport;
 import org.junitpioneer.internal.PioneerAnnotationUtils;
 import org.junitpioneer.internal.PioneerUtils;
 
@@ -29,16 +30,18 @@ class SystemPropertyExtension extends AbstractEntryBasedExtension<String, String
 
 	@Override
 	protected Set<String> entriesToClear(ExtensionContext context) {
-		return PioneerAnnotationUtils
-				.findClosestEnclosingRepeatableAnnotations(context, ClearSystemProperty.class)
+		return AnnotationSupport
+				.findRepeatableAnnotations(context.getElement(), ClearSystemProperty.class)
+				.stream()
 				.map(ClearSystemProperty::key)
 				.collect(PioneerUtils.distinctToSet());
 	}
 
 	@Override
 	protected Map<String, String> entriesToSet(ExtensionContext context) {
-		return PioneerAnnotationUtils
-				.findClosestEnclosingRepeatableAnnotations(context, SetSystemProperty.class)
+		return AnnotationSupport
+				.findRepeatableAnnotations(context.getElement(), SetSystemProperty.class)
+				.stream()
 				.collect(toMap(SetSystemProperty::key, SetSystemProperty::value));
 	}
 

--- a/src/main/java/org/junitpioneer/jupiter/SystemPropertyExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/SystemPropertyExtension.java
@@ -31,6 +31,10 @@ class SystemPropertyExtension extends AbstractEntryBasedExtension<String, String
 	@Override
 	protected Set<String> entriesToClear(ExtensionContext context) {
 		return AnnotationSupport
+				// This extension implements `BeforeAllCallback` and `BeforeEachCallback` and so if an outer class
+				// (i.e. a class that the test class is @Nested within) uses this extension, this method will be
+				// called on those extension points and discover the properties to set/clear. That means we don't need
+				// to search for enclosing annotations here.
 				.findRepeatableAnnotations(context.getElement(), ClearSystemProperty.class)
 				.stream()
 				.map(ClearSystemProperty::key)
@@ -40,6 +44,10 @@ class SystemPropertyExtension extends AbstractEntryBasedExtension<String, String
 	@Override
 	protected Map<String, String> entriesToSet(ExtensionContext context) {
 		return AnnotationSupport
+				// This extension implements `BeforeAllCallback` and `BeforeEachCallback` and so if an outer class
+				// (i.e. a class that the test class is @Nested within) uses this extension, this method will be
+				// called on those extension points and discover the properties to set/clear. That means we don't need
+				// to search for enclosing annotations here.
 				.findRepeatableAnnotations(context.getElement(), SetSystemProperty.class)
 				.stream()
 				.collect(toMap(SetSystemProperty::key, SetSystemProperty::value));

--- a/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
@@ -158,6 +158,19 @@ class EnvironmentVariableExtensionTests {
 			assertThat(systemEnvironmentVariable("clear envvar F")).isNull();
 		}
 
+		@Test
+		@DisplayName("method level should not clash (in terms of duplicate entries) with class level")
+		@SetEnvironmentVariable(key = "set envvar A", value = "new A")
+		void methodLevelShouldNotClashWithClassLevel() {
+			assertThat(systemEnvironmentVariable("set envvar A")).isEqualTo("new A");
+			assertThat(systemEnvironmentVariable("set envvar B")).isEqualTo("old B");
+			assertThat(systemEnvironmentVariable("set envvar C")).isEqualTo("old C");
+			assertThat(systemEnvironmentVariable("clear envvar D")).isEqualTo("new D");
+
+			assertThat(systemEnvironmentVariable("clear envvar E")).isNull();
+			assertThat(systemEnvironmentVariable("clear envvar F")).isNull();
+		}
+
 	}
 
 	@DisplayName("with nested classes")

--- a/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
@@ -150,6 +150,19 @@ class SystemPropertyExtensionTests {
 			assertThat(System.getProperty("clear prop F")).isNull();
 		}
 
+		@Test
+		@DisplayName("method level should not clash (in terms of duplicate entries) with class level")
+		@SetSystemProperty(key = "set prop A", value = "new A")
+		void methodLevelShouldNotClashWithClassLevel() {
+			assertThat(System.getProperty("set prop A")).isEqualTo("new A");
+			assertThat(System.getProperty("set prop B")).isEqualTo("old B");
+			assertThat(System.getProperty("set prop C")).isEqualTo("old C");
+			assertThat(System.getProperty("clear prop D")).isEqualTo("new D");
+
+			assertThat(System.getProperty("clear prop E")).isNull();
+			assertThat(System.getProperty("clear prop F")).isNull();
+		}
+
 	}
 
 	@DisplayName("with nested classes")


### PR DESCRIPTION
Closes #473.

Proposed commit message:

```
Fix annotation lookup in AbstractEntryBasedExtension (#473 / #476)

When using `findClosestEnclosingRepeatableAnnotations(...)`, outer
elements such as classes are also considered during search, if the
current element isn't annotated accordingly. This may cause an
`ExtensionConfigurationException` when an entry is both cleared (e.g.
on the class level) and set (e.g. on the method level).

Closes: #473
PR: #476
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [x] The list of contributions inside `README.md` mentions the new contribution (real name optional) 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
