### PR TITLE
Mention in CONTRIBUTING that test classes must end with `Tests`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,9 +186,9 @@ Pioneer now has its own assertions for asserting not directly executed tests.
 This means asserting `ExecutionResults`.
 We can divide those kinds of assertions into two categories: test case assertions and test suite assertions.
  - Test case assertions are the ones where you assert a single test, e.g.: it failed with an exception or succeeded.
- For those, use the assertions that being with `hasSingle...`, e.g.: `hasSingleSucceededTest()`.
+ For those, use the assertions that begin with `hasSingle...`, e.g.: `hasSingleSucceededTest()`.
  - Test suite assertions are the ones where you assert multiple tests and their outcomes, e.g.: three tests started, two failed, one succeeded.
- For those, use the assertions that being with `hasNumberOf...`, e.g.: `hasNumberOfFailedTests(1)`.
+ For those, use the assertions that begin with `hasNumberOf...`, e.g.: `hasNumberOfFailedTests(1)`.
 
 Do not mix the two - while technically correct (meaning you _can_ write `hasNumberOfFailedTests(3).hasSingleSucceededTest()`) it is better to handle them separately.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ This is true for such diverse areas as a firm legal foundation or a sensible and
 * [Writing Code](#writing-code)
 	* [Code Organization](#code-organization)
 	* [Code Style](#code-style)
+	* [Tests](#tests)
 	* [Documentation](#documentation)
 	* [Git](#git)
 * [Fixing Bugs, Developing Features](#fixing-bugs-developing-features)
@@ -145,25 +146,6 @@ How to write the code itself.
 * design code to avoid optionality wherever feasibly possible
 * in all remaining cases, prefer `Optional` over `null`
 
-#### Assertions
-
-All tests shall use [AssertJ](https://assertj.github.io/doc/)'s assertions and not the ones built into Jupiter:
-
-* more easily discoverable API
-* more detailed assertion failures
-
-Yes, use it even if Jupiter's assertions are as good or better (c.f. `assertTrue(bool)` vs `assertThat(bool).isTrue()`) - that will spare us the discussion which assertion to use in a specific case.
-
-Pioneer now has its own assertions for asserting not directly executed tests.
-This means asserting `ExecutionResults`.
-We can divide those kinds of assertions into two categories: test case assertions and test suite assertions.
- - Test case assertions are the ones where you assert a single test, e.g.: it failed with an exception or succeeded.
- For those, use the assertions that being with `hasSingle...`, e.g.: `hasSingleSucceededTest()`.
- - Test suite assertions are the ones where you assert multiple tests and their outcomes, e.g.: three tests started, two failed, one succeeded.
- For those, use the assertions that being with `hasNumberOf...`, e.g.: `hasNumberOfFailedTests(1)`.
-
-Do not mix the two - while technically correct (meaning you _can_ write `hasNumberOfFailedTests(3).hasSingleSucceededTest()`) it is better to handle them separately.
-
 #### Thread-safety
 
 It must be safe to use Pioneer's extensions in a test suite that is executed in parallel.
@@ -185,6 +167,29 @@ Most extensions verify their configuration at some point.
 It helps with writing parallel tests for them if they do not change global state until the configuration is verified.
 That particularly applies to "store in beforeEach - restore in afterEach"-extensions!
 If they fail after "store", they will still "restore" and thus potentially create a race condition with other tests.
+
+### Tests
+
+The name of test classes _must_ end with `Tests`, otherwise Gradle will ignore them.
+
+#### Assertions
+
+All tests shall use [AssertJ](https://assertj.github.io/doc/)'s assertions and not the ones built into Jupiter:
+
+* more easily discoverable API
+* more detailed assertion failures
+
+Yes, use it even if Jupiter's assertions are as good or better (c.f. `assertTrue(bool)` vs `assertThat(bool).isTrue()`) - that will spare us the discussion which assertion to use in a specific case.
+
+Pioneer now has its own assertions for asserting not directly executed tests.
+This means asserting `ExecutionResults`.
+We can divide those kinds of assertions into two categories: test case assertions and test suite assertions.
+ - Test case assertions are the ones where you assert a single test, e.g.: it failed with an exception or succeeded.
+ For those, use the assertions that being with `hasSingle...`, e.g.: `hasSingleSucceededTest()`.
+ - Test suite assertions are the ones where you assert multiple tests and their outcomes, e.g.: three tests started, two failed, one succeeded.
+ For those, use the assertions that being with `hasNumberOf...`, e.g.: `hasNumberOfFailedTests(1)`.
+
+Do not mix the two - while technically correct (meaning you _can_ write `hasNumberOfFailedTests(3).hasSingleSucceededTest()`) it is better to handle them separately.
 
 ### Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,6 +171,7 @@ If they fail after "store", they will still "restore" and thus potentially creat
 ### Tests
 
 The name of test classes _must_ end with `Tests`, otherwise Gradle will ignore them.
+The name of nested classes which are used as test fixture for executing Jupiter should end with `TestCases`, even when they only contain a single test method.
 
 #### Assertions
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -204,9 +204,8 @@ tasks {
 	}
 
 	test {
-		
-    	    	configure<JacocoTaskExtension> {
-       		isEnabled = !experimentalBuild
+		configure<JacocoTaskExtension> {
+			isEnabled = !experimentalBuild
 		}
 		testLogging {
 			setExceptionFormat("full")

--- a/src/test/java/org/junitpioneer/jupiter/AbstractEntryBasedExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/AbstractEntryBasedExtensionTests.java
@@ -18,6 +18,8 @@ import org.junit.jupiter.api.Test;
 import org.junitpioneer.testkit.PioneerTestKit;
 
 @DisplayName("Abstract entry-based extension")
+@WritesEnvironmentVariable
+@WritesSystemProperty
 class AbstractEntryBasedExtensionTests {
 
 	private static final String CLEAR_ENVVAR_KEY = "clear envvar";

--- a/src/test/java/org/junitpioneer/jupiter/AbstractEntryBasedExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/AbstractEntryBasedExtensionTests.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junitpioneer.testkit.PioneerTestKit;
 
 @DisplayName("Abstract entry-based extension")
-class AbstractEntryBasedExtensionTest {
+class AbstractEntryBasedExtensionTests {
 
 	private static final String CLEAR_ENVVAR_KEY = "clear envvar";
 	private static final String SET_ENVVAR_KEY = "set envvar";

--- a/src/test/java/org/junitpioneer/jupiter/CartesianProductTestExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/CartesianProductTestExtensionTests.java
@@ -481,7 +481,7 @@ public class CartesianProductTestExtensionTests {
 			@Test
 			@DisplayName("when test class has a constructor with auto-injected values")
 			void testClassWithConstructor() {
-				ExecutionResults results = PioneerTestKit.executeTestClass(TestClassWithConstructor.class);
+				ExecutionResults results = PioneerTestKit.executeTestClass(TestClassWithConstructorTestCases.class);
 
 				assertThat(results).hasNumberOfDynamicallyRegisteredTests(4).hasNumberOfSucceededTests(4);
 				assertThat(results).hasNumberOfReportEntries(4).withValues("13", "14", "23", "24");
@@ -1425,11 +1425,11 @@ public class CartesianProductTestExtensionTests {
 
 	}
 
-	static class TestClassWithConstructor {
+	static class TestClassWithConstructorTestCases {
 
 		private final TestInfo testInfo;
 
-		TestClassWithConstructor(TestInfo info) {
+		TestClassWithConstructorTestCases(TestInfo info) {
 			this.testInfo = info;
 		}
 

--- a/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
@@ -99,7 +99,7 @@ class DefaultLocaleTests {
 		@WritesDefaultLocale
 		@DisplayName("should execute tests with configured Locale")
 		void shouldExecuteTestsWithConfiguredLocale() {
-			ExecutionResults results = executeTestClass(ClassLevelTestCase.class);
+			ExecutionResults results = executeTestClass(ClassLevelTestCases.class);
 
 			assertThat(results).hasNumberOfSucceededTests(2);
 		}
@@ -112,7 +112,7 @@ class DefaultLocaleTests {
 	}
 
 	@DefaultLocale(language = "fr", country = "FR")
-	static class ClassLevelTestCase {
+	static class ClassLevelTestCases {
 
 		@Test
 		@ReadsDefaultLocale
@@ -180,7 +180,7 @@ class DefaultLocaleTests {
 			@Test
 			@DisplayName("should fail when nothing is configured")
 			void shouldFailWhenNothingIsConfigured() {
-				ExecutionResults results = executeTestMethod(MethodLevelInitializationFailureTestCase.class,
+				ExecutionResults results = executeTestMethod(MethodLevelInitializationFailureTestCases.class,
 					"shouldFailMissingConfiguration");
 
 				assertThat(results)
@@ -191,7 +191,7 @@ class DefaultLocaleTests {
 			@Test
 			@DisplayName("should fail when variant is set but country is not")
 			void shouldFailWhenVariantIsSetButCountryIsNot() {
-				ExecutionResults results = executeTestMethod(MethodLevelInitializationFailureTestCase.class,
+				ExecutionResults results = executeTestMethod(MethodLevelInitializationFailureTestCases.class,
 					"shouldFailMissingCountry");
 
 				assertThat(results)
@@ -202,7 +202,7 @@ class DefaultLocaleTests {
 			@Test
 			@DisplayName("should fail when languageTag and language is set")
 			void shouldFailWhenLanguageTagAndLanguageIsSet() {
-				ExecutionResults results = executeTestMethod(MethodLevelInitializationFailureTestCase.class,
+				ExecutionResults results = executeTestMethod(MethodLevelInitializationFailureTestCases.class,
 					"shouldFailLanguageTagAndLanguage");
 
 				assertThat(results)
@@ -213,7 +213,7 @@ class DefaultLocaleTests {
 			@Test
 			@DisplayName("should fail when languageTag and country is set")
 			void shouldFailWhenLanguageTagAndCountryIsSet() {
-				ExecutionResults results = executeTestMethod(MethodLevelInitializationFailureTestCase.class,
+				ExecutionResults results = executeTestMethod(MethodLevelInitializationFailureTestCases.class,
 					"shouldFailLanguageTagAndCountry");
 
 				assertThat(results)
@@ -224,7 +224,7 @@ class DefaultLocaleTests {
 			@Test
 			@DisplayName("should fail when languageTag and variant is set")
 			void shouldFailWhenLanguageTagAndVariantIsSet() {
-				ExecutionResults results = executeTestMethod(MethodLevelInitializationFailureTestCase.class,
+				ExecutionResults results = executeTestMethod(MethodLevelInitializationFailureTestCases.class,
 					"shouldFailLanguageTagAndVariant");
 
 				assertThat(results)
@@ -241,7 +241,7 @@ class DefaultLocaleTests {
 			@Test
 			@DisplayName("should fail when variant is set but country is not")
 			void shouldFailWhenVariantIsSetButCountryIsNot() {
-				ExecutionResults results = executeTestClass(ClassLevelInitializationFailureTestCase.class);
+				ExecutionResults results = executeTestClass(ClassLevelInitializationFailureTestCases.class);
 
 				assertThat(results)
 						.hasSingleFailedTest()
@@ -252,7 +252,7 @@ class DefaultLocaleTests {
 
 	}
 
-	static class MethodLevelInitializationFailureTestCase {
+	static class MethodLevelInitializationFailureTestCases {
 
 		@Test
 		@DefaultLocale
@@ -282,7 +282,7 @@ class DefaultLocaleTests {
 	}
 
 	@DefaultLocale(language = "de", variant = "ch")
-	static class ClassLevelInitializationFailureTestCase {
+	static class ClassLevelInitializationFailureTestCases {
 
 		@Test
 		void shouldFail() {

--- a/src/test/java/org/junitpioneer/jupiter/DefaultTimeZoneTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultTimeZoneTests.java
@@ -88,7 +88,7 @@ class DefaultTimeZoneTests {
 	@Nested
 	@DefaultTimeZone("GMT-8:00")
 	@DisplayName("when applied on the class level")
-	class ClassLevelTestCase {
+	class ClassLevelTestCases {
 
 		@Test
 		@ReadsDefaultTimeZone
@@ -109,7 +109,7 @@ class DefaultTimeZoneTests {
 	@Nested
 	@DefaultTimeZone("GMT")
 	@DisplayName("when explicitly set to GMT on the class level")
-	class ExplicitGmtClassLevelTestCase {
+	class ExplicitGmtClassLevelTestCases {
 
 		@Test
 		@DisplayName("does not throw and sets to GMT ")
@@ -168,7 +168,8 @@ class DefaultTimeZoneTests {
 		@ReadsDefaultTimeZone
 		@DisplayName("on method level, throws exception")
 		void throwsWhenConfigurationIsBad() {
-			ExecutionResults results = executeTestMethod(BadMethodLevelConfigurationTestCase.class, "badConfiguration");
+			ExecutionResults results = executeTestMethod(BadMethodLevelConfigurationTestCases.class,
+				"badConfiguration");
 
 			assertThat(results)
 					.hasSingleFailedTest()
@@ -181,7 +182,7 @@ class DefaultTimeZoneTests {
 		@ReadsDefaultTimeZone
 		@DisplayName("on class level, throws exception")
 		void shouldThrowWithBadConfiguration() {
-			ExecutionResults results = executeTestClass(BadClassLevelConfigurationTestCase.class);
+			ExecutionResults results = executeTestClass(BadClassLevelConfigurationTestCases.class);
 
 			assertThat(results)
 					.hasSingleFailedTest()
@@ -196,7 +197,7 @@ class DefaultTimeZoneTests {
 
 	}
 
-	static class BadMethodLevelConfigurationTestCase {
+	static class BadMethodLevelConfigurationTestCases {
 
 		@Test
 		@DefaultTimeZone("Gibberish")
@@ -206,7 +207,7 @@ class DefaultTimeZoneTests {
 	}
 
 	@DefaultTimeZone("Gibberish")
-	static class BadClassLevelConfigurationTestCase {
+	static class BadClassLevelConfigurationTestCases {
 
 		@Test
 		void badConfiguration() {

--- a/src/test/java/org/junitpioneer/jupiter/DisabledUntilExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DisabledUntilExtensionTests.java
@@ -29,7 +29,7 @@ class DisabledUntilExtensionTests {
 	@DisplayName("Should enable test without annotation")
 	void shouldEnableTestWithoutAnnotation() {
 		final ExecutionResults results = PioneerTestKit
-				.executeTestMethod(DisabledUntilExtensionTests.DisabledUntilDummyTestClass.class, "testNoAnnotation");
+				.executeTestMethod(DisabledUntilTestCases.class, "testNoAnnotation");
 		assertThat(results).hasSingleStartedTest();
 		assertThat(results).hasSingleSucceededTest();
 		assertThat(results).hasNumberOfSkippedTests(0);
@@ -40,8 +40,7 @@ class DisabledUntilExtensionTests {
 	@DisplayName("Should enable test with unparsable `date`` string")
 	void shouldEnableTestWithUnparsableUntilDateString() {
 		final ExecutionResults results = PioneerTestKit
-				.executeTestMethod(DisabledUntilExtensionTests.DisabledUntilDummyTestClass.class,
-					"testUnparsableUntilDateString");
+				.executeTestMethod(DisabledUntilTestCases.class, "testUnparsableUntilDateString");
 		assertThat(results).hasSingleStartedTest();
 		assertThat(results).hasSingleFailedTest();
 		assertThat(results).hasNumberOfSkippedTests(0);
@@ -52,8 +51,7 @@ class DisabledUntilExtensionTests {
 	@DisplayName("Should enable test with `date` in the past")
 	void shouldEnableTestWithUntilDateInThePast() {
 		final ExecutionResults results = PioneerTestKit
-				.executeTestMethod(DisabledUntilExtensionTests.DisabledUntilDummyTestClass.class,
-					"testIsAnnotatedWithDateInThePast");
+				.executeTestMethod(DisabledUntilTestCases.class, "testIsAnnotatedWithDateInThePast");
 		assertThat(results).hasSingleStartedTest();
 		assertThat(results).hasSingleSucceededTest();
 		assertThat(results).hasNumberOfSkippedTests(0);
@@ -67,8 +65,7 @@ class DisabledUntilExtensionTests {
 	@DisplayName("Should disable test with `date` in the future")
 	void shouldDisableTestWithUntilDateInTheFuture() {
 		final ExecutionResults results = PioneerTestKit
-				.executeTestMethod(DisabledUntilExtensionTests.DisabledUntilDummyTestClass.class,
-					"testIsAnnotatedWithDateInTheFuture");
+				.executeTestMethod(DisabledUntilTestCases.class, "testIsAnnotatedWithDateInTheFuture");
 		assertThat(results).hasNumberOfStartedTests(0);
 		assertThat(results).hasSingleSkippedTest();
 		assertThat(results).hasNoReportEntries();
@@ -78,15 +75,14 @@ class DisabledUntilExtensionTests {
 	@DisplayName("Should disable nested test with `date` in the future when meta annotated by higher level container")
 	void shouldDisableNestedTestWithUntilDateInTheFutureWhenMetaAnnotated() {
 		final ExecutionResults results = PioneerTestKit
-				.executeTestMethod(DisabledUntilExtensionTests.DisabledUntilDummyTestClass.NestedDummyTestClass.class,
-					"shouldRetrieveFromClass");
+				.executeTestMethod(DisabledUntilTestCases.NestedTestCases.class, "shouldRetrieveFromClass");
 		assertThat(results).hasSingleSkippedContainer(); // NestedDummyTestClass is skipped as container
 		assertThat(results).hasNumberOfStartedTests(0);
 		assertThat(results).hasNumberOfSkippedTests(0);
 		assertThat(results).hasNoReportEntries();
 	}
 
-	static class DisabledUntilDummyTestClass {
+	static class DisabledUntilTestCases {
 
 		@Test
 		void testNoAnnotation() {
@@ -113,7 +109,7 @@ class DisabledUntilExtensionTests {
 
 		@Nested
 		@DisabledUntil(reason = "Yowza!", date = "2199-01-01")
-		class NestedDummyTestClass {
+		class NestedTestCases {
 
 			@Test
 			void shouldRetrieveFromClass() {

--- a/src/test/java/org/junitpioneer/jupiter/IssueExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/IssueExtensionTests.java
@@ -25,8 +25,7 @@ public class IssueExtensionTests {
 	@Test
 	@DisplayName("publishes nothing, if method is not annotated")
 	void publishNothingIfMethodIsNotAnnotated() {
-		ExecutionResults results = PioneerTestKit
-				.executeTestMethod(IssueExtensionTests.IssueDummyTestClass.class, "testNoAnnotation");
+		ExecutionResults results = PioneerTestKit.executeTestMethod(IssueExtensionTestCases.class, "testNoAnnotation");
 
 		assertThat(results).hasNumberOfSucceededTests(1);
 		assertThat(results).hasNumberOfReportEntries(0);
@@ -35,8 +34,7 @@ public class IssueExtensionTests {
 	@Test
 	@DisplayName("publishes the annotations value with key 'Issue'")
 	void publishAnnotationsValueWithKeyIssueFromMethodAnnotation() {
-		ExecutionResults results = PioneerTestKit
-				.executeTestMethod(IssueExtensionTests.IssueDummyTestClass.class, "testIsAnnotated");
+		ExecutionResults results = PioneerTestKit.executeTestMethod(IssueExtensionTestCases.class, "testIsAnnotated");
 		assertThat(results).hasNumberOfSucceededTests(1);
 
 		assertThat(results).hasSingleReportEntry().withKeyAndValue(REPORT_ENTRY_KEY, "Req 11");
@@ -46,13 +44,13 @@ public class IssueExtensionTests {
 	@DisplayName("publishes the class annotation with value 'Req-Class'")
 	void publishAnnotationsFromClass() {
 		ExecutionResults results = PioneerTestKit
-				.executeTestClass(IssueExtensionTests.IssueDummyTestClass.NestedDummyTestClass.class);
+				.executeTestClass(IssueExtensionTestCases.NestedIssueExtensionTestCases.class);
 		assertThat(results).hasNumberOfSucceededTests(1);
 
 		assertThat(results).hasSingleReportEntry().withKeyAndValue(REPORT_ENTRY_KEY, "Req-Class");
 	}
 
-	static class IssueDummyTestClass {
+	static class IssueExtensionTestCases {
 
 		@Test
 		void testNoAnnotation() {
@@ -67,7 +65,7 @@ public class IssueExtensionTests {
 
 		@Nested
 		@Issue("Req-Class")
-		class NestedDummyTestClass {
+		class NestedIssueExtensionTestCases {
 
 			@Test
 			void shouldRetrieveFromClass() {

--- a/src/test/java/org/junitpioneer/jupiter/ReportEntryExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/ReportEntryExtensionTests.java
@@ -42,7 +42,7 @@ public class ReportEntryExtensionTests {
 	@Test
 	@DisplayName("reports given explicit key and value")
 	void explicitKey_keyAndValueAreReported() {
-		ExecutionResults results = PioneerTestKit.executeTestMethod(ReportEntriesTest.class, "explicitKey");
+		ExecutionResults results = PioneerTestKit.executeTestMethod(ReportEntryTestCases.class, "explicitKey");
 
 		assertThat(results).hasSingleReportEntry().withKeyAndValue("Crow2", "While I pondered weak and weary");
 	}
@@ -50,7 +50,7 @@ public class ReportEntryExtensionTests {
 	@Test
 	@DisplayName("reports given explicit value with default key 'value'")
 	void implicitKey_keyIsNamedValue() {
-		ExecutionResults results = PioneerTestKit.executeTestMethod(ReportEntriesTest.class, "implicitKey");
+		ExecutionResults results = PioneerTestKit.executeTestMethod(ReportEntryTestCases.class, "implicitKey");
 
 		assertThat(results).hasSingleReportEntry().withKeyAndValue("value", "Once upon a midnight dreary");
 	}
@@ -58,7 +58,7 @@ public class ReportEntryExtensionTests {
 	@Test
 	@DisplayName("fails when given an empty key explicitly")
 	void emptyKey_fails() {
-		ExecutionResults results = PioneerTestKit.executeTestMethod(ReportEntriesTest.class, "emptyKey");
+		ExecutionResults results = PioneerTestKit.executeTestMethod(ReportEntryTestCases.class, "emptyKey");
 
 		assertThat(results)
 				.hasSingleFailedTest()
@@ -70,7 +70,7 @@ public class ReportEntryExtensionTests {
 	@Test
 	@DisplayName("fails when given an empty value")
 	void emptyValue_fails() {
-		ExecutionResults results = PioneerTestKit.executeTestMethod(ReportEntriesTest.class, "emptyValue");
+		ExecutionResults results = PioneerTestKit.executeTestMethod(ReportEntryTestCases.class, "emptyValue");
 
 		assertThat(results)
 				.hasSingleFailedTest()
@@ -82,7 +82,7 @@ public class ReportEntryExtensionTests {
 	@Test
 	@DisplayName("logs each value as individual entry when annotation is repeated")
 	void repeatedAnnotation_logEachKeyValuePairAsIndividualEntry() {
-		ExecutionResults results = PioneerTestKit.executeTestMethod(ReportEntriesTest.class, "repeatedAnnotation");
+		ExecutionResults results = PioneerTestKit.executeTestMethod(ReportEntryTestCases.class, "repeatedAnnotation");
 
 		assertThat(results)
 				.hasNumberOfReportEntries(3)
@@ -101,7 +101,8 @@ public class ReportEntryExtensionTests {
 			@Test
 			@DisplayName("logs for successful test")
 			void successfulTest_logsMessage() {
-				ExecutionResults results = PioneerTestKit.executeTestMethod(ReportEntriesTest.class, "always_success");
+				ExecutionResults results = PioneerTestKit
+						.executeTestMethod(ReportEntryTestCases.class, "always_success");
 
 				assertThat(results).hasSingleSucceededTest();
 				assertThat(results).hasSingleReportEntry().withKeyAndValue("value", "'Tis some visitor', I muttered");
@@ -110,7 +111,8 @@ public class ReportEntryExtensionTests {
 			@Test
 			@DisplayName("logs for failed test")
 			void failingTest_logsMessage() {
-				ExecutionResults results = PioneerTestKit.executeTestMethod(ReportEntriesTest.class, "always_failure");
+				ExecutionResults results = PioneerTestKit
+						.executeTestMethod(ReportEntryTestCases.class, "always_failure");
 
 				assertThat(results).hasSingleFailedTest();
 				assertThat(results).hasSingleReportEntry().withKeyAndValue("value", "'Tapping at my chamber door' -");
@@ -119,7 +121,8 @@ public class ReportEntryExtensionTests {
 			@Test
 			@DisplayName("logs for aborted test")
 			void abortedTest_logsMessage() {
-				ExecutionResults results = PioneerTestKit.executeTestMethod(ReportEntriesTest.class, "always_aborted");
+				ExecutionResults results = PioneerTestKit
+						.executeTestMethod(ReportEntryTestCases.class, "always_aborted");
 
 				assertThat(results).hasSingleAbortedTest();
 				assertThat(results).hasSingleReportEntry().withKeyAndValue("value", "'Only this and nothing more.'");
@@ -128,7 +131,8 @@ public class ReportEntryExtensionTests {
 			@Test
 			@DisplayName("does not log for disabled test")
 			void disabledTest_logsNoMessage() {
-				ExecutionResults results = PioneerTestKit.executeTestMethod(ReportEntriesTest.class, "always_disabled");
+				ExecutionResults results = PioneerTestKit
+						.executeTestMethod(ReportEntryTestCases.class, "always_disabled");
 
 				assertThat(results).hasSingleSkippedTest();
 				assertThat(results).hasNoReportEntries();
@@ -144,7 +148,7 @@ public class ReportEntryExtensionTests {
 			@DisplayName("logs for successful test")
 			void successfulTest_logsMessage() {
 				ExecutionResults results = PioneerTestKit
-						.executeTestMethod(ReportEntriesTest.class, "onSuccess_success");
+						.executeTestMethod(ReportEntryTestCases.class, "onSuccess_success");
 
 				assertThat(results).hasSingleSucceededTest();
 				assertThat(results).hasSingleReportEntry().withKeyAndValue("value", "it was in the bleak December");
@@ -154,7 +158,7 @@ public class ReportEntryExtensionTests {
 			@DisplayName("does not log for failed test")
 			void failedTest_logsNoMessage() {
 				ExecutionResults results = PioneerTestKit
-						.executeTestMethod(ReportEntriesTest.class, "onSuccess_failure");
+						.executeTestMethod(ReportEntryTestCases.class, "onSuccess_failure");
 
 				assertThat(results).hasSingleFailedTest();
 				assertThat(results).hasNoReportEntries();
@@ -164,7 +168,7 @@ public class ReportEntryExtensionTests {
 			@DisplayName("does not log for aborted test")
 			void abortedTest_logsNoMessage() {
 				ExecutionResults results = PioneerTestKit
-						.executeTestMethod(ReportEntriesTest.class, "onSuccess_aborted");
+						.executeTestMethod(ReportEntryTestCases.class, "onSuccess_aborted");
 
 				assertThat(results).hasSingleAbortedTest();
 				assertThat(results).hasNoReportEntries();
@@ -174,7 +178,7 @@ public class ReportEntryExtensionTests {
 			@DisplayName("does not log for disabled test")
 			void disabledTest_logsNoMessage() {
 				ExecutionResults results = PioneerTestKit
-						.executeTestMethod(ReportEntriesTest.class, "onSuccess_disabled");
+						.executeTestMethod(ReportEntryTestCases.class, "onSuccess_disabled");
 
 				assertThat(results).hasSingleSkippedTest();
 				assertThat(results).hasNoReportEntries();
@@ -190,7 +194,7 @@ public class ReportEntryExtensionTests {
 			@DisplayName("does not log for successful test")
 			void successfulTest_logsNoMessage() {
 				ExecutionResults results = PioneerTestKit
-						.executeTestMethod(ReportEntriesTest.class, "onFailure_success");
+						.executeTestMethod(ReportEntryTestCases.class, "onFailure_success");
 
 				assertThat(results).hasSingleSucceededTest();
 				assertThat(results).hasNoReportEntries();
@@ -200,7 +204,7 @@ public class ReportEntryExtensionTests {
 			@DisplayName("logs for failed test")
 			void failedTest_logsMessage() {
 				ExecutionResults results = PioneerTestKit
-						.executeTestMethod(ReportEntriesTest.class, "onFailure_failure");
+						.executeTestMethod(ReportEntryTestCases.class, "onFailure_failure");
 
 				assertThat(results).hasSingleFailedTest();
 				assertThat(results).hasSingleReportEntry().withKeyAndValue("value", "Nameless here for evermore.");
@@ -210,7 +214,7 @@ public class ReportEntryExtensionTests {
 			@DisplayName("does not log for aborted test")
 			void abortedTest_logsNoMessage() {
 				ExecutionResults results = PioneerTestKit
-						.executeTestMethod(ReportEntriesTest.class, "onFailure_aborted");
+						.executeTestMethod(ReportEntryTestCases.class, "onFailure_aborted");
 
 				assertThat(results).hasSingleAbortedTest();
 				assertThat(results).hasNoReportEntries();
@@ -220,7 +224,7 @@ public class ReportEntryExtensionTests {
 			@DisplayName("does not log for disabled test")
 			void disabledTest_logsNoMessage() {
 				ExecutionResults results = PioneerTestKit
-						.executeTestMethod(ReportEntriesTest.class, "onFailure_disabled");
+						.executeTestMethod(ReportEntryTestCases.class, "onFailure_disabled");
 
 				assertThat(results).hasSingleSkippedTest();
 				assertThat(results).hasNoReportEntries();
@@ -236,7 +240,7 @@ public class ReportEntryExtensionTests {
 			@DisplayName("does not log for successful test")
 			void successfulTest_logsNoMessage() {
 				ExecutionResults results = PioneerTestKit
-						.executeTestMethod(ReportEntriesTest.class, "onAborted_success");
+						.executeTestMethod(ReportEntryTestCases.class, "onAborted_success");
 
 				assertThat(results).hasSingleSucceededTest();
 				assertThat(results).hasNoReportEntries();
@@ -246,7 +250,7 @@ public class ReportEntryExtensionTests {
 			@DisplayName("does not log for failed test")
 			void failedTest_logsNoMessage() {
 				ExecutionResults results = PioneerTestKit
-						.executeTestMethod(ReportEntriesTest.class, "onAborted_failure");
+						.executeTestMethod(ReportEntryTestCases.class, "onAborted_failure");
 
 				assertThat(results).hasSingleFailedTest();
 				assertThat(results).hasNoReportEntries();
@@ -256,7 +260,7 @@ public class ReportEntryExtensionTests {
 			@DisplayName("logs for aborted test")
 			void abortedTest_logsMessage() {
 				ExecutionResults results = PioneerTestKit
-						.executeTestMethod(ReportEntriesTest.class, "onAborted_aborted");
+						.executeTestMethod(ReportEntryTestCases.class, "onAborted_aborted");
 
 				assertThat(results)
 						.hasSingleReportEntry()
@@ -267,7 +271,7 @@ public class ReportEntryExtensionTests {
 			@DisplayName("does not log for disabled test")
 			void disabledTest_logsNoMessage() {
 				ExecutionResults results = PioneerTestKit
-						.executeTestMethod(ReportEntriesTest.class, "onAborted_disabled");
+						.executeTestMethod(ReportEntryTestCases.class, "onAborted_disabled");
 
 				assertThat(results).hasSingleSkippedTest();
 				assertThat(results).hasNoReportEntries();
@@ -283,7 +287,7 @@ public class ReportEntryExtensionTests {
 			@DisplayName("logs entries independently on success, based on publish condition")
 			void conditional_logOnSuccessIndependently() {
 				ExecutionResults results = PioneerTestKit
-						.executeTestMethod(ReportEntriesTest.class, "repeated_success");
+						.executeTestMethod(ReportEntryTestCases.class, "repeated_success");
 
 				assertThat(results).hasSingleSucceededTest();
 				assertThat(results)
@@ -296,7 +300,7 @@ public class ReportEntryExtensionTests {
 			@DisplayName("logs entries independently on failure, based on publish condition")
 			void conditional_logOnFailureIndependently() {
 				ExecutionResults results = PioneerTestKit
-						.executeTestMethod(ReportEntriesTest.class, "repeated_failure");
+						.executeTestMethod(ReportEntryTestCases.class, "repeated_failure");
 
 				assertThat(results).hasSingleFailedTest();
 				assertThat(results)
@@ -309,7 +313,7 @@ public class ReportEntryExtensionTests {
 			@DisplayName("logs entries independently on abortion, based on publish condition")
 			void conditional_logOnAbortedIndependently() {
 				ExecutionResults results = PioneerTestKit
-						.executeTestMethod(ReportEntriesTest.class, "repeated_aborted");
+						.executeTestMethod(ReportEntryTestCases.class, "repeated_aborted");
 
 				assertThat(results).hasSingleAbortedTest();
 				assertThat(results)
@@ -322,7 +326,7 @@ public class ReportEntryExtensionTests {
 			@DisplayName("does not log entries if disabled")
 			void conditional_doesNotLogOnDisabled() {
 				ExecutionResults results = PioneerTestKit
-						.executeTestMethod(ReportEntriesTest.class, "repeated_disabled");
+						.executeTestMethod(ReportEntryTestCases.class, "repeated_disabled");
 
 				assertThat(results).hasSingleSkippedTest();
 				assertThat(results).hasNoReportEntries();
@@ -340,7 +344,8 @@ public class ReportEntryExtensionTests {
 		@DisplayName("publishes the parameter")
 		void parameterized_publishes() {
 			ExecutionResults results = PioneerTestKit
-					.executeTestMethodWithParameterTypes(ReportEntriesTest.class, "parameterized_basic", String.class);
+					.executeTestMethodWithParameterTypes(ReportEntryTestCases.class, "parameterized_basic",
+						String.class);
 
 			assertThat(results).hasNumberOfDynamicallyRegisteredTests(2).hasNumberOfSucceededTests(2);
 			assertThat(results)
@@ -353,7 +358,7 @@ public class ReportEntryExtensionTests {
 		@DisplayName("throws if there are unresolved (too many) parameter variables")
 		void parameterized_unresolvedVars() {
 			ExecutionResults results = PioneerTestKit
-					.executeTestMethodWithParameterTypes(ReportEntriesTest.class, "parameterized_unresolved",
+					.executeTestMethodWithParameterTypes(ReportEntryTestCases.class, "parameterized_unresolved",
 						String.class);
 
 			assertThat(results).hasNumberOfFailedTests(1);
@@ -368,7 +373,7 @@ public class ReportEntryExtensionTests {
 		@DisplayName("throw if the key has a parameter variable")
 		void parameterized_keyCantBeParameterized() {
 			ExecutionResults results = PioneerTestKit
-					.executeTestMethodWithParameterTypes(ReportEntriesTest.class, "parameterized_key_fail",
+					.executeTestMethodWithParameterTypes(ReportEntryTestCases.class, "parameterized_key_fail",
 						String.class);
 
 			assertThat(results).hasNoReportEntries();
@@ -382,7 +387,7 @@ public class ReportEntryExtensionTests {
 		@DisplayName("can publish multiple parameters")
 		void parameterized_multiple() {
 			ExecutionResults results = PioneerTestKit
-					.executeTestMethodWithParameterTypes(ReportEntriesTest.class, "parameterized_multiple",
+					.executeTestMethodWithParameterTypes(ReportEntryTestCases.class, "parameterized_multiple",
 						String.class, int.class);
 
 			assertThat(results).hasNumberOfDynamicallyRegisteredTests(2).hasNumberOfSucceededTests(2);
@@ -396,7 +401,7 @@ public class ReportEntryExtensionTests {
 		@DisplayName("can publish null arguments")
 		void parameterized_with_nulls() {
 			ExecutionResults results = PioneerTestKit
-					.executeTestMethodWithParameterTypes(ReportEntriesTest.class, "parameterized_with_nulls",
+					.executeTestMethodWithParameterTypes(ReportEntryTestCases.class, "parameterized_with_nulls",
 						String.class, String.class);
 
 			assertThat(results).hasSingleSucceededTest();
@@ -407,7 +412,7 @@ public class ReportEntryExtensionTests {
 
 	}
 
-	static class ReportEntriesTest {
+	static class ReportEntryTestCases {
 
 		@Test
 		@ReportEntry("Once upon a midnight dreary")

--- a/src/test/java/org/junitpioneer/jupiter/RetryingTestExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/RetryingTestExtensionTests.java
@@ -31,7 +31,7 @@ class RetryingTestExtensionTests {
 	@Test
 	void invalidConfigurationWithTest() {
 		ExecutionResults results = PioneerTestKit
-				.executeTestMethod(RetryingTestTestCase.class, "invalidConfigurationWithTest");
+				.executeTestMethod(RetryingTestTestCases.class, "invalidConfigurationWithTest");
 
 		assertThat(results).hasSingleDynamicallyRegisteredTest();
 		assertThat(results).hasNumberOfStartedTests(2).hasNumberOfSucceededTests(2);
@@ -40,14 +40,14 @@ class RetryingTestExtensionTests {
 	@Test
 	void executedOneEvenWithTwoTestTemplatesTest() {
 		ExecutionResults results = PioneerTestKit
-				.executeTestMethod(RetryingTestTestCase.class, "executedOneEvenWithTwoTestTemplates");
+				.executeTestMethod(RetryingTestTestCases.class, "executedOneEvenWithTwoTestTemplates");
 
 		assertThat(results).hasSingleDynamicallyRegisteredTest().whichSucceeded();
 	}
 
 	@Test
 	void failsNever_executedOnce_passes() {
-		ExecutionResults results = PioneerTestKit.executeTestMethod(RetryingTestTestCase.class, "failsNever");
+		ExecutionResults results = PioneerTestKit.executeTestMethod(RetryingTestTestCases.class, "failsNever");
 
 		assertThat(results).hasSingleDynamicallyRegisteredTest().whichSucceeded();
 	}
@@ -55,7 +55,7 @@ class RetryingTestExtensionTests {
 	@Test
 	void failsOnlyOnFirstInvocation_executedTwice_passes() {
 		ExecutionResults results = PioneerTestKit
-				.executeTestMethod(RetryingTestTestCase.class, "failsOnlyOnFirstInvocation");
+				.executeTestMethod(RetryingTestTestCases.class, "failsOnlyOnFirstInvocation");
 
 		assertThat(results)
 				.hasNumberOfDynamicallyRegisteredTests(2)
@@ -66,7 +66,7 @@ class RetryingTestExtensionTests {
 	@Test
 	void failsOnlyOnFirstInvocationWithExpectedException_executedTwice_passes() {
 		ExecutionResults results = PioneerTestKit
-				.executeTestMethod(RetryingTestTestCase.class, "failsOnlyOnFirstInvocationWithExpectedException");
+				.executeTestMethod(RetryingTestTestCases.class, "failsOnlyOnFirstInvocationWithExpectedException");
 
 		assertThat(results)
 				.hasNumberOfDynamicallyRegisteredTests(2)
@@ -77,7 +77,7 @@ class RetryingTestExtensionTests {
 	@Test
 	void failsOnlyOnFirstInvocationWithUnexpectedException_executedOnce_fails() {
 		ExecutionResults results = PioneerTestKit
-				.executeTestMethod(RetryingTestTestCase.class, "failsOnlyOnFirstInvocationWithUnexpectedException");
+				.executeTestMethod(RetryingTestTestCases.class, "failsOnlyOnFirstInvocationWithUnexpectedException");
 
 		assertThat(results).hasNumberOfDynamicallyRegisteredTests(1).hasNumberOfFailedTests(1);
 	}
@@ -85,7 +85,7 @@ class RetryingTestExtensionTests {
 	@Test
 	void failsOnlyOnFirstInvocationWithUnexpectedException_executedTwice_fails() {
 		ExecutionResults results = PioneerTestKit
-				.executeTestMethod(RetryingTestTestCase.class, "failsFirstWithExpectedThenWithUnexpectedException");
+				.executeTestMethod(RetryingTestTestCases.class, "failsFirstWithExpectedThenWithUnexpectedException");
 
 		assertThat(results)
 				.hasNumberOfDynamicallyRegisteredTests(2)
@@ -95,7 +95,7 @@ class RetryingTestExtensionTests {
 
 	@Test
 	void failsAlways_executedThreeTimes_fails() {
-		ExecutionResults results = PioneerTestKit.executeTestMethod(RetryingTestTestCase.class, "failsAlways");
+		ExecutionResults results = PioneerTestKit.executeTestMethod(RetryingTestTestCases.class, "failsAlways");
 
 		assertThat(results)
 				.hasNumberOfDynamicallyRegisteredTests(3)
@@ -105,7 +105,7 @@ class RetryingTestExtensionTests {
 
 	@Test
 	void skipByAssumption_executedOnce_skipped() {
-		ExecutionResults results = PioneerTestKit.executeTestMethod(RetryingTestTestCase.class, "skipByAssumption");
+		ExecutionResults results = PioneerTestKit.executeTestMethod(RetryingTestTestCases.class, "skipByAssumption");
 
 		assertThat(results).hasSingleDynamicallyRegisteredTest();
 		assertThat(results).hasSingleAbortedTest();
@@ -114,7 +114,7 @@ class RetryingTestExtensionTests {
 	@Test
 	void failsFirstWithExpectedExceptionThenSkippedByAssumption_executedTwice_skipped() {
 		ExecutionResults results = PioneerTestKit
-				.executeTestMethod(RetryingTestTestCase.class,
+				.executeTestMethod(RetryingTestTestCases.class,
 					"failsFirstWithExpectedExceptionThenSkippedByAssumption");
 
 		assertThat(results).hasNumberOfDynamicallyRegisteredTests(2).hasNumberOfAbortedTests(2);
@@ -122,7 +122,7 @@ class RetryingTestExtensionTests {
 
 	@Test
 	void executesTwice_succeeds() {
-		ExecutionResults results = PioneerTestKit.executeTestMethod(RetryingTestTestCase.class, "executesTwice");
+		ExecutionResults results = PioneerTestKit.executeTestMethod(RetryingTestTestCases.class, "executesTwice");
 
 		assertThat(results)
 				.hasNumberOfDynamicallyRegisteredTests(2)
@@ -134,7 +134,7 @@ class RetryingTestExtensionTests {
 	@Test
 	void executesTwiceWithTwoFails_succeeds() {
 		ExecutionResults results = PioneerTestKit
-				.executeTestMethod(RetryingTestTestCase.class, "executesTwiceWithTwoFails");
+				.executeTestMethod(RetryingTestTestCases.class, "executesTwiceWithTwoFails");
 
 		assertThat(results)
 				.hasNumberOfDynamicallyRegisteredTests(4)
@@ -146,7 +146,7 @@ class RetryingTestExtensionTests {
 	@Test
 	void executesOnceWithThreeFails_fails() {
 		ExecutionResults results = PioneerTestKit
-				.executeTestMethod(RetryingTestTestCase.class, "executesOnceWithThreeFails");
+				.executeTestMethod(RetryingTestTestCases.class, "executesOnceWithThreeFails");
 
 		assertThat(results)
 				.hasNumberOfDynamicallyRegisteredTests(4)
@@ -157,7 +157,7 @@ class RetryingTestExtensionTests {
 
 	@Test
 	void failsThreeTimes_fails() {
-		ExecutionResults results = PioneerTestKit.executeTestMethod(RetryingTestTestCase.class, "failsThreeTimes");
+		ExecutionResults results = PioneerTestKit.executeTestMethod(RetryingTestTestCases.class, "failsThreeTimes");
 
 		assertThat(results)
 				.hasNumberOfDynamicallyRegisteredTests(3)
@@ -168,14 +168,14 @@ class RetryingTestExtensionTests {
 
 	@Test
 	void missingMaxAttempts_fails() {
-		ExecutionResults results = PioneerTestKit.executeTestMethod(RetryingTestTestCase.class, "missingMaxAttempts");
+		ExecutionResults results = PioneerTestKit.executeTestMethod(RetryingTestTestCases.class, "missingMaxAttempts");
 
 		assertThat(results).hasNumberOfDynamicallyRegisteredTests(0);
 	}
 
 	@Test
 	void valueLessThanOne_fails() {
-		ExecutionResults results = PioneerTestKit.executeTestMethod(RetryingTestTestCase.class, "valueLessThanOne");
+		ExecutionResults results = PioneerTestKit.executeTestMethod(RetryingTestTestCases.class, "valueLessThanOne");
 
 		assertThat(results).hasNumberOfDynamicallyRegisteredTests(0);
 	}
@@ -183,7 +183,7 @@ class RetryingTestExtensionTests {
 	@Test
 	void maxAttemptsLessThanOne_fails() {
 		ExecutionResults results = PioneerTestKit
-				.executeTestMethod(RetryingTestTestCase.class, "maxAttemptsLessThanOne");
+				.executeTestMethod(RetryingTestTestCases.class, "maxAttemptsLessThanOne");
 
 		assertThat(results).hasNumberOfDynamicallyRegisteredTests(0);
 	}
@@ -191,7 +191,7 @@ class RetryingTestExtensionTests {
 	@Test
 	void maxAttemptsAndValueSet_fails() {
 		ExecutionResults results = PioneerTestKit
-				.executeTestMethod(RetryingTestTestCase.class, "maxAttemptsAndValueSet");
+				.executeTestMethod(RetryingTestTestCases.class, "maxAttemptsAndValueSet");
 
 		assertThat(results).hasNumberOfDynamicallyRegisteredTests(0);
 	}
@@ -199,7 +199,7 @@ class RetryingTestExtensionTests {
 	@Test
 	void maxAttemptsEqualsMinSuccess_fails() {
 		ExecutionResults results = PioneerTestKit
-				.executeTestMethod(RetryingTestTestCase.class, "maxAttemptsEqualsMinSuccess");
+				.executeTestMethod(RetryingTestTestCases.class, "maxAttemptsEqualsMinSuccess");
 
 		assertThat(results).hasNumberOfDynamicallyRegisteredTests(0);
 	}
@@ -207,7 +207,7 @@ class RetryingTestExtensionTests {
 	@Test
 	void maxAttemptsLessThanMinSuccess_fails() {
 		ExecutionResults results = PioneerTestKit
-				.executeTestMethod(RetryingTestTestCase.class, "maxAttemptsLessThanMinSuccess");
+				.executeTestMethod(RetryingTestTestCases.class, "maxAttemptsLessThanMinSuccess");
 
 		assertThat(results).hasNumberOfDynamicallyRegisteredTests(0);
 	}
@@ -215,7 +215,7 @@ class RetryingTestExtensionTests {
 	@Test
 	void minSuccessLessThanOne_fails() {
 		ExecutionResults results = PioneerTestKit
-				.executeTestMethod(RetryingTestTestCase.class, "minSuccessLessThanOne");
+				.executeTestMethod(RetryingTestTestCases.class, "minSuccessLessThanOne");
 
 		assertThat(results).hasNumberOfDynamicallyRegisteredTests(0);
 	}
@@ -229,7 +229,7 @@ class RetryingTestExtensionTests {
 	// this lead to flaky tests under threading. Using a `PER_CLASS` lifecycle allows us to make it an
 	// instance field and that worked.
 	@TestInstance(PER_CLASS)
-	static class RetryingTestTestCase {
+	static class RetryingTestTestCases {
 
 		private int executionCount;
 

--- a/src/test/java/org/junitpioneer/jupiter/StdIoExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/StdIoExtensionTests.java
@@ -215,7 +215,7 @@ public class StdIoExtensionTests {
 		@WritesStdIo
 		@DisplayName("correctly, no exception is thrown")
 		void correctConfigurations() {
-			ExecutionResults results = executeTestClass(CorrectConfigurations.class);
+			ExecutionResults results = executeTestClass(CorrectConfigurationTestCases.class);
 
 			assertThat(results).hasNumberOfStartedTests(3).hasNumberOfSucceededTests(3);
 		}
@@ -223,7 +223,7 @@ public class StdIoExtensionTests {
 		@Test
 		@DisplayName("without input but StdIn parameter, an exception is thrown")
 		void withoutInputWithStdInParameter() {
-			ExecutionResults results = executeTestMethodWithParameterTypes(IllegalConfigurations.class,
+			ExecutionResults results = executeTestMethodWithParameterTypes(IllegalConfigurationTestCases.class,
 				"noInputButStdIn", StdIn.class);
 
 			assertThat(results).hasSingleFailedTest();
@@ -232,14 +232,14 @@ public class StdIoExtensionTests {
 		@Test
 		@DisplayName("without input and without parameters, an exception is thrown")
 		void withoutInputAndWithoutParameters() {
-			ExecutionResults results = executeTestMethod(IllegalConfigurations.class, "noParameterAndNoInput");
+			ExecutionResults results = executeTestMethod(IllegalConfigurationTestCases.class, "noParameterAndNoInput");
 
 			assertThat(results).hasSingleFailedTest();
 		}
 
 	}
 
-	static class CorrectConfigurations {
+	static class CorrectConfigurationTestCases {
 
 		@Test
 		@StdIo("Redirected output")
@@ -258,7 +258,7 @@ public class StdIoExtensionTests {
 
 	}
 
-	static class IllegalConfigurations {
+	static class IllegalConfigurationTestCases {
 
 		@Test
 		@StdIo

--- a/src/test/java/org/junitpioneer/jupiter/StopwatchExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/StopwatchExtensionTests.java
@@ -25,8 +25,7 @@ public class StopwatchExtensionTests {
 	@Test
 	void runClassLevelAnnotationTest() {
 
-		ExecutionResults results = PioneerTestKit
-				.executeTestClass(StopwatchExtensionTests.ClassLevelAnnotationTest.class);
+		ExecutionResults results = PioneerTestKit.executeTestClass(ClassLevelAnnotationTestCases.class);
 
 		PioneerAssert.assertThat(results).hasNumberOfReportEntries(1);
 
@@ -40,8 +39,7 @@ public class StopwatchExtensionTests {
 	void runClassAndMethodLevelAnnotationTest() {
 		String methodName = "stopwatchExtensionShouldBeExecutedWithAnnotationOnClassAndMethodLevel";
 
-		ExecutionResults results = PioneerTestKit
-				.executeTestClass(StopwatchExtensionTests.ClassAndMethodLevelAnnotationTest.class);
+		ExecutionResults results = PioneerTestKit.executeTestClass(ClassAndMethodLevelAnnotationTestCases.class);
 		PioneerAssert.assertThat(results).hasNumberOfReportEntries(1);
 
 		assertStringStartWithUnitAndContainsName(results, methodName);
@@ -52,8 +50,7 @@ public class StopwatchExtensionTests {
 	void runMethodLevelAnnotationTest() {
 		String methodName = "stopwatchExtensionShouldBeExecutedOnWithAnnotationOnMethodLevel";
 
-		ExecutionResults results = PioneerTestKit
-				.executeTestMethod(StopwatchExtensionTests.MethodLevelAnnotationTest.class, methodName);
+		ExecutionResults results = PioneerTestKit.executeTestMethod(MethodLevelAnnotationTestCases.class, methodName);
 		PioneerAssert.assertThat(results).hasNumberOfReportEntries(1);
 
 		assertStringStartWithUnitAndContainsName(results, methodName);
@@ -64,8 +61,7 @@ public class StopwatchExtensionTests {
 	void runAnnotationTest() {
 		String methodName = "stopwatchExtensionShouldNotBeExecuted";
 
-		ExecutionResults results = PioneerTestKit
-				.executeTestMethod(StopwatchExtensionTests.NonAnnotationTest.class, methodName);
+		ExecutionResults results = PioneerTestKit.executeTestMethod(NonAnnotationTestCases.class, methodName);
 		PioneerAssert.assertThat(results).hasNumberOfReportEntries(0);
 
 	}
@@ -82,7 +78,7 @@ public class StopwatchExtensionTests {
 	 * Inner test class for testing the class level annotation.
 	 */
 	@Stopwatch
-	static class ClassLevelAnnotationTest {
+	static class ClassLevelAnnotationTestCases {
 
 		@Test
 		void stopwatchExtensionShouldBeExecutedWithAnnotationOnClassLevel() {
@@ -93,7 +89,7 @@ public class StopwatchExtensionTests {
 	/**
 	 * Inner test class for testing the method level annotation.
 	 */
-	static class MethodLevelAnnotationTest {
+	static class MethodLevelAnnotationTestCases {
 
 		@Stopwatch
 		@Test
@@ -106,7 +102,7 @@ public class StopwatchExtensionTests {
 	 * Inner test class for testing the class level annotation.
 	 */
 	@Stopwatch
-	static class ClassAndMethodLevelAnnotationTest {
+	static class ClassAndMethodLevelAnnotationTestCases {
 
 		@Stopwatch
 		@Test
@@ -118,7 +114,7 @@ public class StopwatchExtensionTests {
 	/**
 	 * Inner test class for testing a not annotated method / class annotation.
 	 */
-	static class NonAnnotationTest {
+	static class NonAnnotationTestCases {
 
 		@Test
 		void stopwatchExtensionShouldNotBeExecuted() {

--- a/src/test/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtensionTests.java
@@ -349,7 +349,7 @@ public class CartesianTestExtensionTests {
 			@Test
 			@DisplayName("when test class has a constructor with auto-injected values")
 			void testClassWithConstructor() {
-				ExecutionResults results = PioneerTestKit.executeTestClass(TestClassWithConstructor.class);
+				ExecutionResults results = PioneerTestKit.executeTestClass(TestClassWithConstructorTestCases.class);
 
 				assertThat(results).hasNumberOfDynamicallyRegisteredTests(4).hasNumberOfSucceededTests(4);
 				assertThat(results).hasNumberOfReportEntries(4).withValues("13", "14", "23", "24");
@@ -903,11 +903,11 @@ public class CartesianTestExtensionTests {
 
 	}
 
-	static class TestClassWithConstructor {
+	static class TestClassWithConstructorTestCases {
 
 		private final TestInfo testInfo;
 
-		TestClassWithConstructor(TestInfo info) {
+		TestClassWithConstructorTestCases(TestInfo info) {
 			this.testInfo = info;
 		}
 

--- a/src/test/java/org/junitpioneer/jupiter/params/RangeSourceArgumentsProviderTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/params/RangeSourceArgumentsProviderTests.java
@@ -163,11 +163,11 @@ class RangeSourceArgumentsProviderTests {
 	}
 
 	@Nested
-	class InvalidRangeTestCases {
+	class InvalidRangeTests {
 
 		@Test
 		void twoAnnotations() {
-			ExecutionResults results = PioneerTestKit.executeTestMethod(InvalidRanges.class, "twoAnnotations");
+			ExecutionResults results = PioneerTestKit.executeTestMethod(InvalidRangeTestCases.class, "twoAnnotations");
 
 			assertThat(results)
 					.hasSingleFailedContainer()
@@ -177,7 +177,7 @@ class RangeSourceArgumentsProviderTests {
 
 		@Test
 		void zeroStep() {
-			ExecutionResults results = PioneerTestKit.executeTestMethod(InvalidRanges.class, "zeroStep");
+			ExecutionResults results = PioneerTestKit.executeTestMethod(InvalidRangeTestCases.class, "zeroStep");
 
 			assertThat(results)
 					.hasSingleFailedContainer()
@@ -187,7 +187,7 @@ class RangeSourceArgumentsProviderTests {
 
 		@Test
 		void illegalStep() {
-			ExecutionResults results = PioneerTestKit.executeTestMethod(InvalidRanges.class, "illegalStep");
+			ExecutionResults results = PioneerTestKit.executeTestMethod(InvalidRangeTestCases.class, "illegalStep");
 
 			assertThat(results)
 					.hasSingleFailedContainer()
@@ -197,7 +197,7 @@ class RangeSourceArgumentsProviderTests {
 
 		@Test
 		void emptyRange() {
-			ExecutionResults results = PioneerTestKit.executeTestMethod(InvalidRanges.class, "emptyRange");
+			ExecutionResults results = PioneerTestKit.executeTestMethod(InvalidRangeTestCases.class, "emptyRange");
 
 			assertThat(results)
 					.hasSingleFailedContainer()
@@ -207,7 +207,7 @@ class RangeSourceArgumentsProviderTests {
 
 	}
 
-	static class InvalidRanges {
+	static class InvalidRangeTestCases {
 
 		@IntRangeSource(from = 1, to = 2)
 		@LongRangeSource(from = 1L, to = 2L)

--- a/src/test/java/org/junitpioneer/vintage/TestIntegrationTests.java
+++ b/src/test/java/org/junitpioneer/vintage/TestIntegrationTests.java
@@ -28,14 +28,14 @@ class TestIntegrationTests {
 
 	@org.junit.jupiter.api.Test
 	void test_successfulTest_passes() throws Exception {
-		ExecutionResults results = PioneerTestKit.executeTestMethod(TestTestCase.class, "test_successfulTest");
+		ExecutionResults results = PioneerTestKit.executeTestMethod(TestTestCases.class, "test_successfulTest");
 
 		assertThat(results).hasSingleStartedTest().whichSucceeded();
 	}
 
 	@org.junit.jupiter.api.Test
 	void test_exceptionThrown_fails() throws Exception {
-		ExecutionResults results = PioneerTestKit.executeTestMethod(TestTestCase.class, "test_exceptionThrown");
+		ExecutionResults results = PioneerTestKit.executeTestMethod(TestTestCases.class, "test_exceptionThrown");
 
 		assertThat(results).hasSingleStartedTest().whichFailed();
 	}
@@ -45,7 +45,7 @@ class TestIntegrationTests {
 	@org.junit.jupiter.api.Test
 	void testWithExpectedException_successfulTest_fails() {
 		ExecutionResults results = PioneerTestKit
-				.executeTestMethod(TestTestCase.class, "testWithExpectedException_successfulTest");
+				.executeTestMethod(TestTestCases.class, "testWithExpectedException_successfulTest");
 
 		assertThat(results)
 				.hasSingleStartedTest()
@@ -57,7 +57,7 @@ class TestIntegrationTests {
 	@org.junit.jupiter.api.Test
 	void testWithExpectedException_exceptionThrownOfRightType_passes() {
 		ExecutionResults results = PioneerTestKit
-				.executeTestMethod(TestTestCase.class, "testWithExpectedException_exceptionThrownOfRightType");
+				.executeTestMethod(TestTestCases.class, "testWithExpectedException_exceptionThrownOfRightType");
 
 		assertThat(results).hasSingleStartedTest().whichSucceeded();
 	}
@@ -65,7 +65,7 @@ class TestIntegrationTests {
 	@org.junit.jupiter.api.Test
 	void testWithExpectedException_exceptionThrownOfSubtype_passes() {
 		ExecutionResults results = PioneerTestKit
-				.executeTestMethod(TestTestCase.class, "testWithExpectedException_exceptionThrownOfSubtype");
+				.executeTestMethod(TestTestCases.class, "testWithExpectedException_exceptionThrownOfSubtype");
 
 		assertThat(results).hasSingleStartedTest().whichSucceeded();
 	}
@@ -73,7 +73,7 @@ class TestIntegrationTests {
 	@org.junit.jupiter.api.Test
 	void testWithExpectedException_exceptionThrownOfSupertype_fails() {
 		ExecutionResults results = PioneerTestKit
-				.executeTestMethod(TestTestCase.class, "testWithExpectedException_exceptionThrownOfSupertype");
+				.executeTestMethod(TestTestCases.class, "testWithExpectedException_exceptionThrownOfSupertype");
 
 		assertThat(results).hasSingleStartedTest().whichFailed().withExceptionInstanceOf(RuntimeException.class);
 	}
@@ -82,14 +82,15 @@ class TestIntegrationTests {
 
 	@org.junit.jupiter.api.Test
 	void testWithTimeout_belowZero_failsConfiguration() {
-		ExecutionResults results = PioneerTestKit.executeTestMethod(TestTestCase.class, "testWithTimeout_belowZero");
+		ExecutionResults results = PioneerTestKit.executeTestMethod(TestTestCases.class, "testWithTimeout_belowZero");
 
 		assertThat(results).hasSingleFailedTest().withExceptionInstanceOf(ExtensionConfigurationException.class);
 	}
 
 	@org.junit.jupiter.api.Test
 	void testWithTimeout_belowTimeout_passes() {
-		ExecutionResults results = PioneerTestKit.executeTestMethod(TestTestCase.class, "testWithTimeout_belowTimeout");
+		ExecutionResults results = PioneerTestKit
+				.executeTestMethod(TestTestCases.class, "testWithTimeout_belowTimeout");
 
 		assertThat(results).hasSingleStartedTest().whichSucceeded();
 	}
@@ -97,7 +98,7 @@ class TestIntegrationTests {
 	@org.junit.jupiter.api.Test
 	void testWithTimeout_exceedsTimeout_fails() throws Exception {
 		ExecutionResults results = PioneerTestKit
-				.executeTestMethod(TestTestCase.class, "testWithTimeout_exceedsTimeout");
+				.executeTestMethod(TestTestCases.class, "testWithTimeout_exceedsTimeout");
 		String expectedMessage = format(TimeoutExtension.TEST_RAN_TOO_LONG, "testWithTimeout_exceedsTimeout()", 1);
 		// the message contains the actual run time, which is unpredictable, so it has to be cut off for the assertion
 		String expectedKnownPrefix = expectedMessage.substring(0, expectedMessage.length() - 6);
@@ -111,7 +112,7 @@ class TestIntegrationTests {
 
 	// TEST CASES -------------------------------------------------------------------
 
-	static class TestTestCase {
+	static class TestTestCases {
 
 		@Test
 		void test_successfulTest() {


### PR DESCRIPTION
Mentions in CONTRIBUTING that test classes must end with `Tests`, as required here:
https://github.com/junit-pioneer/junit-pioneer/blob/9ccc619ea1cf5f48696328b47e450cded339af09/build.gradle.kts#L216

However, maybe it would make sense to also allow the suffix `Test`? Because that is common in other projects and build tools (e.g. Maven Surefire) and otherwise leads to tests not being executed by Gradle by accident.

Proposed commit message:

```
Mention in CONTRIBUTING that test classes must end with `Tests` (#543)

PR: #543
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [x] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [x] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [x] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [x] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [x] The `package-info.java` contains information about the new extension

Code
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [x] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 
☝️ Is this required? For such a small change it does not seem worth it.

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
