### PR TITLE
Decouple CartesianArgumentsProvider from the Jupiter Arguments Provider

### DIFF
--- a/src/main/java/org/junitpioneer/internal/PioneerAnnotationConsumerInitializer.java
+++ b/src/main/java/org/junitpioneer/internal/PioneerAnnotationConsumerInitializer.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junitpioneer.internal;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.params.support.AnnotationConsumer;
+import org.junit.platform.commons.JUnitException;
+import org.junit.platform.commons.support.HierarchyTraversalMode;
+import org.junit.platform.commons.support.ReflectionSupport;
+
+/**
+ * This is a slight copy of the Jupiter's {@link org.junit.jupiter.params.support.AnnotationConsumerInitializer AnnotationConsumerInitializer}
+ * except that it does not lookup the consumed annotation, but it used the
+ * {@code AnnotationConsumerInitializer} is an internal helper class for
+ * initializing {@link AnnotationConsumer AnnotationConsumers}.
+ *
+ */
+public final class PioneerAnnotationConsumerInitializer {
+
+	// @formatter:off
+	private static final Predicate<Method> isAnnotationConsumerAcceptMethod = method ->
+			method.getName().equals("accept")
+			&& method.getParameterCount() == 1
+			&& method.getParameterTypes()[0].isAnnotation();
+	// @formatter:on
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public static <T> T initialize(Annotation annotation, T instance) {
+		if (instance instanceof AnnotationConsumer) {
+			Method method = ReflectionSupport
+					.findMethods(instance.getClass(), isAnnotationConsumerAcceptMethod,
+						HierarchyTraversalMode.BOTTOM_UP)
+					.get(0);
+			Class<? extends Annotation> annotationType = (Class<? extends Annotation>) method.getParameterTypes()[0];
+			if (annotationType.isInstance(annotation)) {
+				initializeAnnotationConsumer((AnnotationConsumer) instance, annotation);
+			} else {
+				throw new JUnitException(instance.getClass().getName() + " must be used with an annotation of type "
+						+ annotationType.getName());
+			}
+		}
+		return instance;
+	}
+
+	private static <A extends Annotation> void initializeAnnotationConsumer(AnnotationConsumer<A> instance,
+			A annotation) {
+		try {
+			instance.accept(annotation);
+		}
+		catch (Exception ex) {
+			throw new JUnitException("Failed to initialize AnnotationConsumer: " + instance, ex);
+		}
+	}
+
+}

--- a/src/main/java/org/junitpioneer/internal/PioneerAnnotationUtils.java
+++ b/src/main/java/org/junitpioneer/internal/PioneerAnnotationUtils.java
@@ -16,6 +16,7 @@ import java.lang.annotation.Repeatable;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -27,6 +28,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.platform.commons.support.AnnotationSupport;
+import org.junitpioneer.jupiter.cartesian.CartesianArgumentsSource;
 
 /**
  * Pioneer-internal utility class to handle annotations.
@@ -257,12 +259,19 @@ public class PioneerAnnotationUtils {
 	}
 
 	public static List<? extends Annotation> findParameterArgumentsSources(Method testMethod) {
-		return Arrays
-				.stream(testMethod.getParameters())
-				.map(parameter -> PioneerAnnotationUtils.findAnnotatedAnnotations(parameter, ArgumentsSource.class))
+		//@formatter:off
+		return Arrays.stream(testMethod.getParameters())
+				.map(parameter -> {
+					List<Annotation> annotations = new ArrayList<>();
+					annotations
+							.addAll(PioneerAnnotationUtils.findAnnotatedAnnotations(parameter, CartesianArgumentsSource.class));
+					annotations.addAll(PioneerAnnotationUtils.findAnnotatedAnnotations(parameter, ArgumentsSource.class));
+					return annotations;
+				})
 				.filter(list -> !list.isEmpty())
 				.map(annotations -> annotations.get(0))
 				.collect(Collectors.toList());
+		//@formatter:on
 	}
 
 }

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianArgumentsProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianArgumentsProvider.java
@@ -11,20 +11,29 @@
 package org.junitpioneer.jupiter.cartesian;
 
 import java.lang.reflect.Parameter;
+import java.util.stream.Stream;
 
-import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
 
 /**
  * If you are implementing an {@link org.junit.jupiter.params.provider.ArgumentsProvider ArgumentsProvider}
- * for {@link CartesianTest}, it has to implement this interface <b>instead</b> to know which parameter it provides
+ * for {@link CartesianTest}, it has to implement this interface <b>as well</b> to know which parameter it provides
  * arguments to. For more information, see
  * <a href="https://junit-pioneer.org/docs/cartesian-product/" target="_top">the Cartesian product documentation</a>.
  *
  * @see org.junit.jupiter.params.provider.ArgumentsProvider
  * @see CartesianTestExtension
  */
-public interface CartesianArgumentsProvider extends ArgumentsProvider {
+public interface CartesianArgumentsProvider {
 
-	void accept(Parameter parameter);
+	/**
+	 * Provider a {@link Stream} of {@link Arguments} that needs to be used for the {@code @CartesianTest}.
+	 *
+	 * @param context the current extension context; never {@code null}
+	 * @param parameter the parameter for which the arguments needs to be provided
+	 * @return a stream of arguments; never {@code null}
+	 */
+	Stream<? extends Arguments> provideArguments(ExtensionContext context, Parameter parameter) throws Exception;
 
 }

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianArgumentsSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianArgumentsSource.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junitpioneer.jupiter.cartesian;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * {@code @CartesianArgumentsSource} is an annotation
+ * that is used to register {@linkplain CartesianArgumentsProvider cartesian argument providers}
+ * for the annotated test parameter.
+ *
+ * <p>{@code @CartesianArgumentsSource} may also be used as a meta-annotation in order to
+ * create a custom <em>composed annotation</em> that inherits the semantics
+ * of {@code @CartesianArgumentsSource}.
+ *
+ * This is similar to {@link org.junit.jupiter.params.provider.ArgumentsSource ArgumentsSource} and is used
+ * to provide arguments for {@link CartesianTest}.
+ *
+ * @see CartesianTest
+ */
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface CartesianArgumentsSource {
+
+	/**
+	 * The type of {@link CartesianArgumentsProvider} to be used.
+	 */
+	Class<? extends CartesianArgumentsProvider> value();
+
+}

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianEnumArgumentsProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianEnumArgumentsProvider.java
@@ -25,31 +25,27 @@ import org.junit.platform.commons.support.AnnotationSupport;
 
 /**
  * This is basically an enhanced copy of Jupiter's {@code EnumArgumentsProvider},
- * except it does NOT support {@code @ParameterizedTest} and consumes a {@code Parameter}
- * instead of an annotation.
+ * except it does NOT support {@code @ParameterizedTest} and implements {@link CartesianArgumentsProvider}
+ * for use with {@code @CartesianTest}.
+ * <p>
+ * This class does not implement {@code ArgumentsProvider} since the Jupiter's {@code EnumSource} should be used for that.
  */
 class CartesianEnumArgumentsProvider implements CartesianArgumentsProvider {
 
-	private CartesianTest.Enum enumSource;
-	private Class<?> parameterType;
-
 	@Override
-	public void accept(Parameter parameter) {
-		this.parameterType = parameter.getType();
-		if (!Enum.class.isAssignableFrom(this.parameterType))
+	public Stream<? extends Arguments> provideArguments(ExtensionContext context, Parameter parameter) {
+		Class<?> parameterType = parameter.getType();
+		if (!Enum.class.isAssignableFrom(parameterType))
 			throw new PreconditionViolationException(String
 					.format(
 						"Parameter of type %s must reference an Enum type (alternatively, use the annotation's 'value' attribute to specify the type explicitly)",
-						this.parameterType));
-		this.enumSource = AnnotationSupport
+						parameterType));
+		CartesianTest.Enum enumSource = AnnotationSupport
 				.findAnnotation(parameter, CartesianTest.Enum.class)
 				.orElseThrow(() -> new PreconditionViolationException(
 					"Parameter has to be annotated with " + CartesianTest.Enum.class.getName()));
-	}
 
-	@Override
-	public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-		Set<? extends Enum<?>> constants = getEnumConstants();
+		Set<? extends Enum<?>> constants = getEnumConstants(enumSource, parameterType);
 		CartesianTest.Enum.Mode mode = enumSource.mode();
 		String[] declaredConstantNames = enumSource.names();
 		if (declaredConstantNames.length > 0) {
@@ -63,16 +59,17 @@ class CartesianEnumArgumentsProvider implements CartesianArgumentsProvider {
 		return constants.stream().map(Arguments::of);
 	}
 
-	private <E extends Enum<E>> Set<? extends E> getEnumConstants() {
-		Class<E> enumClass = determineEnumClass();
+	private <E extends Enum<E>> Set<? extends E> getEnumConstants(CartesianTest.Enum enumSource,
+			Class<?> parameterType) {
+		Class<E> enumClass = determineEnumClass(enumSource, parameterType);
 		return EnumSet.allOf(enumClass);
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
-	private <E extends Enum<E>> Class<E> determineEnumClass() {
+	private <E extends Enum<E>> Class<E> determineEnumClass(CartesianTest.Enum enumSource, Class<?> parameterType) {
 		Class enumClass = enumSource.value();
 		if (enumClass.equals(NullEnum.class)) {
-			enumClass = this.parameterType;
+			enumClass = parameterType;
 		}
 		return enumClass;
 	}

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianTest.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianTest.java
@@ -24,7 +24,6 @@ import java.util.regex.PatternSyntaxException;
 
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.platform.commons.PreconditionViolationException;
 import org.junitpioneer.jupiter.cartesian.CartesianEnumArgumentsProvider.NullEnum;
 
@@ -85,7 +84,7 @@ public @interface CartesianTest {
 
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target({ ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
-	@ArgumentsSource(CartesianValueArgumentsProvider.class)
+	@CartesianArgumentsSource(CartesianValueArgumentsProvider.class)
 	@interface Values {
 
 		/**
@@ -142,7 +141,7 @@ public @interface CartesianTest {
 
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target({ ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
-	@ArgumentsSource(CartesianEnumArgumentsProvider.class)
+	@CartesianArgumentsSource(CartesianEnumArgumentsProvider.class)
 	@interface Enum {
 
 		/**

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtension.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Parameter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.AnnotationConsumerInitializer;
 import org.junit.platform.commons.PreconditionViolationException;
 import org.junit.platform.commons.support.AnnotationSupport;
 import org.junit.platform.commons.support.ReflectionSupport;
@@ -89,7 +91,7 @@ class CartesianTestExtension implements TestTemplateInvocationContextProvider {
 
 	private List<Object> getSetFromAnnotation(ExtensionContext context, Annotation source, Parameter parameter) {
 		try {
-			CartesianArgumentsProvider provider = initializeArgumentsProvider(source);
+			CartesianArgumentsProvider provider = initializeArgumentsProvider(source, parameter);
 			return provideArguments(context, parameter, provider);
 		}
 		catch (Exception ex) {
@@ -97,15 +99,24 @@ class CartesianTestExtension implements TestTemplateInvocationContextProvider {
 		}
 	}
 
-	private CartesianArgumentsProvider initializeArgumentsProvider(Annotation source) {
+	private CartesianArgumentsProvider initializeArgumentsProvider(Annotation source, Parameter parameter) {
+		Optional<CartesianArgumentsSource> cartesianProviderAnnotation = AnnotationSupport
+				.findAnnotation(source.annotationType(), CartesianArgumentsSource.class);
+
+		if (cartesianProviderAnnotation.isPresent()) {
+			return AnnotationConsumerInitializer
+					.initialize(parameter, ReflectionSupport.newInstance(cartesianProviderAnnotation.get().value()));
+		}
+
 		ArgumentsSource providerAnnotation = AnnotationSupport
 				.findAnnotation(source.annotationType(), ArgumentsSource.class)
 				// never happens, we already know these annotations are annotated with @ArgumentsSource
 				.orElseThrow(() -> new PreconditionViolationException(format(
-					"%s was not annotated with @ArgumentsSource but should have been.", source.annotationType())));
+					"%s was not annotated with @CartesianArgumentsSource or @ArgumentsSource but should have been.",
+					source.annotationType())));
 		ArgumentsProvider provider = ReflectionSupport.newInstance(providerAnnotation.value());
 		if (provider instanceof CartesianArgumentsProvider)
-			return (CartesianArgumentsProvider) provider;
+			return AnnotationConsumerInitializer.initialize(parameter, (CartesianArgumentsProvider) provider);
 		else
 			throw new PreconditionViolationException(
 				format("%s does not implement the CartesianArgumentsProvider interface.", provider.getClass()));
@@ -113,9 +124,8 @@ class CartesianTestExtension implements TestTemplateInvocationContextProvider {
 
 	private List<Object> provideArguments(ExtensionContext context, Parameter source,
 			CartesianArgumentsProvider provider) throws Exception {
-		provider.accept(source);
 		return provider
-				.provideArguments(context)
+				.provideArguments(context, source)
 				.map(Arguments::get)
 				.flatMap(Arrays::stream)
 				.distinct()

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianValueArgumentsProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianValueArgumentsProvider.java
@@ -14,25 +14,30 @@ import static java.util.stream.Collectors.toList;
 
 import java.lang.reflect.Array;
 import java.lang.reflect.Parameter;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.support.AnnotationConsumer;
 import org.junit.platform.commons.PreconditionViolationException;
 import org.junit.platform.commons.support.AnnotationSupport;
 
 /**
- * This is a slightly modified copy of Jupiter's {@code ValueSourceArgumentsProvider},
- * except it does NOT support {@code @ParameterizedTest} and can consume a {@code Parameter}
- * instead of an annotation.
+ * This is a slightly modified copy of Jupiter's {@code ValueArgumentsProvider},
+ * except it does NOT support {@code @ParameterizedTest} and implements {@link CartesianArgumentsProvider}
+ * for use with {@code @CartesianTest}.
+ * <p>
+ * This class does not implement {@code ArgumentsProvider} since the Jupiter's {@code ValueSource} should be used for that.
  */
-class CartesianValueArgumentsProvider implements CartesianArgumentsProvider {
+class CartesianValueArgumentsProvider implements CartesianArgumentsProvider, AnnotationConsumer<CartesianTest.Values> {
 
 	private Object[] arguments;
 
-	private void getArgumentsFromAnnotation(CartesianTest.Values source) {
+	@Override
+	public void accept(CartesianTest.Values source) {
 		// @formatter:off
 		List<Object> arrays =
 				// Declaration of <Object> is necessary due to a bug in Eclipse Photon.
@@ -64,17 +69,8 @@ class CartesianValueArgumentsProvider implements CartesianArgumentsProvider {
 	}
 
 	@Override
-	public void accept(Parameter parameter) {
-		CartesianTest.Values source = AnnotationSupport
-				.findAnnotation(parameter, CartesianTest.Values.class)
-				.orElseThrow(() -> new PreconditionViolationException(
-					"Parameter has to be annotated with " + CartesianTest.Values.class.getName()));
-		getArgumentsFromAnnotation(source);
-	}
-
-	@Override
-	public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
-		return Stream.of(Arguments.of(arguments));
+	public Stream<? extends Arguments> provideArguments(ExtensionContext context, Parameter parameter) {
+		return Arrays.stream(arguments).map(Arguments::of);
 	}
 
 }

--- a/src/main/java/org/junitpioneer/jupiter/params/RangeSourceArgumentsProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/RangeSourceArgumentsProvider.java
@@ -50,11 +50,24 @@ class RangeSourceArgumentsProvider
 	private Annotation argumentsSource;
 
 	@Override
+	public Stream<? extends Arguments> provideArguments(ExtensionContext context, Parameter parameter)
+			throws Exception {
+		initArgumentsSource(parameter);
+		return provideArguments(context, argumentsSource);
+	}
+
+	@Override
 	public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
 		// argumentSource is present if fed through the CartesianAnnotationConsumer interface
 		if (argumentsSource == null)
 			// since it's a method annotation, the element will always be present
 			initArgumentsSource(context.getRequiredTestMethod());
+
+		return provideArguments(context, argumentsSource);
+	}
+
+	private Stream<? extends Arguments> provideArguments(ExtensionContext context, Annotation argumentsSource)
+			throws Exception {
 		Class<? extends Annotation> argumentsSourceClass = argumentsSource.annotationType();
 		Class<? extends Range> rangeClass = argumentsSourceClass.getAnnotation(RangeClass.class).value();
 
@@ -84,11 +97,6 @@ class RangeSourceArgumentsProvider
 	@Override
 	public void accept(Annotation argumentsSource) {
 		this.argumentsSource = argumentsSource;
-	}
-
-	@Override
-	public void accept(Parameter parameter) {
-		initArgumentsSource(parameter);
 	}
 
 }

--- a/src/test/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtensionTests.java
@@ -405,7 +405,7 @@ public class CartesianTestExtensionTests {
 					.hasSingleFailedContainer()
 					.withExceptionInstanceOf(ExtensionConfigurationException.class)
 					.hasMessageContaining("Could not provide arguments")
-					.hasCauseExactlyInstanceOf(PreconditionViolationException.class);
+					.hasRootCauseExactlyInstanceOf(PreconditionViolationException.class);
 		}
 
 		@Test


### PR DESCRIPTION
As I mentioned in the last stream (2nd of September). I had some ideas about decoupling the CartesianArgumentsProvider from the ArgumentsProvider. With this PR I am showcasing my idea.

The goal is to support both ArgumentsProvider. There is a new `@CartesianArgumentsSource` that would allow users to write custom `CartesianArgumentsProvider` by using it directly on parameters (the `@ArgumentsSource` does not allow this).

Proposed commit message:

```
Decouple CartesianArgumentsProvider from the Jupiter Arguments Provider (${issues} / ${pull-request}) [max 70 characters]

The CartesianArgumentsProvider supports the Jupiter AnnotationConsumer interface.
The CartesianArgumentsProvider has a method for providing arguments 
that accepts the ExtensionContext and the Parameter for which it provides arguments.


${references}: ${issues}
PR: ${pull-request}
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [ ] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
