### PR TITLE
Untangle CartesianTestNameFormatter from ParameterizedTest

### DIFF
--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianTest.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianTest.java
@@ -60,7 +60,7 @@ public @interface CartesianTest {
 	/**
 	 * Placeholder for the display name of a {@code @CartesianTest}
 	 *
-	 * @since 5.3
+	 * @since 1.5
 	 * @see #name
 	 */
 	String DISPLAY_NAME_PLACEHOLDER = "{displayName}";
@@ -69,7 +69,7 @@ public @interface CartesianTest {
 	 * Placeholder for the current invocation index of a {@code @CartesianTest}
 	 * method (1-based): <code>{index}</code>
 	 *
-	 * @since 5.3
+	 * @since 1.5
 	 * @see #name
 	 */
 	String INDEX_PLACEHOLDER = "{index}";
@@ -79,7 +79,7 @@ public @interface CartesianTest {
 	 * current invocation of a {@code @CartesianTest} method:
 	 * <code>{arguments}</code>
 	 *
-	 * @since 5.3
+	 * @since 1.5
 	 * @see #name
 	 */
 	String ARGUMENTS_PLACEHOLDER = "{arguments}";

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianTest.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianTest.java
@@ -49,7 +49,6 @@ import org.junitpioneer.jupiter.cartesian.CartesianEnumArgumentsProvider.NullEnu
  * <a href="https://junit-pioneer.org/docs/cartesian-product/" target="_top">the documentation on <code>@CartesianTest</code></a>.
  * </p>
  *
- * @see org.junitpioneer.jupiter.CartesianValueSource
  * @since 1.5.0
  */
 @TestTemplate
@@ -57,6 +56,33 @@ import org.junitpioneer.jupiter.cartesian.CartesianEnumArgumentsProvider.NullEnu
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CartesianTest {
+
+	/**
+	 * Placeholder for the display name of a {@code @CartesianTest}
+	 *
+	 * @since 5.3
+	 * @see #name
+	 */
+	String DISPLAY_NAME_PLACEHOLDER = "{displayName}";
+
+	/**
+	 * Placeholder for the current invocation index of a {@code @CartesianTest}
+	 * method (1-based): <code>{index}</code>
+	 *
+	 * @since 5.3
+	 * @see #name
+	 */
+	String INDEX_PLACEHOLDER = "{index}";
+
+	/**
+	 * Placeholder for the complete, comma-separated arguments list of the
+	 * current invocation of a {@code @CartesianTest} method:
+	 * <code>{arguments}</code>
+	 *
+	 * @since 5.3
+	 * @see #name
+	 */
+	String ARGUMENTS_PLACEHOLDER = "{arguments}";
 
 	/**
 	 * <p>The display name to be used for individual invocations of the

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianTestNameFormatter.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianTestNameFormatter.java
@@ -11,7 +11,9 @@
 package org.junitpioneer.jupiter.cartesian;
 
 import static java.util.stream.Collectors.joining;
-import static org.junitpioneer.jupiter.cartesian.CartesianTest.*;
+import static org.junitpioneer.jupiter.cartesian.CartesianTest.ARGUMENTS_PLACEHOLDER;
+import static org.junitpioneer.jupiter.cartesian.CartesianTest.DISPLAY_NAME_PLACEHOLDER;
+import static org.junitpioneer.jupiter.cartesian.CartesianTest.INDEX_PLACEHOLDER;
 
 import java.text.MessageFormat;
 import java.util.Arrays;

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianTestNameFormatter.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianTestNameFormatter.java
@@ -11,9 +11,7 @@
 package org.junitpioneer.jupiter.cartesian;
 
 import static java.util.stream.Collectors.joining;
-import static org.junit.jupiter.params.ParameterizedTest.ARGUMENTS_PLACEHOLDER;
-import static org.junit.jupiter.params.ParameterizedTest.DISPLAY_NAME_PLACEHOLDER;
-import static org.junit.jupiter.params.ParameterizedTest.INDEX_PLACEHOLDER;
+import static org.junitpioneer.jupiter.cartesian.CartesianTest.*;
 
 import java.text.MessageFormat;
 import java.util.Arrays;


### PR DESCRIPTION
Proposed commit message:

```
Untangle CartesianTestNameFormatter (#382 / #533)

CartesianTestNameFormatter no longer references constants used by
Jupiter's ParameterizedTest.

Closes: #382
PR: #533
```

---
I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
