### PR TITLE
Replace references to old RetryingTest class name

### DIFF
--- a/src/main/java/org/junitpioneer/jupiter/RetryingTest.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTest.java
@@ -58,12 +58,14 @@ import org.junit.jupiter.api.parallel.Execution;
  *
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,
- * all repetitions of a {@code @RepeatFailedTest} are executed sequentially to guarantee thread-safety.
+ * all repetitions of a {@code RetryingTest} are executed sequentially to guarantee thread-safety.
  * </p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/repeat-failed-test/" target="_top">the documentation on <code>@RepeatFailedTest</code></a>.
+ * <a href="https://junit-pioneer.org/docs/retrying-test/" target="_top">the documentation on <code>@RetryingTest</code></a>.
  * </p>
+ *
+ * <p>Before version 0.7.0 this annotation was called {@code @RepeatFailedTest}.
  *
  * @since 0.4
  */


### PR DESCRIPTION
Replaces some references to the old `@RetryingTest` class name (`@RepeatFailedTest`) which were missed by #236 or added afterwards.

Proposed commit message:

```
Replace references to old RetryingTest class name (#545)

PR: #545
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [x] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [x] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [x] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [x] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [x] The `package-info.java` contains information about the new extension

Code
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [x] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 
☝️ Is this necessary for such a small change?

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
