### PR TITLE
Use HTTPS URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ local.properties
 build/
 
 # JVM crash logs
-# see http://www.java.com/en/download/help/error_hotspot.xml
+# see https://www.java.com/en/download/help/error_hotspot.html
 hs_err_pid*
 
 # MacOS

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,7 +223,7 @@ One aspect that's relevant to contributors is the list of contributions at the e
 
 #### Line Endings
 
-We [mind the end of our lines](http://adaptivepatchwork.com/2012/03/01/mind-the-end-of-your-line/) and have [instructed](.gitattributes) Git to replace all line endings with `LF` (the non-Windows variant) when writing files to the working directory.
+We [mind the end of our lines](https://adaptivepatchwork.com/2012/03/01/mind-the-end-of-your-line/) and have [instructed](.gitattributes) Git to replace all line endings with `LF` (the non-Windows variant) when writing files to the working directory.
 If you're on Windows and prefer `CRLF` line endings, consider setting `core.autocrlf` to `true`:
 
 ```bash
@@ -258,8 +258,7 @@ Lab branches should be deleted once they become obsolete - when that is the case
 
 While it is nice to have each individual commit pass the build, this is not a requirement - it is the contributor's branch to play on.
 
-As a general rule, the style and formatting of commit messages should follow the [guidelines for good Git commit messages](http://chris.beams.io/posts/git-commit/).
-Because of the noise it generates on the issue, please do _not_ mention the issue number in the message.
+See section [Commit Message](#commit-message) for how the commit message should look like.
 
 ### Pull Requests
 
@@ -290,7 +289,9 @@ This can be achieved with GitHub's [_squash and merge_](https://help.github.com/
 
 ### Commit Message
 
-To make the single commit expressive, its message must be detailed and [good]((http://chris.beams.io/posts/git-commit/)) (really, read that post!).
+Because of the noise it generates on the issue, please do _not_ mention the issue number in the message.
+
+To make the single commit expressive, its message must be detailed and [good]((https://chris.beams.io/posts/git-commit/)) (really, read that post!).
 Furthermore, it must follow this structure:
 
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -258,7 +258,7 @@ Lab branches should be deleted once they become obsolete - when that is the case
 
 While it is nice to have each individual commit pass the build, this is not a requirement - it is the contributor's branch to play on.
 
-See section [Commit Message](#commit-message) for how the commit message should look like.
+See section [_Commit Message_](#commit-message) for how the commit message should look like.
 
 ### Pull Requests
 
@@ -288,8 +288,6 @@ A pull request is accepted by squashing the commits and fast-forwarding `main`, 
 This can be achieved with GitHub's [_squash and merge_](https://help.github.com/articles/about-pull-request-merges/#squash-and-merge-your-pull-request-commits) feature.
 
 ### Commit Message
-
-Because of the noise it generates on the issue, please do _not_ mention the issue number in the message.
 
 To make the single commit expressive, its message must be detailed and [good]((https://chris.beams.io/posts/git-commit/)) (really, read that post!).
 Furthermore, it must follow this structure:
@@ -345,6 +343,7 @@ Closes: #30
 Closes: #31
 ```
 
+Finally, because of the noise it generates on the issue, please do _not_ mention the issue number in the message during development.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 A melting pot for all kinds of extensions to
 [JUnit 5](https://github.com/junit-team/junit5), particular to its Jupiter API.
 
-Check out [junit-pioneer.org](http://junit-pioneer.org), particularly [the documentation section](http://junit-pioneer.org/docs).
+Check out [junit-pioneer.org](https://junit-pioneer.org/), particularly [the documentation section](https://junit-pioneer.org/docs/).
 
 
 ## A Pioneer's Mission
@@ -22,7 +22,7 @@ To enable easy exchange of code with JUnit 5, JUnit Pioneer copies most of its i
 
 ## Getting on Board
 
-JUnit Pioneer is released on [GitHub](https://github.com/junit-pioneer/junit-pioneer/releases) and [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.junit-pioneer%22%20a%3A%22junit-pioneer%22). Coordinates:
+JUnit Pioneer is released on [GitHub](https://github.com/junit-pioneer/junit-pioneer/releases) and [Maven Central](https://search.maven.org/artifact/org.junit-pioneer/junit-pioneer). Coordinates:
 
 * group ID: `org.junit-pioneer`
 * artifact ID: `junit-pioneer`

--- a/docs/environment-variables.adoc
+++ b/docs/environment-variables.adoc
@@ -100,7 +100,7 @@ The next best thing is to allow access to that specific package with `--add-open
 These command line options need to be added to the JVM that executes the tests:
 
 * https://docs.gradle.org/current/dsl/org.gradle.api.tasks.testing.Test.html[Gradle]
-* http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#argLine[Maven basics] and https://nipafx.dev/maven-on-java-9/[advanced]
+* https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#argLine[Maven basics] and https://nipafx.dev/maven-on-java-9/[advanced]
 
 == Thread-Safety
 

--- a/docs/project-page.adoc
+++ b/docs/project-page.adoc
@@ -12,7 +12,7 @@ It offers https://junit-pioneer.org/docs/[a wide variety of extensions] and is c
 
 == Quick start
 
-Determine the latest version (e.g. on http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.junit-pioneer%22%20a%3A%22junit-pioneer%22"[Maven Central]) and add Pioneer as a test dependency.
+Determine the latest version (e.g. on https://search.maven.org/artifact/org.junit-pioneer/junit-pioneer[Maven Central]) and add Pioneer as a test dependency.
 
 Maven:
 

--- a/docs/retrying-test.adoc
+++ b/docs/retrying-test.adoc
@@ -27,7 +27,7 @@ The default for `minSuccess` is 1. The value must be greater than or equal to 1.
 
 === onExceptions [optional]
 
-By default a test annotated with `@RetryingTest` will be retried on all exceptions except http://ota4j-team.github.io/opentest4j/docs/current/api/org/opentest4j/TestAbortedException.html[`TestAbortedException`] (which will abort the test entirely).
+By default a test annotated with `@RetryingTest` will be retried on all exceptions except https://ota4j-team.github.io/opentest4j/docs/current/api/org/opentest4j/TestAbortedException.html[`TestAbortedException`] (which will abort the test entirely).
 To only retry on specific exceptions, use `onExceptions`.
 
 == Basic Use

--- a/src/test/java/org/junitpioneer/testkit/assertion/AbstractPioneerAssert.java
+++ b/src/test/java/org/junitpioneer/testkit/assertion/AbstractPioneerAssert.java
@@ -23,7 +23,7 @@ import org.assertj.core.api.AbstractAssert;
  * <p>assertThat(results).hasNumberOfTests(3).thatStarted().andAllOfThemFailed()</p>
  *
  * @param <SELF> the "self" type of this assertion class. Please read
- *          &quot;<a href="http://web.archive.org/web/20130721224442/http:/passion.forco.de/content/emulating-self-types-using-java-generics-simplify-fluent-api-implementation" target="_blank">
+ *          &quot;<a href="https://web.archive.org/web/20130721224442/http:/passion.forco.de/content/emulating-self-types-using-java-generics-simplify-fluent-api-implementation" target="_blank">
  *          Emulating 'self types' using Java Generics to simplify fluent API implementation</a>&quot;
  *          for more details.
  * @param <ACTUAL> the type of the "actual" value.


### PR DESCRIPTION
Where supported use HTTPS instead of HTTP URLs. Mockito seems to use a malformed HTTPS ceritificate and http://shipkit.org/ seems to be unreachable, therefore I have not adjusted these URLs.

Additionally it would be good if you could change the "About" section of this repository to use an HTTPS URL as well:
![About section screenshot](https://user-images.githubusercontent.com/11685886/142783936-7f0c2cd4-5214-4aa2-947f-edf0444f84e0.png)


Proposed commit message:

```
Use HTTPS URLs (#544)

Where supported use HTTPS instead of HTTP URLs.

PR: #544
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [x] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [x] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [x] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [x] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [x] The `package-info.java` contains information about the new extension

Code
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [x] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 
☝️ Is this needed for such a small change?

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
