### PR TITLE
Fix broken links in `param` `package-info.java`

### DIFF
--- a/src/main/java/org/junitpioneer/jupiter/params/package-info.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/package-info.java
@@ -11,12 +11,12 @@
  * Argument providers for a range of numbers.
  * <p>Check out the following types for details on providing values for parameterized tests:
  * <ul>
- *     <li>{@link org.junitpioneer.jupiter.params.ByteRange}</li>
- *     <li>{@link org.junitpioneer.jupiter.params.ShortRange}</li>
- *     <li>{@link org.junitpioneer.jupiter.params.IntRange}</li>
- *     <li>{@link org.junitpioneer.jupiter.params.LongRange}</li>
- *     <li>{@link org.junitpioneer.jupiter.params.FloatRange}</li>
- *     <li>{@link org.junitpioneer.jupiter.params.DoubleRange}</li>
+ *     <li>{@link org.junitpioneer.jupiter.params.ByteRangeSource}</li>
+ *     <li>{@link org.junitpioneer.jupiter.params.ShortRangeSource}</li>
+ *     <li>{@link org.junitpioneer.jupiter.params.IntRangeSource}</li>
+ *     <li>{@link org.junitpioneer.jupiter.params.LongRangeSource}</li>
+ *     <li>{@link org.junitpioneer.jupiter.params.FloatRangeSource}</li>
+ *     <li>{@link org.junitpioneer.jupiter.params.DoubleRangeSource}</li>
  * </ul>
  */
 


### PR DESCRIPTION
Proposed commit message:

```
Fix broken links in `params` `package-info.java` (#568)

Documentation referred to internal classes which are not visible in
generated Javadoc documentation.

PR: #568
```

Can be seen here in the generated Javadoc documentation: https://javadoc.io/static/org.junit-pioneer/junit-pioneer/1.5.0/org/junitpioneer/jupiter/params/package-summary.html#package.description

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [x] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [x] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [x] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [x] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [x] The `package-info.java` contains information about the new extension

Code
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [x] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
