### PR TITLE
Use Java 17 instead of 16 in build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        java: [ 8, 11, 16 ]
+        java: [ 8, 11, 17 ]
         junit-version: [ '5.7.2', '5.8.1' ]
         modular: [true, false]
         os: [ubuntu, macos, windows]
@@ -172,7 +172,7 @@ jobs:
         run: echo "JDK_EXPERIMENTAL=$JAVA_HOME" >> $GITHUB_ENV
       - uses: actions/setup-java@v2
         with:
-          java-version: 16
+          java-version: 17
           distribution: temurin
           cache: 'gradle'
       - name: Gradle toolchains

--- a/docs/cartesian-product.adoc
+++ b/docs/cartesian-product.adoc
@@ -428,7 +428,7 @@ Basic bit test
 └─ 4 => first bit: 1 second bit: 1
 ----
 
-Please note that name is a https://docs.oracle.com/en/java/javase/16/docs/api/java.base/java/text/MessageFormat.html::[`MessageFormat`] pattern.
+Please note that name is a https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/text/MessageFormat.html::[`MessageFormat`] pattern.
 A single quote (') needs to be represented as a doubled single quote ('') in order to be displayed.
 
 `CartesianTest` supports the following placeholders in custom display names:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Closes #521.

Gradle noob question: as described [here](https://docs.gradle.org/current/userguide/gradle_wrapper.html#sec:upgrading_wrapper), I ran the following command _twice_:

```text
$ ./gradlew wrapper --gradle-version 7.3
```

The `gradle-wrapper.jar` and `gradle` executables, however, didn't change. Did I do something wrong?

Anyway, this PR should be merged after #535.

Proposed commit message:

```
Use Java 17 instead of 16 in build (#521 / #536)

Since this requires Gradle 7.3, this PR updates the Gradle wrapper
accordingly.

Closes: #521
PR: #536
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
