### PR TITLE
Sign artifacts conditionally

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The least we can do is to thank them and list some of their accomplishments here
 #### 2021
 
 * [Cory Thomas](https://github.com/dump247) contributed the `minSuccess` attribute in [retrying tests](https://junit-pioneer.org/docs/retrying-test/) (#408 / #430)
-* [Daniel Kraus](https://github.com/beatngu13) fixed bugs in the environment variable and system property extensions (#432 / #433, #448 / #449, and #473 / #476)
+* [Daniel Kraus](https://github.com/beatngu13) fixed bugs in the environment variable and system property extensions (#432 / #433, #448 / #449, and #473 / #476) and improved the build process (#482 / #483)
 * [Slawomir Jaranowski](https://github.com/slawekjaranowski) Migrate to new Shipkit plugins (#410 / #419)
 * [Stefano Cordio](https://github.com/scordio) contributed [the Cartesian Enum source](https://junit-pioneer.org/docs/cartesian-product/#cartesianenumsource) (#379 / #409 and #414 / #453)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -174,7 +174,7 @@ publishing {
 
 signing {
 	setRequired({
-		project.version != "unspecified"
+		project.version != "unspecified" && gradle.taskGraph.hasTask("publishToSonatype")
 	})
 	val signingKey: String? by project
 	val signingPassword: String? by project

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -173,6 +173,9 @@ publishing {
 }
 
 signing {
+	setRequired({
+		project.version != "unspecified"
+	})
 	val signingKey: String? by project
 	val signingPassword: String? by project
 	useInMemoryPgpKeys(signingKey, signingPassword)


### PR DESCRIPTION
Closes #482. (Disclaimer: Gradle noob!)

Proposed commit message:

```
Sign artifacts conditionally (#482 / #483)

To e.g. enable JitPack usage or make `publishToMavenLocal` pass
_without_ configured signatory, signing should happen conditionally.
The given PR modifies the build to only signs artifacts iff there's a
`project.version` and `publishToSonatype` is included in the Gradle
task graph.

This approach is compatible with JUnit Pioneer's release build since
`publishToSonatype` is executed and `project.version` is set via the
environment variable `ORG_GRADLE_PROJECT_version`, which in turn is
injected as a workflow parameter.

Closes: #482
PR: #483
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [x] The list of contributions inside `README.md` mentions the new contribution (real name optional) 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
