### PR TITLE
Add TestKitTest for easier running of PioneerTestKit in tests

### DIFF
--- a/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
@@ -11,8 +11,6 @@
 package org.junitpioneer.jupiter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junitpioneer.testkit.PioneerTestKit.executeTestClass;
-import static org.junitpioneer.testkit.PioneerTestKit.executeTestMethod;
 import static org.junitpioneer.testkit.assertion.PioneerAssert.assertThat;
 
 import java.util.Locale;
@@ -26,6 +24,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junitpioneer.testkit.ExecutionResults;
+import org.junitpioneer.testkit.TestKitTest;
 
 @DisplayName("DefaultLocale extension")
 class DefaultLocaleTests {
@@ -95,12 +94,10 @@ class DefaultLocaleTests {
 			assertThat(Locale.getDefault()).isEqualTo(TEST_DEFAULT_LOCALE);
 		}
 
-		@Test
+		@TestKitTest(testClass = ClassLevelTestCase.class)
 		@WritesDefaultLocale
 		@DisplayName("should execute tests with configured Locale")
-		void shouldExecuteTestsWithConfiguredLocale() {
-			ExecutionResults results = executeTestClass(ClassLevelTestCase.class);
-
+		void shouldExecuteTestsWithConfiguredLocale(ExecutionResults results) {
 			assertThat(results).hasNumberOfSucceededTests(2);
 		}
 
@@ -177,56 +174,41 @@ class DefaultLocaleTests {
 		@DisplayName("on the method level")
 		class MethodLevel {
 
-			@Test
+			@TestKitTest(testClass = MethodLevelInitializationFailureTestCase.class, method = "shouldFailMissingConfiguration")
 			@DisplayName("should fail when nothing is configured")
-			void shouldFailWhenNothingIsConfigured() {
-				ExecutionResults results = executeTestMethod(MethodLevelInitializationFailureTestCase.class,
-					"shouldFailMissingConfiguration");
-
+			void shouldFailWhenNothingIsConfigured(ExecutionResults results) {
 				assertThat(results)
 						.hasSingleFailedTest()
 						.withExceptionInstanceOf(ExtensionConfigurationException.class);
 			}
 
-			@Test
+			@TestKitTest(testClass = MethodLevelInitializationFailureTestCase.class, method = "shouldFailMissingCountry")
 			@DisplayName("should fail when variant is set but country is not")
-			void shouldFailWhenVariantIsSetButCountryIsNot() {
-				ExecutionResults results = executeTestMethod(MethodLevelInitializationFailureTestCase.class,
-					"shouldFailMissingCountry");
-
+			void shouldFailWhenVariantIsSetButCountryIsNot(ExecutionResults results) {
 				assertThat(results)
 						.hasSingleFailedTest()
 						.withExceptionInstanceOf(ExtensionConfigurationException.class);
 			}
 
-			@Test
+			@TestKitTest(testClass = MethodLevelInitializationFailureTestCase.class, method = "shouldFailLanguageTagAndLanguage")
 			@DisplayName("should fail when languageTag and language is set")
-			void shouldFailWhenLanguageTagAndLanguageIsSet() {
-				ExecutionResults results = executeTestMethod(MethodLevelInitializationFailureTestCase.class,
-					"shouldFailLanguageTagAndLanguage");
-
+			void shouldFailWhenLanguageTagAndLanguageIsSet(ExecutionResults results) {
 				assertThat(results)
 						.hasSingleFailedTest()
 						.withExceptionInstanceOf(ExtensionConfigurationException.class);
 			}
 
-			@Test
+			@TestKitTest(testClass = MethodLevelInitializationFailureTestCase.class, method = "shouldFailLanguageTagAndCountry")
 			@DisplayName("should fail when languageTag and country is set")
-			void shouldFailWhenLanguageTagAndCountryIsSet() {
-				ExecutionResults results = executeTestMethod(MethodLevelInitializationFailureTestCase.class,
-					"shouldFailLanguageTagAndCountry");
-
+			void shouldFailWhenLanguageTagAndCountryIsSet(ExecutionResults results) {
 				assertThat(results)
 						.hasSingleFailedTest()
 						.withExceptionInstanceOf(ExtensionConfigurationException.class);
 			}
 
-			@Test
+			@TestKitTest(testClass = MethodLevelInitializationFailureTestCase.class, method = "shouldFailLanguageTagAndVariant")
 			@DisplayName("should fail when languageTag and variant is set")
-			void shouldFailWhenLanguageTagAndVariantIsSet() {
-				ExecutionResults results = executeTestMethod(MethodLevelInitializationFailureTestCase.class,
-					"shouldFailLanguageTagAndVariant");
-
+			void shouldFailWhenLanguageTagAndVariantIsSet(ExecutionResults results) {
 				assertThat(results)
 						.hasSingleFailedTest()
 						.withExceptionInstanceOf(ExtensionConfigurationException.class);
@@ -238,11 +220,9 @@ class DefaultLocaleTests {
 		@DisplayName("on the class level")
 		class ClassLevel {
 
-			@Test
+			@TestKitTest(testClass = ClassLevelInitializationFailureTestCase.class)
 			@DisplayName("should fail when variant is set but country is not")
-			void shouldFailWhenVariantIsSetButCountryIsNot() {
-				ExecutionResults results = executeTestClass(ClassLevelInitializationFailureTestCase.class);
-
+			void shouldFailWhenVariantIsSetButCountryIsNot(ExecutionResults results) {
 				assertThat(results)
 						.hasSingleFailedTest()
 						.withExceptionInstanceOf(ExtensionConfigurationException.class);

--- a/src/test/java/org/junitpioneer/jupiter/params/DisableIfArgumentExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/params/DisableIfArgumentExtensionTests.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junitpioneer.testkit.ExecutionResults;
-import org.junitpioneer.testkit.PioneerTestKit;
+import org.junitpioneer.testkit.TestKitTest;
 
 /**
  * Oscar Wilde: Requiescat is in the public domain
@@ -37,73 +37,52 @@ class DisableIfArgumentExtensionTests {
 	@DisplayName("when configured correctly")
 	class CorrectConfigurationTests {
 
-		@Test
+		@TestKitTest(testClass = CorrectConfigTestCases.class, method = "interceptContainsExplicitIndex", methodParameterTypes = {
+				String.class, String.class })
 		@DisplayName("disables tests when parameter targeted by explicit index contains any value from the 'contains' array")
-		void interceptContainsExplicitIndex() {
-			ExecutionResults results = PioneerTestKit
-					.executeTestMethodWithParameterTypes(CorrectConfigTestCases.class, "interceptContainsExplicitIndex",
-						String.class, String.class);
-
+		void interceptContainsExplicitIndex(ExecutionResults results) {
 			assertThat(results).hasNumberOfAbortedTests(1).hasNumberOfSucceededTests(7).hasNumberOfFailedTests(2);
 		}
 
-		@Test
+		@TestKitTest(testClass = CorrectConfigTestCases.class, method = "interceptContainsImplicitIndex", methodParameterTypes = {
+				String.class, String.class })
 		@DisplayName("disables tests when parameter targeted by implicit index contains any value from the 'contains' array")
-		void interceptContainsImplicitIndex() {
-			ExecutionResults results = PioneerTestKit
-					.executeTestMethodWithParameterTypes(CorrectConfigTestCases.class, "interceptContainsImplicitIndex",
-						String.class, String.class);
-
+		void interceptContainsImplicitIndex(ExecutionResults results) {
 			assertThat(results).hasNumberOfAbortedTests(2).hasNumberOfSucceededTests(6).hasNumberOfFailedTests(2);
 		}
 
-		@Test
+		@TestKitTest(testClass = CorrectConfigTestCases.class, method = "interceptContainsAny", methodParameterTypes = {
+				String.class, String.class })
 		@DisplayName("disables tests when any parameter contains any value from the 'contains' array")
-		void interceptContainsAny() {
-			ExecutionResults results = PioneerTestKit
-					.executeTestMethodWithParameterTypes(CorrectConfigTestCases.class, "interceptContainsAny",
-						String.class, String.class);
-
+		void interceptContainsAny(ExecutionResults results) {
 			assertThat(results).hasNumberOfAbortedTests(4).hasNumberOfSucceededTests(6);
 		}
 
-		@Test
+		@TestKitTest(testClass = CorrectConfigTestCases.class, method = "interceptContainsAll", methodParameterTypes = {
+				String.class, String.class })
 		@DisplayName("disables tests when all parameters contains any value from the 'contains' array")
-		void interceptContainsAll() {
-			ExecutionResults results = PioneerTestKit
-					.executeTestMethodWithParameterTypes(CorrectConfigTestCases.class, "interceptContainsAll",
-						String.class, String.class);
-
+		void interceptContainsAll(ExecutionResults results) {
 			assertThat(results).hasNumberOfAbortedTests(1).hasNumberOfSucceededTests(9);
 		}
 
-		@Test
+		@TestKitTest(testClass = CorrectConfigTestCases.class, method = "interceptMatches", methodParameterTypes = {
+				String.class, String.class })
 		@DisplayName("disables tests when parameter matches any regex from the 'matches' array")
-		void interceptMatches() {
-			ExecutionResults results = PioneerTestKit
-					.executeTestMethodWithParameterTypes(CorrectConfigTestCases.class, "interceptMatches", String.class,
-						String.class);
-
+		void interceptMatches(ExecutionResults results) {
 			assertThat(results).hasNumberOfAbortedTests(5).hasNumberOfSucceededTests(2).hasNumberOfFailedTests(3);
 		}
 
-		@Test
+		@TestKitTest(testClass = CorrectConfigTestCases.class, method = "interceptMatchesAny", methodParameterTypes = {
+				String.class, String.class })
 		@DisplayName("disables tests when any parameter matches any regex from the 'matches' array")
-		void interceptMatchesAny() {
-			ExecutionResults results = PioneerTestKit
-					.executeTestMethodWithParameterTypes(CorrectConfigTestCases.class, "interceptMatchesAny",
-						String.class, String.class);
-
+		void interceptMatchesAny(ExecutionResults results) {
 			assertThat(results).hasNumberOfAbortedTests(3).hasNumberOfSucceededTests(7);
 		}
 
-		@Test
+		@TestKitTest(testClass = CorrectConfigTestCases.class, method = "interceptMatchesAll", methodParameterTypes = {
+				String.class, String.class })
 		@DisplayName("disables tests when all parameters match any regex from the 'matches' array")
-		void interceptMatchesAll() {
-			ExecutionResults results = PioneerTestKit
-					.executeTestMethodWithParameterTypes(CorrectConfigTestCases.class, "interceptMatchesAll",
-						String.class, String.class);
-
+		void interceptMatchesAll(ExecutionResults results) {
 			assertThat(results).hasNumberOfAbortedTests(1).hasNumberOfSucceededTests(2).hasNumberOfFailedTests(7);
 		}
 
@@ -113,32 +92,24 @@ class DisableIfArgumentExtensionTests {
 	@DisplayName("when not configured correctly")
 	class MisconfigurationTests {
 
-		@Test
+		@TestKitTest(testClass = BadConfigTestCases.class, method = "simpleTest")
 		@DisplayName("does not intercept non-parameterized tests")
-		void simpleTest() {
-			ExecutionResults results = PioneerTestKit.executeTestMethod(BadConfigTestCases.class, "simpleTest");
-
+		void simpleTest(ExecutionResults results) {
 			assertThat(results).hasSingleSucceededTest();
 		}
 
-		@Test
+		@TestKitTest(testClass = BadConfigTestCases.class, method = "overindexed", methodParameterTypes = String.class)
 		@DisplayName("throws an exception if DisableIfArgument index is too large")
-		void overindex() {
-			ExecutionResults results = PioneerTestKit
-					.executeTestMethodWithParameterTypes(BadConfigTestCases.class, "overindexed", String.class);
-
+		void overindex(ExecutionResults results) {
 			assertThat(results)
 					.hasNumberOfFailedTests(2)
 					.withExceptionInstancesOf(ExtensionConfigurationException.class)
 					.allMatch(s -> s.startsWith("Annotation has invalid index"));
 		}
 
-		@Test
+		@TestKitTest(testClass = BadConfigTestCases.class, method = "multipleTargets", methodParameterTypes = String.class)
 		@DisplayName("throws an exception if both index and name is set on DisableIfArgument")
-		void multipleTargets() {
-			ExecutionResults results = PioneerTestKit
-					.executeTestMethodWithParameterTypes(BadConfigTestCases.class, "multipleTargets", String.class);
-
+		void multipleTargets(ExecutionResults results) {
 			assertThat(results)
 					.hasSingleFailedTest()
 					.withExceptionInstanceOf(ExtensionConfigurationException.class)
@@ -146,107 +117,81 @@ class DisableIfArgumentExtensionTests {
 						"Using both name and index parameter targeting in a single @DisableIfArgument is not permitted.");
 		}
 
-		@Test
+		@TestKitTest(testClass = BadConfigTestCases.class, method = "noParameters")
 		@DisplayName("throws an exception if method has no parameters")
-		void noParameters() {
-			ExecutionResults results = PioneerTestKit.executeTestMethod(BadConfigTestCases.class, "noParameters");
-
+		void noParameters(ExecutionResults results) {
 			assertThat(results)
 					.hasSingleFailedTest()
 					.withExceptionInstanceOf(ExtensionConfigurationException.class)
 					.hasMessageContainingAll("Can't disable based on arguments", "had no parameters");
 		}
 
-		@Test
+		@TestKitTest(testClass = BadConfigTestCases.class, method = "missingInputs", methodParameterTypes = String.class)
 		@DisplayName("throws an exception if both 'matches' and 'contains' is missing for DisableIfArgument")
-		void missingValues() {
-			ExecutionResults results = PioneerTestKit
-					.executeTestMethodWithParameterTypes(BadConfigTestCases.class, "missingInputs", String.class);
-
+		void missingValues(ExecutionResults results) {
 			assertThat(results)
 					.hasNumberOfFailedTests(3)
 					.withExceptionInstancesOf(ExtensionConfigurationException.class)
 					.allMatch(("DisableIfArgument requires that either `contains` or `matches` is set.")::equals);
 		}
 
-		@Test
+		@TestKitTest(testClass = BadConfigTestCases.class, method = "missingInputsAny", methodParameterTypes = String.class)
 		@DisplayName("throws an exception if both 'matches' and 'contains' is missing for DisableIfAnyArgument")
-		void missingValuesAny() {
-			ExecutionResults results = PioneerTestKit
-					.executeTestMethodWithParameterTypes(BadConfigTestCases.class, "missingInputsAny", String.class);
-
+		void missingValuesAny(ExecutionResults results) {
 			assertThat(results)
 					.hasNumberOfFailedTests(3)
 					.withExceptionInstancesOf(ExtensionConfigurationException.class)
 					.allMatch(("DisableIfAnyArgument requires that either `contains` or `matches` is set.")::equals);
 		}
 
-		@Test
+		@TestKitTest(testClass = BadConfigTestCases.class, method = "missingInputsAll", methodParameterTypes = String.class)
 		@DisplayName("throws an exception if both 'matches' and 'contains' is missing for DisableIfAllArguments")
-		void missingValuesAll() {
-			ExecutionResults results = PioneerTestKit
-					.executeTestMethodWithParameterTypes(BadConfigTestCases.class, "missingInputsAll", String.class);
-
+		void missingValuesAll(ExecutionResults results) {
 			assertThat(results)
 					.hasNumberOfFailedTests(3)
 					.withExceptionInstancesOf(ExtensionConfigurationException.class)
 					.allMatch(("DisableIfAllArguments requires that either `contains` or `matches` is set.")::equals);
 		}
 
-		@Test
+		@TestKitTest(testClass = BadConfigTestCases.class, method = "setBothParams", methodParameterTypes = String.class)
 		@DisplayName("throws an exception if both 'matches' and 'contains' is set for DisableIfArgument")
-		void bothValuesSet() {
-			ExecutionResults results = PioneerTestKit
-					.executeTestMethodWithParameterTypes(BadConfigTestCases.class, "setBothParams", String.class);
-
+		void bothValuesSet(ExecutionResults results) {
 			assertThat(results)
 					.hasNumberOfFailedTests(3)
 					.withExceptionInstancesOf(ExtensionConfigurationException.class)
 					.allMatch(("DisableIfArgument requires that either `contains` or `matches` is set.")::equals);
 		}
 
-		@Test
+		@TestKitTest(testClass = BadConfigTestCases.class, method = "setBothParamsAny", methodParameterTypes = String.class)
 		@DisplayName("throws an exception if both 'matches' and 'contains' is set for DisableIfAnyArgument")
-		void bothValuesSetAny() {
-			ExecutionResults results = PioneerTestKit
-					.executeTestMethodWithParameterTypes(BadConfigTestCases.class, "setBothParamsAny", String.class);
-
+		void bothValuesSetAny(ExecutionResults results) {
 			assertThat(results)
 					.hasNumberOfFailedTests(3)
 					.withExceptionInstancesOf(ExtensionConfigurationException.class)
 					.allMatch(("DisableIfAnyArgument requires that either `contains` or `matches` is set.")::equals);
 		}
 
-		@Test
+		@TestKitTest(testClass = BadConfigTestCases.class, method = "setBothParamsAll", methodParameterTypes = String.class)
 		@DisplayName("throws an exception if both 'matches' and 'contains' is set for DisableIfAllArguments")
-		void bothValuesSetAll() {
-			ExecutionResults results = PioneerTestKit
-					.executeTestMethodWithParameterTypes(BadConfigTestCases.class, "setBothParamsAll", String.class);
-
+		void bothValuesSetAll(ExecutionResults results) {
 			assertThat(results)
 					.hasNumberOfFailedTests(3)
 					.withExceptionInstancesOf(ExtensionConfigurationException.class)
 					.allMatch(("DisableIfAllArguments requires that either `contains` or `matches` is set.")::equals);
 		}
 
-		@Test
+		@TestKitTest(testClass = BadConfigTestCases.class, method = "badlyNamedParam", methodParameterTypes = String.class)
 		@DisplayName("throws an exception if it can not find the parameter based on the given name for DisableIfArgument")
-		void missingParameter() {
-			ExecutionResults results = PioneerTestKit
-					.executeTestMethodWithParameterTypes(BadConfigTestCases.class, "badlyNamedParam", String.class);
-
+		void missingParameter(ExecutionResults results) {
 			assertThat(results)
 					.hasNumberOfFailedTests(3)
 					.withExceptions()
 					.allMatch(s -> s.contains("Could not resolve parameter"));
 		}
 
-		@Test
+		@TestKitTest(testClass = BadConfigTestCases.class, method = "forced", methodParameterTypes = String.class)
 		@DisplayName("does not work without required annotation(s)")
-		void forcedExtension() {
-			ExecutionResults results = PioneerTestKit
-					.executeTestMethodWithParameterTypes(BadConfigTestCases.class, "forced", String.class);
-
+		void forcedExtension(ExecutionResults results) {
 			assertThat(results)
 					.hasSingleFailedTest()
 					.withExceptionInstanceOf(ExtensionConfigurationException.class)

--- a/src/test/java/org/junitpioneer/testkit/PioneerTestKitExtension.java
+++ b/src/test/java/org/junitpioneer/testkit/PioneerTestKitExtension.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2016-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junitpioneer.testkit;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.platform.commons.PreconditionViolationException;
+import org.junit.platform.commons.support.AnnotationSupport;
+
+class PioneerTestKitExtension implements ParameterResolver {
+
+	@Override
+	public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+			throws ParameterResolutionException {
+		return parameterContext.getParameter().getType().equals(ExecutionResults.class);
+	}
+
+	@Override
+	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+			throws ParameterResolutionException {
+		Optional<TestKitTest> annotation = AnnotationSupport
+				.findAnnotation(extensionContext.getTestMethod(), TestKitTest.class);
+		if (annotation.isPresent()) {
+			TestKitTest pioneerTest = annotation.get();
+			Class<?> testClass = pioneerTest.testClass();
+			String method = pioneerTest.method();
+			Class<?>[] methodParameterTypes = pioneerTest.methodParameterTypes();
+			if (methodParameterTypes.length > 0) {
+				if (method.isEmpty()) {
+					throw new PreconditionViolationException(
+						"Test method name has to be defined when method parameter types are defined");
+				}
+				return PioneerTestKit.executeTestMethodWithParameterTypes(testClass, method, methodParameterTypes);
+			} else if (!method.isEmpty()) {
+				return PioneerTestKit.executeTestMethod(testClass, method);
+			} else {
+				return PioneerTestKit.executeTestClass(testClass);
+			}
+		}
+		throw new ParameterResolutionException("Failed to resolve parameter because TestKitTest is missing");
+	}
+
+}

--- a/src/test/java/org/junitpioneer/testkit/TestKitTest.java
+++ b/src/test/java/org/junitpioneer/testkit/TestKitTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junitpioneer.testkit;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * A test which executes tests using {@link PioneerTestKit} with the provided arguments.
+ */
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Test
+@ExtendWith(PioneerTestKitExtension.class)
+public @interface TestKitTest {
+
+	/**
+	 * The class that should be run.
+	 */
+	Class<?> testClass();
+
+	/**
+	 * The test method name that should be run.
+	 * If not set then the entire class will be run through {@link PioneerTestKit#executeTestClass(Class)}
+	 * otherwise {@link PioneerTestKit#executeTestMethod(Class, String)} or {@link PioneerTestKit#executeTestMethodWithParameterTypes(Class, String, Class[])}
+	 */
+	String method() default "";
+
+	/**
+	 * The method parameter types that should be used for {@link PioneerTestKit#executeTestMethodWithParameterTypes(Class, String, Class[])}.
+	 * If this is set then {@link #method()} has to be set as well.
+	 */
+	Class<?>[] methodParameterTypes() default {};
+
+}


### PR DESCRIPTION
This is a potential idea for making it simpler (in my eyes) the execution of `PioneerTestKit` tests.

before:

```java
@Test
@WritesDefaultLocale
@DisplayName("should execute tests with configured Locale")
void shouldExecuteTestsWithConfiguredLocale() {
    ExecutionResults results = executeTestClass(ClassLevelTestCase.class);

    assertThat(results).hasNumberOfSucceededTests(2);
}
```

after:

```java
@TestKitTest(testClass = ClassLevelTestCase.class)
@WritesDefaultLocale
@DisplayName("should execute tests with configured Locale")
void shouldExecuteTestsWithConfiguredLocale(ExecutionResults results) {
    assertThat(results).hasNumberOfSucceededTests(2);
}
```

It also allows running a specific method and passing additional parameters. If you think that this is something interesting for the Pioneer test suite, I can go ahead and add tests for the `@TestKitTest` annotation and also adapt the rest of the suite.


Proposed commit message:

```
${action} (${issues} / ${pull-request}) [max 70 characters]

${body} [max 70 characters per line]

${references}: ${issues}
PR: ${pull-request}
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [ ] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
