### PR TITLE
Update JUnit versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,7 +128,7 @@ jobs:
     strategy:
       matrix:
         java: [ 8, 11, 16 ]
-        junit-version: [ '5.7.0', '5.7.1', '5.8.0-M1' ]
+        junit-version: [ '5.7.0', '5.7.2', '5.8.0-RC1' ]
         modular: [true, false]
         os: [ubuntu, macos, windows]
         exclude:

--- a/src/test/java/org/junitpioneer/jupiter/issue/IssueExtensionExecutionListenerTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/issue/IssueExtensionExecutionListenerTests.java
@@ -14,8 +14,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junitpioneer.jupiter.issue.IssueExtensionExecutionListener.REPORT_ENTRY_KEY;
 import static org.junitpioneer.jupiter.issue.TestPlanHelper.createTestIdentifier;
+import static org.mockito.Mockito.mock;
 
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -35,7 +35,9 @@ public class IssueExtensionExecutionListenerTests {
 	// when debugging, be aware that the service loader also created instances of the listener;
 	// we can't use it here, because the running Jupiter instance uses it to gather test information
 	private final IssueExtensionExecutionListener executionListener = new IssueExtensionExecutionListener();
-	private final TestPlan testPlan = TestPlan.from(Collections.emptyList());
+	// TestPlan only offers a single public but internal factory method that changed in JUnit v5.8.0-RC1
+	// since we test with multiple JUnit versions, we mock this class to circumvent the problem of creating it
+	private final TestPlan testPlan = mock(TestPlan.class);
 
 	@Test
 	void noIssueTestCasesCreated() {


### PR DESCRIPTION
Closes #512.

Proposed commit message:

```
Update JUnit versions in build matrix (#512 / #511)

As of today, 5.7.2 is the latest stable and 5.8.0-RC1 the latest
non-stable version.

Closes: #512
PR: #511
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
