### PR TITLE
Improve exception message when modifying environment variables fails

### DIFF
--- a/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableUtils.java
+++ b/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableUtils.java
@@ -95,7 +95,19 @@ class EnvironmentVariableUtils {
 	private static Map<String, String> getFieldValue(Class<?> clazz, Object object, String name)
 			throws ReflectiveOperationException {
 		Field field = clazz.getDeclaredField(name);
-		field.setAccessible(true); //NOSONAR illegal access required to implement the extension
+		try {
+			field.setAccessible(true); //NOSONAR illegal access required to implement the extension
+		}
+		catch (RuntimeException ex) {
+			// Java 9 added InaccessibleObjectException (but this project compiles against Java 8 at the moment)
+			if (ex.getClass().getName().equals("java.lang.reflect.InaccessibleObjectException")) {
+				throw new ExtensionConfigurationException("Cannot access JDK internals to modify environment variables."
+						+ " Have a look at the Javadoc or the documentation for possible solutions.",
+					ex);
+			} else {
+				throw ex;
+			}
+		}
 		return (Map<String, String>) field.get(object);
 	}
 


### PR DESCRIPTION
Relates to #509

Wraps the standard JDK exception "InaccessibleObjectException: Unable to make field ..." with a custom exception to indicate that this is a known issue, and to prevent users from reporting it as bug here.

Proposed commit message:

```
Improve exception message when modifying environment variables fails ()

Relates to: #509
PR: ${pull-request}
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [x] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [x] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [x] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [x] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [x] The `package-info.java` contains information about the new extension

Code
* [x] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
☝️ Have not added tests because it appears Gradle opens the JDK modules by default (?); in Eclipse IDE the tests were passing successfully, but when running Gradle the tests failed (because illegal reflective access was not throwing an exception).
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
