### PR TITLE
Support for array arguments in `@CartesianTest`

### DIFF
--- a/docs/cartesian-product.adoc
+++ b/docs/cartesian-product.adoc
@@ -346,9 +346,9 @@ import org.junitpioneer.jupiter.cartesian.CartesianArgumentsProvider;
 class IntArgumentsProvider implements CartesianArgumentsProvider {
 
 	@Override
-	public Stream<? extends Arguments> provideArguments(ExtensionContext context, Parameter parameter) {
+	public Stream<Integer> provideArguments(ExtensionContext context, Parameter parameter) {
 		Ints source = Objects.requireNonNull(parameter.getAnnotation(Ints.class));
-		return Arrays.stream(source.value()).map(Arguments::of);
+		return Arrays.stream(source.value());
 	}
 
 }
@@ -386,11 +386,10 @@ import org.junitpioneer.jupiter.cartesian.CartesianArgumentsProvider;
 class PeopleProvider implements CartesianArgumentsProvider {
 
 	@Override
-public Stream<? extends Arguments> provideArguments(ExtensionContext context, Parameter parameter) {
+public Stream<Person> provideArguments(ExtensionContext context, Parameter parameter) {
 		People source = Objects.requireNonNull(parameter.getAnnotation(People.class));
 	return IntStream.range(0, source.names().length)
-		.mapToObj(i -> new Person(source.names()[i], source.ages()[i]))
-		.map(Arguments::of);
+		.mapToObj(i -> new Person(source.names()[i], source.ages()[i]));
 	}
 }
 ----

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianArgumentsProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianArgumentsProvider.java
@@ -21,10 +21,12 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  * arguments to. For more information, see
  * <a href="https://junit-pioneer.org/docs/cartesian-product/" target="_top">the Cartesian product documentation</a>.
  *
+ * @param <T> type of arguments this provider returns
+ *
  * @see org.junit.jupiter.params.provider.ArgumentsProvider
  * @see CartesianTestExtension
  */
-public interface CartesianArgumentsProvider {
+public interface CartesianArgumentsProvider<T> {
 
 	/**
 	 * Provider a {@link Stream} of values that needs to be used for a single parameter in {@code @CartesianTest}.
@@ -33,6 +35,6 @@ public interface CartesianArgumentsProvider {
 	 * @param parameter the parameter for which the arguments needs to be provided
 	 * @return a stream of values; never {@code null}
 	 */
-	Stream<?> provideArguments(ExtensionContext context, Parameter parameter) throws Exception;
+	Stream<T> provideArguments(ExtensionContext context, Parameter parameter) throws Exception;
 
 }

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianArgumentsProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianArgumentsProvider.java
@@ -14,7 +14,6 @@ import java.lang.reflect.Parameter;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.params.provider.Arguments;
 
 /**
  * If you are implementing an {@link org.junit.jupiter.params.provider.ArgumentsProvider ArgumentsProvider}
@@ -28,12 +27,12 @@ import org.junit.jupiter.params.provider.Arguments;
 public interface CartesianArgumentsProvider {
 
 	/**
-	 * Provider a {@link Stream} of {@link Arguments} that needs to be used for the {@code @CartesianTest}.
+	 * Provider a {@link Stream} of values that needs to be used for a single parameter in {@code @CartesianTest}.
 	 *
 	 * @param context the current extension context; never {@code null}
 	 * @param parameter the parameter for which the arguments needs to be provided
-	 * @return a stream of arguments; never {@code null}
+	 * @return a stream of values; never {@code null}
 	 */
-	Stream<? extends Arguments> provideArguments(ExtensionContext context, Parameter parameter) throws Exception;
+	Stream<?> provideArguments(ExtensionContext context, Parameter parameter) throws Exception;
 
 }

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianEnumArgumentsProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianEnumArgumentsProvider.java
@@ -30,7 +30,7 @@ import org.junit.platform.commons.support.AnnotationSupport;
  * @implNote This class does not implement {@code ArgumentsProvider} since the Jupiter's {@code EnumSource}
  * should be used for that.
  */
-class CartesianEnumArgumentsProvider<E extends Enum<E>> implements CartesianArgumentsProvider {
+class CartesianEnumArgumentsProvider<E extends Enum<E>> implements CartesianArgumentsProvider<E> {
 
 	@Override
 	public Stream<E> provideArguments(ExtensionContext context, Parameter parameter) {
@@ -59,8 +59,7 @@ class CartesianEnumArgumentsProvider<E extends Enum<E>> implements CartesianArgu
 		return constants.stream();
 	}
 
-	private Set<E> getEnumConstants(CartesianTest.Enum enumSource,
-			Class<?> parameterType) {
+	private Set<E> getEnumConstants(CartesianTest.Enum enumSource, Class<?> parameterType) {
 		Class<E> enumClass = determineEnumClass(enumSource, parameterType);
 		return EnumSet.allOf(enumClass);
 	}

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianEnumArgumentsProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianEnumArgumentsProvider.java
@@ -30,10 +30,10 @@ import org.junit.platform.commons.support.AnnotationSupport;
  * @implNote This class does not implement {@code ArgumentsProvider} since the Jupiter's {@code EnumSource}
  * should be used for that.
  */
-class CartesianEnumArgumentsProvider implements CartesianArgumentsProvider {
+class CartesianEnumArgumentsProvider<E extends Enum<E>> implements CartesianArgumentsProvider {
 
 	@Override
-	public Stream<? extends Enum<?>> provideArguments(ExtensionContext context, Parameter parameter) {
+	public Stream<E> provideArguments(ExtensionContext context, Parameter parameter) {
 		Class<?> parameterType = parameter.getType();
 		if (!Enum.class.isAssignableFrom(parameterType))
 			throw new PreconditionViolationException(String
@@ -45,7 +45,7 @@ class CartesianEnumArgumentsProvider implements CartesianArgumentsProvider {
 				.orElseThrow(() -> new PreconditionViolationException(
 					"Parameter has to be annotated with " + CartesianTest.Enum.class.getName()));
 
-		Set<? extends Enum<?>> constants = getEnumConstants(enumSource, parameterType);
+		Set<E> constants = getEnumConstants(enumSource, parameterType);
 		CartesianTest.Enum.Mode mode = enumSource.mode();
 		String[] declaredConstantNames = enumSource.names();
 		if (declaredConstantNames.length > 0) {
@@ -59,14 +59,14 @@ class CartesianEnumArgumentsProvider implements CartesianArgumentsProvider {
 		return constants.stream();
 	}
 
-	private <E extends Enum<E>> Set<? extends E> getEnumConstants(CartesianTest.Enum enumSource,
+	private Set<E> getEnumConstants(CartesianTest.Enum enumSource,
 			Class<?> parameterType) {
 		Class<E> enumClass = determineEnumClass(enumSource, parameterType);
 		return EnumSet.allOf(enumClass);
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
-	private <E extends Enum<E>> Class<E> determineEnumClass(CartesianTest.Enum enumSource, Class<?> parameterType) {
+	private Class<E> determineEnumClass(CartesianTest.Enum enumSource, Class<?> parameterType) {
 		Class enumClass = enumSource.value();
 		if (enumClass.equals(NullEnum.class)) {
 			enumClass = parameterType;

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianEnumArgumentsProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianEnumArgumentsProvider.java
@@ -19,7 +19,6 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.platform.commons.PreconditionViolationException;
 import org.junit.platform.commons.support.AnnotationSupport;
 
@@ -34,7 +33,7 @@ import org.junit.platform.commons.support.AnnotationSupport;
 class CartesianEnumArgumentsProvider implements CartesianArgumentsProvider {
 
 	@Override
-	public Stream<? extends Arguments> provideArguments(ExtensionContext context, Parameter parameter) {
+	public Stream<? extends Enum<?>> provideArguments(ExtensionContext context, Parameter parameter) {
 		Class<?> parameterType = parameter.getType();
 		if (!Enum.class.isAssignableFrom(parameterType))
 			throw new PreconditionViolationException(String
@@ -57,7 +56,7 @@ class CartesianEnumArgumentsProvider implements CartesianArgumentsProvider {
 			mode.validate(enumSource, constants, uniqueNames);
 			constants.removeIf(constant -> !mode.select(constant, uniqueNames));
 		}
-		return constants.stream().map(Arguments::of);
+		return constants.stream();
 	}
 
 	private <E extends Enum<E>> Set<? extends E> getEnumConstants(CartesianTest.Enum enumSource,

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtension.java
@@ -90,7 +90,7 @@ class CartesianTestExtension implements TestTemplateInvocationContextProvider {
 
 	private List<?> getSetFromAnnotation(ExtensionContext context, Annotation source, Parameter parameter) {
 		try {
-			CartesianArgumentsProvider provider = initializeArgumentsProvider(source, parameter);
+			CartesianArgumentsProvider<?> provider = initializeArgumentsProvider(source, parameter);
 			return provideArguments(context, parameter, provider);
 		}
 		catch (Exception ex) {
@@ -98,7 +98,7 @@ class CartesianTestExtension implements TestTemplateInvocationContextProvider {
 		}
 	}
 
-	private CartesianArgumentsProvider initializeArgumentsProvider(Annotation source, Parameter parameter) {
+	private CartesianArgumentsProvider<?> initializeArgumentsProvider(Annotation source, Parameter parameter) {
 		Optional<CartesianArgumentsSource> cartesianProviderAnnotation = AnnotationSupport
 				.findAnnotation(parameter, CartesianArgumentsSource.class);
 
@@ -115,14 +115,14 @@ class CartesianTestExtension implements TestTemplateInvocationContextProvider {
 					source.annotationType())));
 		ArgumentsProvider provider = ReflectionSupport.newInstance(providerAnnotation.value());
 		if (provider instanceof CartesianArgumentsProvider)
-			return AnnotationConsumerInitializer.initialize(parameter, (CartesianArgumentsProvider) provider);
+			return AnnotationConsumerInitializer.initialize(parameter, (CartesianArgumentsProvider<?>) provider);
 		else
 			throw new PreconditionViolationException(
 				format("%s does not implement the CartesianArgumentsProvider interface.", provider.getClass()));
 	}
 
-	private List<?> provideArguments(ExtensionContext context, Parameter source,
-			CartesianArgumentsProvider provider) throws Exception {
+	private List<?> provideArguments(ExtensionContext context, Parameter source, CartesianArgumentsProvider<?> provider)
+			throws Exception {
 		return provider
 				.provideArguments(context, source)
 				.distinct()

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtension.java
@@ -88,7 +88,7 @@ class CartesianTestExtension implements TestTemplateInvocationContextProvider {
 		return sets;
 	}
 
-	private List<Object> getSetFromAnnotation(ExtensionContext context, Annotation source, Parameter parameter) {
+	private List<?> getSetFromAnnotation(ExtensionContext context, Annotation source, Parameter parameter) {
 		try {
 			CartesianArgumentsProvider provider = initializeArgumentsProvider(source, parameter);
 			return provideArguments(context, parameter, provider);
@@ -121,7 +121,7 @@ class CartesianTestExtension implements TestTemplateInvocationContextProvider {
 				format("%s does not implement the CartesianArgumentsProvider interface.", provider.getClass()));
 	}
 
-	private List<Object> provideArguments(ExtensionContext context, Parameter source,
+	private List<?> provideArguments(ExtensionContext context, Parameter source,
 			CartesianArgumentsProvider provider) throws Exception {
 		return provider
 				.provideArguments(context, source)

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtension.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.support.AnnotationConsumerInitializer;
@@ -126,8 +125,6 @@ class CartesianTestExtension implements TestTemplateInvocationContextProvider {
 			CartesianArgumentsProvider provider) throws Exception {
 		return provider
 				.provideArguments(context, source)
-				.map(Arguments::get)
-				.flatMap(Arrays::stream)
 				.distinct()
 				// We like to keep arguments in the order in which they were listed
 				// in the annotation. Could use a set with defined iteration, but

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianValueArgumentsProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianValueArgumentsProvider.java
@@ -20,7 +20,6 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.support.AnnotationConsumer;
 import org.junit.platform.commons.PreconditionViolationException;
 
@@ -69,8 +68,8 @@ class CartesianValueArgumentsProvider implements CartesianArgumentsProvider, Ann
 	}
 
 	@Override
-	public Stream<? extends Arguments> provideArguments(ExtensionContext context, Parameter parameter) {
-		return Arrays.stream(arguments).map(Arguments::of);
+	public Stream<Object> provideArguments(ExtensionContext context, Parameter parameter) {
+		return Arrays.stream(arguments);
 	}
 
 }

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianValueArgumentsProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianValueArgumentsProvider.java
@@ -31,7 +31,8 @@ import org.junit.platform.commons.PreconditionViolationException;
  * @implNote This class does not implement {@code ArgumentsProvider} since the Jupiter's {@code ValueSource}
  * should be used for that.
  */
-class CartesianValueArgumentsProvider implements CartesianArgumentsProvider, AnnotationConsumer<CartesianTest.Values> {
+class CartesianValueArgumentsProvider
+		implements CartesianArgumentsProvider<Object>, AnnotationConsumer<CartesianTest.Values> {
 
 	private Object[] arguments;
 

--- a/src/main/java/org/junitpioneer/jupiter/params/RangeSourceArgumentsProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/RangeSourceArgumentsProvider.java
@@ -51,8 +51,7 @@ class RangeSourceArgumentsProvider
 	private Annotation argumentsSource;
 
 	@Override
-	public Stream<? extends Arguments> provideArguments(ExtensionContext context, Parameter parameter)
-			throws Exception {
+	public Stream<? extends Number> provideArguments(ExtensionContext context, Parameter parameter) throws Exception {
 		initArgumentsSource(parameter);
 		return provideArguments(context, argumentsSource);
 	}
@@ -64,17 +63,17 @@ class RangeSourceArgumentsProvider
 			// since it's a method annotation, the element will always be present
 			initArgumentsSource(context.getRequiredTestMethod());
 
-		return provideArguments(context, argumentsSource);
+		return provideArguments(context, argumentsSource).map(Arguments::of);
 	}
 
-	private Stream<? extends Arguments> provideArguments(ExtensionContext context, Annotation argumentsSource)
+	private Stream<? extends Number> provideArguments(ExtensionContext context, Annotation argumentsSource)
 			throws Exception {
 		Class<? extends Annotation> argumentsSourceClass = argumentsSource.annotationType();
 		Class<? extends Range> rangeClass = argumentsSourceClass.getAnnotation(RangeClass.class).value();
 
 		Range<?> range = (Range<?>) rangeClass.getConstructors()[0].newInstance(argumentsSource);
 		range.validate();
-		return asStream(range).map(Arguments::of);
+		return asStream(range);
 	}
 
 	private void initArgumentsSource(AnnotatedElement element) {
@@ -91,7 +90,7 @@ class RangeSourceArgumentsProvider
 		argumentsSource = argumentsSources.get(0);
 	}
 
-	private Stream<?> asStream(Range<?> r) {
+	private Stream<? extends Number> asStream(Range<?> r) {
 		return StreamSupport.stream(Spliterators.spliteratorUnknownSize(r, Spliterator.ORDERED), false);
 	}
 

--- a/src/main/java/org/junitpioneer/jupiter/params/RangeSourceArgumentsProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/RangeSourceArgumentsProvider.java
@@ -44,14 +44,14 @@ import org.junitpioneer.jupiter.cartesian.CartesianArgumentsProvider;
  * @see DoubleRangeSource
  * @see FloatRangeSource
  */
-class RangeSourceArgumentsProvider
+class RangeSourceArgumentsProvider<N extends Number & Comparable<N>>
 		implements ArgumentsProvider, CartesianAnnotationConsumer<Annotation>, CartesianArgumentsProvider { //NOSONAR deprecated interface use will be removed in later release
 
 	// Once the CartesianAnnotationConsumer is removed we can make this provider stateless.
 	private Annotation argumentsSource;
 
 	@Override
-	public Stream<? extends Number> provideArguments(ExtensionContext context, Parameter parameter) throws Exception {
+	public Stream<N> provideArguments(ExtensionContext context, Parameter parameter) throws Exception {
 		initArgumentsSource(parameter);
 		return provideArguments(argumentsSource);
 	}
@@ -66,11 +66,12 @@ class RangeSourceArgumentsProvider
 		return provideArguments(argumentsSource).map(Arguments::of);
 	}
 
-	private Stream<? extends Number> provideArguments(Annotation argumentsSource) throws Exception {
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	private Stream<N> provideArguments(Annotation argumentsSource) throws Exception {
 		Class<? extends Annotation> argumentsSourceClass = argumentsSource.annotationType();
 		Class<? extends Range> rangeClass = argumentsSourceClass.getAnnotation(RangeClass.class).value();
 
-		Range<?> range = (Range<?>) rangeClass.getConstructors()[0].newInstance(argumentsSource);
+		Range<N> range = (Range<N>) rangeClass.getConstructors()[0].newInstance(argumentsSource);
 		range.validate();
 		return asStream(range);
 	}
@@ -89,7 +90,7 @@ class RangeSourceArgumentsProvider
 		argumentsSource = argumentsSources.get(0);
 	}
 
-	private Stream<? extends Number> asStream(Range<?> range) {
+	private Stream<N> asStream(Range<N> range) {
 		return StreamSupport.stream(Spliterators.spliteratorUnknownSize(range, Spliterator.ORDERED), false);
 	}
 

--- a/src/main/java/org/junitpioneer/jupiter/params/RangeSourceArgumentsProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/RangeSourceArgumentsProvider.java
@@ -45,7 +45,7 @@ import org.junitpioneer.jupiter.cartesian.CartesianArgumentsProvider;
  * @see FloatRangeSource
  */
 class RangeSourceArgumentsProvider<N extends Number & Comparable<N>>
-		implements ArgumentsProvider, CartesianAnnotationConsumer<Annotation>, CartesianArgumentsProvider { //NOSONAR deprecated interface use will be removed in later release
+		implements ArgumentsProvider, CartesianAnnotationConsumer<Annotation>, CartesianArgumentsProvider<N> { //NOSONAR deprecated interface use will be removed in later release
 
 	// Once the CartesianAnnotationConsumer is removed we can make this provider stateless.
 	private Annotation argumentsSource;
@@ -66,7 +66,7 @@ class RangeSourceArgumentsProvider<N extends Number & Comparable<N>>
 		return provideArguments(argumentsSource).map(Arguments::of);
 	}
 
-	@SuppressWarnings({"unchecked", "rawtypes"})
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	private Stream<N> provideArguments(Annotation argumentsSource) throws Exception {
 		Class<? extends Annotation> argumentsSourceClass = argumentsSource.annotationType();
 		Class<? extends Range> rangeClass = argumentsSourceClass.getAnnotation(RangeClass.class).value();

--- a/src/main/java/org/junitpioneer/jupiter/params/RangeSourceArgumentsProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/RangeSourceArgumentsProvider.java
@@ -53,7 +53,7 @@ class RangeSourceArgumentsProvider
 	@Override
 	public Stream<? extends Number> provideArguments(ExtensionContext context, Parameter parameter) throws Exception {
 		initArgumentsSource(parameter);
-		return provideArguments(context, argumentsSource);
+		return provideArguments(argumentsSource);
 	}
 
 	@Override
@@ -63,11 +63,10 @@ class RangeSourceArgumentsProvider
 			// since it's a method annotation, the element will always be present
 			initArgumentsSource(context.getRequiredTestMethod());
 
-		return provideArguments(context, argumentsSource).map(Arguments::of);
+		return provideArguments(argumentsSource).map(Arguments::of);
 	}
 
-	private Stream<? extends Number> provideArguments(ExtensionContext context, Annotation argumentsSource)
-			throws Exception {
+	private Stream<? extends Number> provideArguments(Annotation argumentsSource) throws Exception {
 		Class<? extends Annotation> argumentsSourceClass = argumentsSource.annotationType();
 		Class<? extends Range> rangeClass = argumentsSourceClass.getAnnotation(RangeClass.class).value();
 

--- a/src/main/java/org/junitpioneer/jupiter/params/RangeSourceArgumentsProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/RangeSourceArgumentsProvider.java
@@ -90,8 +90,8 @@ class RangeSourceArgumentsProvider
 		argumentsSource = argumentsSources.get(0);
 	}
 
-	private Stream<? extends Number> asStream(Range<?> r) {
-		return StreamSupport.stream(Spliterators.spliteratorUnknownSize(r, Spliterator.ORDERED), false);
+	private Stream<? extends Number> asStream(Range<?> range) {
+		return StreamSupport.stream(Spliterators.spliteratorUnknownSize(range, Spliterator.ORDERED), false);
 	}
 
 	@Override

--- a/src/test/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtensionTests.java
@@ -945,7 +945,7 @@ public class CartesianTestExtensionTests {
 		ALPHA, BETA, GAMMA
 	}
 
-	static class FirstCustomCartesianArgumentsProvider implements CartesianArgumentsProvider {
+	static class FirstCustomCartesianArgumentsProvider implements CartesianArgumentsProvider<String> {
 
 		@Override
 		public Stream<String> provideArguments(ExtensionContext context, Parameter parameter) {
@@ -954,7 +954,7 @@ public class CartesianTestExtensionTests {
 
 	}
 
-	static class SecondCustomCartesianArgumentsProvider implements CartesianArgumentsProvider {
+	static class SecondCustomCartesianArgumentsProvider implements CartesianArgumentsProvider<Integer> {
 
 		@Override
 		public Stream<Integer> provideArguments(ExtensionContext context, Parameter parameter) {
@@ -963,7 +963,7 @@ public class CartesianTestExtensionTests {
 
 	}
 
-	static class StringArrayArgumentsProvider implements CartesianArgumentsProvider {
+	static class StringArrayArgumentsProvider implements CartesianArgumentsProvider<String[]> {
 
 		@Override
 		public Stream<String[]> provideArguments(ExtensionContext context, Parameter parameter) {

--- a/src/test/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtensionTests.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
 import org.junit.platform.commons.PreconditionViolationException;
 import org.junitpioneer.jupiter.ReportEntry;
 import org.junitpioneer.jupiter.cartesian.CartesianTest.Enum.Mode;
@@ -373,6 +372,16 @@ public class CartesianTestExtensionTests {
 				assertThat(results)
 						.hasNumberOfReportEntries(6)
 						.withValues("first(1)", "first(2)", "second(1)", "second(2)", "third(1)", "third(2)");
+			}
+
+			@Test
+			@DisplayName("when configured with array parameters")
+			void usesCustomCartesianArgumentsProviderWithArrayArgumentOnParameters() {
+				ExecutionResults results = PioneerTestKit
+						.executeTestMethodWithParameterTypes(CustomCartesianArgumentsProviderTestCases.class,
+							"singleArrayArgument", String[].class);
+
+				assertThat(results).hasNumberOfDynamicallyRegisteredTests(2).hasNumberOfSucceededTests(2);
 			}
 
 		}
@@ -921,6 +930,11 @@ public class CartesianTestExtensionTests {
 
 		}
 
+		@CartesianTest
+		void singleArrayArgument(@CartesianArgumentsSource(StringArrayArgumentsProvider.class) String[] source) {
+			assertThat(source).hasSize(2);
+		}
+
 	}
 
 	private enum TestEnum {
@@ -934,8 +948,8 @@ public class CartesianTestExtensionTests {
 	static class FirstCustomCartesianArgumentsProvider implements CartesianArgumentsProvider {
 
 		@Override
-		public Stream<? extends Arguments> provideArguments(ExtensionContext context, Parameter parameter) {
-			return Stream.of("first", "second", "third").map(Arguments::of);
+		public Stream<String> provideArguments(ExtensionContext context, Parameter parameter) {
+			return Stream.of("first", "second", "third");
 		}
 
 	}
@@ -943,8 +957,17 @@ public class CartesianTestExtensionTests {
 	static class SecondCustomCartesianArgumentsProvider implements CartesianArgumentsProvider {
 
 		@Override
-		public Stream<? extends Arguments> provideArguments(ExtensionContext context, Parameter parameter) {
-			return Stream.of(1, 2).map(Arguments::of);
+		public Stream<Integer> provideArguments(ExtensionContext context, Parameter parameter) {
+			return Stream.of(1, 2);
+		}
+
+	}
+
+	static class StringArrayArgumentsProvider implements CartesianArgumentsProvider {
+
+		@Override
+		public Stream<String[]> provideArguments(ExtensionContext context, Parameter parameter) {
+			return Stream.of(new String[] { "1", "2" }, new String[] { "3", "4" });
 		}
 
 	}


### PR DESCRIPTION
Proposed commit message:

```
Support array arguments in `@CartesianTest` (#523 / ${pull-request}) [max 70 characters]

${body} [max 70 characters per line]

${references}: ${issues}
PR: ${pull-request}
```

This has a prerequisite on PR #519. It can only be reviewed / merged after that one.

While working on this I realised that there is no point in using `Arguments` from JUnit Jupiter. That API has support for providing an array of arguments that should then be resolved to the test method. However, with `@CartesianTest` you want to provider to provide a stream of single object values for a single parameter. Basically always using the first value of the `Arguments`.  

In order to avoid complexity in the validations I removed the usage of `Arguments` and instead now we return only a stream of object. I think that it might be better if we can create an `Argument` interface and return `Stream<? extends Argument>` or make the `CartesianArgumentsProvider` generic and return `Stream<T>`. Let me know what you think.

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [ ] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
