### PR TITLE
Improve Javadoc creation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -233,7 +233,11 @@ tasks {
 		})
 
 		// Exclude internal implementation package from javadoc
-		exclude("org/junitpioneer/internal")
+		/*
+		 * TODO: Currently disabled because modular Gradle build fails when this package is excluded
+		 * See https://stackoverflow.com/q/32785002 and slightly related Gradle issue https://github.com/gradle/gradle/issues/14066
+		*/
+		//exclude("org/junitpioneer/internal")
 
 		options {
 			// Cast to standard doclet options, see https://github.com/gradle/gradle/issues/7038#issuecomment-448294937
@@ -244,7 +248,8 @@ tasks {
 
 			// Set javadoc `--release` flag (affects which warnings and errors are reported)
 			// (Note: Gradle adds one leading '-' to the option on its own)
-			addStringOption("-release", targetJavaVersion.majorVersion)
+			// Have to use at least Java 9 to support modular build
+			addStringOption("-release", maxOf(9, targetJavaVersion.majorVersion.toInt()).toString())
 
 			// Enable doclint, but ignore warnings for missing tags, see
 			// https://docs.oracle.com/en/java/javase/17/docs/specs/man/javadoc.html#additional-options-provided-by-the-standard-doclet

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,7 +99,7 @@ jacoco {
 }
 
 sonarqube {
-	// If you want to use this logically a sonarLogin has to be provided, either via Username and Password
+	// If you want to use this locally a sonarLogin has to be provided, either via Username and Password
 	// or via token, https://docs.sonarqube.org/latest/analysis/analysis-parameters/
 	properties {
 		// Default properties if somebody wants to execute it locally

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -227,6 +227,11 @@ tasks {
 	}
 
 	javadoc {
+		javadocTool.set(project.javaToolchains.javadocToolFor {
+			// Create Javadoc with newer JDK to get the latest features, e.g. search bar
+			languageVersion.set(JavaLanguageVersion.of(17))
+		})
+
 		// Exclude internal implementation package from javadoc
 		exclude("org/junitpioneer/internal")
 
@@ -234,18 +239,18 @@ tasks {
 			// Cast to standard doclet options, see https://github.com/gradle/gradle/issues/7038#issuecomment-448294937
 			this as StandardJavadocDocletOptions
 
+			encoding = "UTF-8"
 			links = listOf("https://junit.org/junit5/docs/current/api/")
 
 			// Set javadoc `--release` flag (affects which warnings and errors are reported)
 			// (Note: Gradle adds one leading '-' to the option on its own)
-			addStringOption("-release", targetJavaVersion.getMajorVersion())
+			addStringOption("-release", targetJavaVersion.majorVersion)
 
 			// Enable doclint, but ignore warnings for missing tags, see
 			// https://docs.oracle.com/en/java/javase/17/docs/specs/man/javadoc.html#additional-options-provided-by-the-standard-doclet
 			// The Gradle option methods are rather misleading, but a boolean `true` value just makes sure the flag
 			// is passed to javadoc, see https://github.com/gradle/gradle/issues/2354
 			addBooleanOption("Xdoclint:all,-missing", true)
-			encoding = "UTF-8"
 		}
 
 		shouldRunAfter(test)
@@ -287,11 +292,4 @@ tasks {
 		githubToken = generateChangelogTask.githubToken
 		newTagRevision = System.getenv("GITHUB_SHA")
 	}
-}
-
-tasks.withType<Javadoc>().configureEach {
-	javadocTool.set(javaToolchains.javadocToolFor {
-		// Create Javadoc with newer JDK to get the latest features, e.g. search bar
-		languageVersion.set(JavaLanguageVersion.of(17))
-	})
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -237,6 +237,7 @@ tasks {
 			links = listOf("https://junit.org/junit5/docs/current/api/")
 
 			// Set javadoc `--release` flag (affects which warnings and errors are reported)
+			// (Note: Gradle adds one leading '-' to the option on its own)
 			addStringOption("-release", targetJavaVersion.getMajorVersion())
 
 			// Enable doclint, but ignore warnings for missing tags, see

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -234,10 +234,12 @@ tasks {
 
 		// Exclude internal implementation package from javadoc
 		/*
-		 * TODO: Currently disabled because modular Gradle build fails when this package is excluded
+		 * Disabled for modular Gradle build because it fails when these source files are excluded
 		 * See https://stackoverflow.com/q/32785002 and slightly related Gradle issue https://github.com/gradle/gradle/issues/14066
-		*/
-		//exclude("org/junitpioneer/internal")
+		 */
+		if (!modularBuild.toBoolean()) {
+			exclude("org/junitpioneer/internal")
+		}
 
 		options {
 			// Cast to standard doclet options, see https://github.com/gradle/gradle/issues/7038#issuecomment-448294937

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,7 +95,7 @@ yamlValidator {
 }
 
 jacoco {
-	toolVersion = "0.8.6"
+	toolVersion = "0.8.7"
 }
 
 sonarqube {

--- a/src/main/java/org/junitpioneer/vintage/package-info.java
+++ b/src/main/java/org/junitpioneer/vintage/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Contains extensions to JUnit Vintage, i.e. functionality that is concerned with older JUnit versions.
+ * {@summary Contains extensions to JUnit Vintage, i.e. functionality that is concerned with older JUnit versions.}
  *
  * <p>Check out the following types for details:
  * <ul>


### PR DESCRIPTION
Resolves #522

Proposed commit message:

```
Improve Javadoc creation (#522 / #566)

Resolves: #522
PR: #566
```

Improves Javadoc creation by:
- Using [Gradle toolchains](https://docs.gradle.org/current/userguide/toolchains.html) to create the Javadoc with JDK 17
- Add external links to the JUnit Javadoc
- (Implicitly) add external links to the JDK Javadoc
- Enable doclint, except for the `missing` group

Future suggested work:
I currently do not completely understand why the project is built multiple times with different target Java versions and with different modularity settings. In my opinion (but maybe I am overlooking something):
- The project should always be built modular, but 

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [x] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [x] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [x] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [x] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [x] The `package-info.java` contains information about the new extension

Code
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [x] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
