### PR TITLE
Add JUnit 5.8 to build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
     strategy:
       matrix:
         java: [ 8, 11, 16 ]
-        junit-version: [ '5.7.2', '5.8.0-RC1' ]
+        junit-version: [ '5.7.2', '5.8.1' ]
         modular: [true, false]
         os: [ubuntu, macos, windows]
         exclude:
@@ -150,7 +150,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        junit-version: [ '5.7.0', '5.7.1', '5.8.0-M1' ]
+        junit-version: [ '5.7.2', '5.8.1' ]
         modular: [true, false]
         os: [ubuntu, macos, windows]
     name: Experimental build with newest JDK early-access build and Gradle release candidate

--- a/src/test/java/org/junitpioneer/internal/TestExtensionContext.java
+++ b/src/test/java/org/junitpioneer/internal/TestExtensionContext.java
@@ -20,7 +20,16 @@ import java.util.function.Function;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestInstances;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
+/**
+ * Rudimentary implementation of an {@link ExtensionContext} that
+ * returns a {@link Class} and {@link Method} that were specified
+ * during construction.
+ *
+ * Best used to text annotation discovery mechanisms that expect an
+ * {@code ExtensionContext} as input.
+ */
 public class TestExtensionContext implements ExtensionContext {
 
 	private static final UnsupportedOperationException NOT_SUPPORTED_IN_TEST_CONTEXT = new UnsupportedOperationException(
@@ -31,6 +40,11 @@ public class TestExtensionContext implements ExtensionContext {
 	public TestExtensionContext(Class<?> testClass, Method testMethod) {
 		this.testClass = testClass;
 		this.testMethod = testMethod;
+	}
+
+	// @Override once we baseline against 5.8
+	public ExecutionMode getExecutionMode() {
+		throw NOT_SUPPORTED_IN_TEST_CONTEXT;
 	}
 
 	@Override


### PR DESCRIPTION
Proposed commit message:

```
Add JUnit 5.8 to build matrix

Jupiter 5.8 added the method `getExecutionMode` to the interface
`ExtensionContext`. This change adds that method to our
implementation `TestExtensionContext` - it just throws an exception.
Once we require 5.8+, we can add the `@Override` annotation to it.

PR: ${pull-request}
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [ ] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
