### PR TITLE
Fix backup mechanism in AbstractEntryBasedExtension

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The least we can do is to thank them and list some of their accomplishments here
 #### 2021
 
 * [Cory Thomas](https://github.com/dump247) contributed the `minSuccess` attribute in [retrying tests](https://junit-pioneer.org/docs/retrying-test/) (#408 / #430)
-* [Daniel Kraus](https://github.com/beatngu13) fixed bugs in the environment variable and system property extensions (#432 / #433, #448 / #449, #473 / #476, and #480 / #481)
+* [Daniel Kraus](https://github.com/beatngu13) fixed bugs in the environment variable and system property extensions (#432 / #433, #448 / #449, and more)
 * [Slawomir Jaranowski](https://github.com/slawekjaranowski) Migrate to new Shipkit plugins (#410 / #419)
 * [Stefano Cordio](https://github.com/scordio) contributed [the Cartesian Enum source](https://junit-pioneer.org/docs/cartesian-product/#cartesianenumsource) (#379 / #409 and #414 / #453)
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The least we can do is to thank them and list some of their accomplishments here
 #### 2021
 
 * [Cory Thomas](https://github.com/dump247) contributed the `minSuccess` attribute in [retrying tests](https://junit-pioneer.org/docs/retrying-test/) (#408 / #430)
-* [Daniel Kraus](https://github.com/beatngu13) fixed bugs in the environment variable and system property extensions (#432 / #433, #448 / #449, and #473 / #476)
+* [Daniel Kraus](https://github.com/beatngu13) fixed bugs in the environment variable and system property extensions (#432 / #433, #448 / #449, #473 / #476, and #480 / #481)
 * [Slawomir Jaranowski](https://github.com/slawekjaranowski) Migrate to new Shipkit plugins (#410 / #419)
 * [Stefano Cordio](https://github.com/scordio) contributed [the Cartesian Enum source](https://junit-pioneer.org/docs/cartesian-product/#cartesianenumsource) (#379 / #409 and #414 / #453)
 

--- a/src/main/java/org/junitpioneer/jupiter/AbstractEntryBasedExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/AbstractEntryBasedExtension.java
@@ -146,7 +146,7 @@ abstract class AbstractEntryBasedExtension<K, V>
 	}
 
 	private Object getStoreKey(ExtensionContext context) {
-		return context.getDisplayName();
+		return context.getUniqueId();
 	}
 
 	private class EntriesBackup {

--- a/src/main/java/org/junitpioneer/jupiter/AbstractEntryBasedExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/AbstractEntryBasedExtension.java
@@ -38,12 +38,6 @@ abstract class AbstractEntryBasedExtension<K, V>
 
 	/**
 	 * @param context The current extension context.
-	 * @return <code>true</code> if one or more of the extension's annotations are present.
-	 */
-	protected abstract boolean isAnnotationPresent(ExtensionContext context);
-
-	/**
-	 * @param context The current extension context.
 	 * @return The entry keys to be cleared.
 	 */
 	protected abstract Set<K> entriesToClear(ExtensionContext context);
@@ -135,8 +129,7 @@ abstract class AbstractEntryBasedExtension<K, V>
 
 	@Override
 	public void afterEach(ExtensionContext context) throws Exception {
-		if (isAnnotationPresent(context))
-			restoreOriginalEntries(context);
+		restoreOriginalEntries(context);
 	}
 
 	@Override

--- a/src/main/java/org/junitpioneer/jupiter/AbstractEntryBasedExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/AbstractEntryBasedExtension.java
@@ -36,8 +36,6 @@ import org.junit.jupiter.api.extension.ExtensionContext.Store;
 abstract class AbstractEntryBasedExtension<K, V>
 		implements BeforeAllCallback, BeforeEachCallback, AfterAllCallback, AfterEachCallback {
 
-	private static final String BACKUP = "Backup";
-
 	/**
 	 * @param context The current extension context.
 	 * @return <code>true</code> if one or more of the extension's annotations are present.
@@ -124,7 +122,7 @@ abstract class AbstractEntryBasedExtension<K, V>
 
 	private void storeOriginalEntries(ExtensionContext context, Collection<K> entriesToClear,
 			Collection<K> entriesToSet) {
-		getStore(context).put(BACKUP, new EntriesBackup(entriesToClear, entriesToSet));
+		getStore(context).put(getStoreKey(context), new EntriesBackup(entriesToClear, entriesToSet));
 	}
 
 	private void clearEntries(Collection<K> entriesToClear) {
@@ -147,11 +145,15 @@ abstract class AbstractEntryBasedExtension<K, V>
 	}
 
 	private void restoreOriginalEntries(ExtensionContext context) {
-		getStore(context).get(BACKUP, EntriesBackup.class).restoreBackup();
+		getStore(context).getOrDefault(getStoreKey(context), EntriesBackup.class, new EntriesBackup()).restoreBackup();
 	}
 
 	private Store getStore(ExtensionContext context) {
 		return context.getStore(Namespace.create(getClass()));
+	}
+
+	private Object getStoreKey(ExtensionContext context) {
+		return context.getDisplayName();
 	}
 
 	private class EntriesBackup {

--- a/src/main/java/org/junitpioneer/jupiter/AbstractEntryBasedExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/AbstractEntryBasedExtension.java
@@ -159,6 +159,10 @@ abstract class AbstractEntryBasedExtension<K, V>
 		private final Set<K> entriesToClear = new HashSet<>();
 		private final Map<K, V> entriesToSet = new HashMap<>();
 
+		public EntriesBackup() {
+			// empty backup
+		}
+
 		public EntriesBackup(Collection<K> entriesToClear, Collection<K> entriesToSet) {
 			Stream.concat(entriesToClear.stream(), entriesToSet.stream()).forEach(entry -> {
 				V backup = AbstractEntryBasedExtension.this.getEntry(entry);

--- a/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
@@ -18,7 +18,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.support.AnnotationSupport;
-import org.junitpioneer.internal.PioneerAnnotationUtils;
 import org.junitpioneer.internal.PioneerUtils;
 
 class EnvironmentVariableExtension extends AbstractEntryBasedExtension<String, String> {
@@ -27,13 +26,6 @@ class EnvironmentVariableExtension extends AbstractEntryBasedExtension<String, S
 	static final AtomicBoolean REPORTED_WARNING = new AtomicBoolean(false);
 	static final String WARNING_KEY = EnvironmentVariableExtension.class.getSimpleName();
 	static final String WARNING_VALUE = "This extension uses reflection to mutate JDK-internal state, which is fragile. Check the Javadoc or documentation for more details.";
-
-	@Override
-	protected boolean isAnnotationPresent(ExtensionContext context) {
-		return PioneerAnnotationUtils
-				.isAnyRepeatableAnnotationPresent(context, ClearEnvironmentVariable.class,
-					SetEnvironmentVariable.class);
-	}
 
 	@Override
 	protected Set<String> entriesToClear(ExtensionContext context) {

--- a/src/main/java/org/junitpioneer/jupiter/SystemPropertyExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/SystemPropertyExtension.java
@@ -17,16 +17,9 @@ import java.util.Set;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.platform.commons.support.AnnotationSupport;
-import org.junitpioneer.internal.PioneerAnnotationUtils;
 import org.junitpioneer.internal.PioneerUtils;
 
 class SystemPropertyExtension extends AbstractEntryBasedExtension<String, String> {
-
-	@Override
-	protected boolean isAnnotationPresent(ExtensionContext context) {
-		return PioneerAnnotationUtils
-				.isAnyRepeatableAnnotationPresent(context, ClearSystemProperty.class, SetSystemProperty.class);
-	}
 
 	@Override
 	protected Set<String> entriesToClear(ExtensionContext context) {

--- a/src/test/java/org/junitpioneer/jupiter/AbstractEntryBasedExtensionTest.java
+++ b/src/test/java/org/junitpioneer/jupiter/AbstractEntryBasedExtensionTest.java
@@ -38,6 +38,7 @@ class AbstractEntryBasedExtensionTest {
 	}
 
 	@Test
+	@Issue("432")
 	@DisplayName("should not mix backups of different extensions on clear environment variable and clear system property")
 	void shouldNotMixBackupsOfDifferentExtensionsOnClearEnvironmentVariableAndClearSystemProperty() {
 		PioneerTestKit.executeTestMethod(MixBackupsTestCases.class, "clearEnvironmentVariableAndClearSystemProperty");
@@ -47,6 +48,7 @@ class AbstractEntryBasedExtensionTest {
 	}
 
 	@Test
+	@Issue("432")
 	@DisplayName("should not mix backups of different extensions on set environment variable and set system property")
 	void shouldNotMixBackupsOfDifferentExtensionsOnSetEnvironmentVariableAndSetSystemProperty() {
 		PioneerTestKit.executeTestMethod(MixBackupsTestCases.class, "setEnvironmentVariableAndSetSystemProperty");
@@ -56,6 +58,7 @@ class AbstractEntryBasedExtensionTest {
 	}
 
 	@Test
+	@Issue("432")
 	@DisplayName("should not mix backups of different extensions on clear environment variable and set system property")
 	void shouldNotMixBackupsOfDifferentExtensionsOnClearEnvironmentVariableAndSetSystemProperty() {
 		PioneerTestKit.executeTestMethod(MixBackupsTestCases.class, "clearEnvironmentVariableAndSetSystemProperty");
@@ -65,6 +68,7 @@ class AbstractEntryBasedExtensionTest {
 	}
 
 	@Test
+	@Issue("432")
 	@DisplayName("should not mix backups of different extensions on set environment variable and clear system property")
 	void shouldNotMixBackupsOfDifferentExtensionsOnSetEnvironmentVariableAndClearSystemProperty() {
 		PioneerTestKit.executeTestMethod(MixBackupsTestCases.class, "setEnvironmentVariableAndClearSystemProperty");

--- a/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
@@ -162,6 +162,7 @@ class EnvironmentVariableExtensionTests {
 		}
 
 		@Test
+		@Issue("473")
 		@DisplayName("method level should not clash (in terms of duplicate entries) with class level")
 		@SetEnvironmentVariable(key = "set envvar A", value = "new A")
 		void methodLevelShouldNotClashWithClassLevel() {
@@ -197,6 +198,7 @@ class EnvironmentVariableExtensionTests {
 			}
 
 			@Test
+			@Issue("480")
 			@Order(2)
 			@ReadsEnvironmentVariable
 			@DisplayName("environment variables should be set from enclosed class after restore")
@@ -354,6 +356,7 @@ class EnvironmentVariableExtensionTests {
 	class InheritanceTests extends InheritanceBaseTest {
 
 		@Test
+		@Issue("448")
 		@DisplayName("should inherit clear and set annotations")
 		void shouldInheritClearAndSetProperty() {
 			assertThat(systemEnvironmentVariable("set envvar A")).isNull();

--- a/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
@@ -22,8 +22,11 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junitpioneer.testkit.ExecutionResults;
 
@@ -180,13 +183,24 @@ class EnvironmentVariableExtensionTests {
 	class NestedEnvironmentVariableTests {
 
 		@Nested
+		@TestMethodOrder(OrderAnnotation.class)
 		@DisplayName("without EnvironmentVariable annotations")
 		class NestedClass {
 
 			@Test
+			@Order(1)
 			@ReadsEnvironmentVariable
 			@DisplayName("environment variables should be set from enclosed class when they are not provided in nested")
 			public void shouldSetEnvironmentVariableFromEnclosedClass() {
+				assertThat(systemEnvironmentVariable("set envvar A")).isNull();
+				assertThat(systemEnvironmentVariable("set envvar B")).isEqualTo("new B");
+			}
+
+			@Test
+			@Order(2)
+			@ReadsEnvironmentVariable
+			@DisplayName("environment variables should be set from enclosed class after restore")
+			public void shouldSetEnvironmentVariableFromEnclosedClassAfterRestore() {
 				assertThat(systemEnvironmentVariable("set envvar A")).isNull();
 				assertThat(systemEnvironmentVariable("set envvar B")).isEqualTo("new B");
 			}

--- a/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
@@ -191,7 +191,7 @@ class EnvironmentVariableExtensionTests {
 			@Order(1)
 			@ReadsEnvironmentVariable
 			@DisplayName("environment variables should be set from enclosed class when they are not provided in nested")
-			public void shouldSetEnvironmentVariableFromEnclosedClass() {
+			void shouldSetEnvironmentVariableFromEnclosedClass() {
 				assertThat(systemEnvironmentVariable("set envvar A")).isNull();
 				assertThat(systemEnvironmentVariable("set envvar B")).isEqualTo("new B");
 			}
@@ -200,7 +200,7 @@ class EnvironmentVariableExtensionTests {
 			@Order(2)
 			@ReadsEnvironmentVariable
 			@DisplayName("environment variables should be set from enclosed class after restore")
-			public void shouldSetEnvironmentVariableFromEnclosedClassAfterRestore() {
+			void shouldSetEnvironmentVariableFromEnclosedClassAfterRestore() {
 				assertThat(systemEnvironmentVariable("set envvar A")).isNull();
 				assertThat(systemEnvironmentVariable("set envvar B")).isEqualTo("new B");
 			}
@@ -215,14 +215,14 @@ class EnvironmentVariableExtensionTests {
 			@Test
 			@ReadsEnvironmentVariable
 			@DisplayName("environment variable should be set from nested class when it is provided")
-			public void shouldSetEnvironmentVariableFromNestedClass() {
+			void shouldSetEnvironmentVariableFromNestedClass() {
 				assertThat(systemEnvironmentVariable("set envvar B")).isEqualTo("newer B");
 			}
 
 			@Test
 			@SetEnvironmentVariable(key = "set envvar B", value = "newest B")
 			@DisplayName("environment variable should be set from method when it is provided")
-			public void shouldSetEnvironmentVariableFromMethodOfNestedClass() {
+			void shouldSetEnvironmentVariableFromMethodOfNestedClass() {
 				assertThat(systemEnvironmentVariable("set envvar B")).isEqualTo("newest B");
 			}
 

--- a/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
@@ -17,8 +17,11 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junitpioneer.testkit.ExecutionResults;
 import org.junitpioneer.testkit.PioneerTestKit;
@@ -172,13 +175,24 @@ class SystemPropertyExtensionTests {
 	class NestedSystemPropertyTests {
 
 		@Nested
+		@TestMethodOrder(OrderAnnotation.class)
 		@DisplayName("without SystemProperty annotations")
 		class NestedClass {
 
 			@Test
+			@Order(1)
 			@ReadsSystemProperty
 			@DisplayName("system properties should be set from enclosed class when they are not provided in nested")
 			public void shouldSetSystemPropertyFromEnclosedClass() {
+				assertThat(System.getProperty("set prop A")).isNull();
+				assertThat(System.getProperty("set prop B")).isEqualTo("new B");
+			}
+
+			@Test
+			@Order(2)
+			@ReadsSystemProperty
+			@DisplayName("system properties should be set from enclosed class after restore")
+			public void shouldSetSystemPropertyFromEnclosedClassAfterRestore() {
 				assertThat(System.getProperty("set prop A")).isNull();
 				assertThat(System.getProperty("set prop B")).isEqualTo("new B");
 			}

--- a/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
@@ -183,7 +183,7 @@ class SystemPropertyExtensionTests {
 			@Order(1)
 			@ReadsSystemProperty
 			@DisplayName("system properties should be set from enclosed class when they are not provided in nested")
-			public void shouldSetSystemPropertyFromEnclosedClass() {
+			void shouldSetSystemPropertyFromEnclosedClass() {
 				assertThat(System.getProperty("set prop A")).isNull();
 				assertThat(System.getProperty("set prop B")).isEqualTo("new B");
 			}
@@ -192,7 +192,7 @@ class SystemPropertyExtensionTests {
 			@Order(2)
 			@ReadsSystemProperty
 			@DisplayName("system properties should be set from enclosed class after restore")
-			public void shouldSetSystemPropertyFromEnclosedClassAfterRestore() {
+			void shouldSetSystemPropertyFromEnclosedClassAfterRestore() {
 				assertThat(System.getProperty("set prop A")).isNull();
 				assertThat(System.getProperty("set prop B")).isEqualTo("new B");
 			}
@@ -207,14 +207,14 @@ class SystemPropertyExtensionTests {
 			@Test
 			@ReadsSystemProperty
 			@DisplayName("system property should be set from nested class when it is provided")
-			public void shouldSetSystemPropertyFromNestedClass() {
+			void shouldSetSystemPropertyFromNestedClass() {
 				assertThat(System.getProperty("set prop B")).isEqualTo("newer B");
 			}
 
 			@Test
 			@SetSystemProperty(key = "set prop B", value = "newest B")
 			@DisplayName("system property should be set from method when it is provided")
-			public void shouldSetSystemPropertyFromMethodOfNestedClass() {
+			void shouldSetSystemPropertyFromMethodOfNestedClass() {
 				assertThat(System.getProperty("set prop B")).isEqualTo("newest B");
 			}
 

--- a/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
@@ -154,6 +154,7 @@ class SystemPropertyExtensionTests {
 		}
 
 		@Test
+		@Issue("473")
 		@DisplayName("method level should not clash (in terms of duplicate entries) with class level")
 		@SetSystemProperty(key = "set prop A", value = "new A")
 		void methodLevelShouldNotClashWithClassLevel() {
@@ -189,6 +190,7 @@ class SystemPropertyExtensionTests {
 			}
 
 			@Test
+			@Issue("480")
 			@Order(2)
 			@ReadsSystemProperty
 			@DisplayName("system properties should be set from enclosed class after restore")
@@ -288,6 +290,7 @@ class SystemPropertyExtensionTests {
 	class InheritanceTests extends InheritanceBaseTest {
 
 		@Test
+		@Issue("448")
 		@DisplayName("should inherit clear and set annotations")
 		void shouldInheritClearAndSetProperty() {
 			assertThat(System.getProperty("set prop A")).isNull();


### PR DESCRIPTION
Closes #480.

Proposed commit message:

```
Fix AbstractEntryBasedExtension backups in nested tests (#480 / #481)

`ExtensionContext$Store#get(Object)` queries ancestors of the current
context if no value is stored under the supplied key. This can mess up
backups of system properties and environment variables in nested
classes if, for instance, the current test method has no corresponding
annotation but the surrounding container. Then, the first test
execution accidentally restores the backup, which leads to incorrect
system property / environment variables settings.

This PR sidesteps this issue by ensuring that the store / backup key
is unique per test or container, respectively, by using the given
display name.

Closes: #480
PR: #481
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [x] The list of contributions inside `README.md` mentions the new contribution (real name optional) 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
