### PR TITLE
Remove Spotless configuration for Groovy

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,17 +72,6 @@ spotless {
 		trimTrailingWhitespace()
 		endWithNewline()
 	}
-
-	format("groovy") {
-		target("**/*.groovy")
-		indentWithTabs()
-		trimTrailingWhitespace()
-		endWithNewline()
-		licenseHeaderFile(headerFile, "package ")
-
-		replaceRegex("class-level Javadoc indentation fix", """^\*""", " *")
-		replaceRegex("nested Javadoc indentation fix", "\t\\*", "\t *")
-	}
 }
 
 checkstyle {


### PR DESCRIPTION
No separate issue for this one … 🙃

Proposed commit message:

```
Remove Spotless configuration for Groovy (#484)

Since 2649599 converted the build scripts to Kotlin DSL, Groovy is
no longer used and the corresponding Spotless configuration can
be removed.

PR: #484
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
