### PR TITLE
Remove unnecessary words in Javadoc

### DIFF
--- a/src/main/java/org/junitpioneer/jupiter/ClearEnvironmentVariable.java
+++ b/src/main/java/org/junitpioneer/jupiter/ClearEnvironmentVariable.java
@@ -23,9 +23,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * {@code @ClearEnvironmentVariable} is a JUnit Jupiter extension to clear the value
  * of a environment variable for a test execution.
  *
- * <p>The key of the environment variable to be cleared must be specified via
- * {@link #key()}. After the annotated element has been executed, After the
- * annotated method has been executed, the initial default value is restored.</p>
+ * <p>The key of the environment variable to be cleared must be specified via {@link #key()}.
+ * After the annotated element has been executed, the initial default value is restored.</p>
  *
  * <p>{@code ClearEnvironmentVariable} is repeatable and can be used on the method and
  * on the class level. If a class is annotated, the configured variable will be

--- a/src/main/java/org/junitpioneer/jupiter/ClearSystemProperty.java
+++ b/src/main/java/org/junitpioneer/jupiter/ClearSystemProperty.java
@@ -23,9 +23,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * {@code @ClearSystemProperty} is a JUnit Jupiter extension to clear the value
  * of a system property for a test execution.
  *
- * <p>The key of the system property to be cleared must be specified via
- * {@link #key()}. After the annotated element has been executed, After the
- * annotated method has been executed, the initial default value is restored.</p>
+ * <p>The key of the system property to be cleared must be specified via {@link #key()}.
+ * After the annotated element has been executed, the initial default value is restored.</p>
  *
  * <p>{@code ClearSystemProperty} is repeatable and can be used on the method and
  * on the class level. If a class is annotated, the configured property will be


### PR DESCRIPTION
Just trivial changes in Javadoc comments.

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
