### PR TITLE
Adds FreePort test extension

### DIFF
--- a/docs/docs-nav.yml
+++ b/docs/docs-nav.yml
@@ -30,4 +30,6 @@
         url: /docs/temp-directory/
       - title: "Vintage @Test"
         url: /docs/vintage-test/
+      - title: "Free port"
+        url: /docs/free-port/
 

--- a/docs/free-port.adoc
+++ b/docs/free-port.adoc
@@ -1,0 +1,28 @@
+:page-title: Free Port
+:page-description: Extends JUnit Jupiter with `@FreePort` to get a free port.
+
+== Introduction
+
+Sometimes we want a free port in our tests so that we can either start a server on it or
+to test a failure scenario when there is no service at given port.
+
+It's a JUnit Jupiter extension which provides a free port for above-mentioned use cases. Also, there is no guarantee that the port will still be available by the time you use it.
+
+NOTE: You can retry the test in such cases based on `FreePort.isFreeNow`
+
+== Usage
+
+To get the `FreePort` as an argument on a test just add the annotation to your test suite as shown in the following example:
+
+[source,java]
+----
+
+@ExtendWith(FreePortExtension.class)
+class ServerTest {
+
+    @Test
+    void test(FreePort port) {
+        // use port.number() or check before using port.isFreeNow()
+    }
+}
+----

--- a/docs/free-port.adoc
+++ b/docs/free-port.adoc
@@ -6,7 +6,8 @@
 Sometimes we want a free port in our tests so that we can either start a server on it or
 to test a failure scenario when there is no service at given port.
 
-It's a JUnit Jupiter extension which provides a free port for above-mentioned use cases. Also, there is no guarantee that the port will still be available by the time you use it.
+It's a JUnit Jupiter extension which provides a free port for above-mentioned use cases.
+Also, there is no guarantee that the port will still be available by the time you use it.
 
 NOTE: You can retry the test in such cases based on `FreePort.isFreeNow`
 

--- a/src/main/java/org/junitpioneer/jupiter/FreePort.java
+++ b/src/main/java/org/junitpioneer/jupiter/FreePort.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junitpioneer.jupiter;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+public final class FreePort {
+
+	private final int portNumber;
+
+	public FreePort() throws IOException {
+		this.portNumber = getFreePortNumber();
+	}
+
+	private Integer getFreePortNumber() throws IOException {
+		ServerSocket socket = new ServerSocket(0);
+		int freePort = socket.getLocalPort();
+		socket.close();
+		return freePort;
+	}
+
+	public int number() {
+		return portNumber;
+	}
+
+	public boolean isFreeNow() {
+		try (ServerSocket ignored = new ServerSocket(portNumber)) {
+			return true;
+		}
+		catch (IOException exception) {
+			return false;
+		}
+	}
+
+}

--- a/src/main/java/org/junitpioneer/jupiter/FreePortExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/FreePortExtension.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junitpioneer.jupiter;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+
+public class FreePortExtension implements ParameterResolver {
+
+	@Override
+	public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+			throws ParameterResolutionException {
+		return parameterContext.getParameter().getType().equals(FreePort.class);
+	}
+
+	@Override
+	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+			throws ParameterResolutionException {
+		try {
+			return new FreePort();
+		}
+		catch (IOException e) {
+			throw new ParameterResolutionException("Error while creating free port", e);
+		}
+	}
+
+}

--- a/src/main/java/org/junitpioneer/jupiter/package-info.java
+++ b/src/main/java/org/junitpioneer/jupiter/package-info.java
@@ -12,6 +12,7 @@
  *     <li>{@link org.junitpioneer.jupiter.RetryingTest}</li>
  *     <li>{@link org.junitpioneer.jupiter.StdIoExtension} and {@link org.junitpioneer.jupiter.StdIo}</li>
  *     <li>{@link org.junitpioneer.jupiter.Stopwatch}</li>
+ *     <li>{@link org.junitpioneer.jupiter.FreePortExtension}</li>
  * </ul>
  *
  * Also check the {@link org.junitpioneer.jupiter.params params} package.

--- a/src/test/java/org/junitpioneer/jupiter/FreePortExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/FreePortExtensionTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016-2021 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junitpioneer.jupiter;
+
+import static org.junitpioneer.testkit.assertion.PioneerAssert.assertThat;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junitpioneer.testkit.ExecutionResults;
+import org.junitpioneer.testkit.PioneerTestKit;
+
+@DisplayName("Free port extension")
+public class FreePortExtensionTests {
+
+	@Test
+	@DisplayName("resolve FreePort parameter successfully")
+	void testFreePortParameterResolution() {
+		ExecutionResults results = PioneerTestKit.executeTestClass(FreePortTestCase.class);
+		assertThat(results).hasSingleSucceededTest();
+	}
+
+	@ExtendWith(FreePortExtension.class)
+	static class FreePortTestCase {
+
+		@Test
+		void testFreePortParameterResolution(FreePort port) {
+			Assertions.assertThat(port).isNotNull();
+			Assertions.assertThat(port.isFreeNow()).isTrue();
+		}
+
+	}
+
+}


### PR DESCRIPTION
Proposed commit message:

```
Adds extension for providing free port (#141 / #541)

This parameter resolution extension provides with a free port to test.

Closes: #141
PR: #541
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [x] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [x] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [x] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [x] The `package-info.java` contains information about the new extension

Code
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [x] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
