### PR TITLE
Update to Log4J2 2.17.0 (#562 / #563)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,8 +65,8 @@ dependencies {
 	testImplementation(group = "com.google.jimfs", name = "jimfs", version = "1.2")
 	testImplementation(group = "nl.jqno.equalsverifier", name = "equalsverifier", version = "3.7.1")
 
-	testRuntimeOnly(group = "org.apache.logging.log4j", name = "log4j-core", version = "2.14.1")
-	testRuntimeOnly(group = "org.apache.logging.log4j", name = "log4j-jul", version = "2.14.1")
+	testRuntimeOnly(group = "org.apache.logging.log4j", name = "log4j-core", version = "2.17.0")
+	testRuntimeOnly(group = "org.apache.logging.log4j", name = "log4j-jul", version = "2.17.0")
 }
 
 spotless {


### PR DESCRIPTION
Closes #562 

```
Update to Log4J2 2.17.0 (#562 / #563)

This commits updates the used version of Log4J2 to 2.17.0 as lower versions are known to contain vulnerabilities with CVE-score of 9+

Proposed commit message:

fixes: #562
PR: #563
```

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
