### PR TITLE
Fix tests not reverting system property and environment variable changes

### DIFF
--- a/src/test/java/org/junitpioneer/jupiter/AbstractEntryBasedExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/AbstractEntryBasedExtensionTests.java
@@ -12,6 +12,7 @@ package org.junitpioneer.jupiter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,6 +38,13 @@ class AbstractEntryBasedExtensionTests {
 
 		System.clearProperty(CLEAR_SYSPROP_KEY);
 		System.setProperty(SET_SYSPROP_KEY, SET_SYSPROP_ORIGINAL_VALUE);
+	}
+
+	@AfterEach
+	void tearDown() {
+		// Revert changes to not affect other tests
+		EnvironmentVariableUtils.clear(SET_ENVVAR_KEY);
+		System.clearProperty(SET_SYSPROP_KEY);
 	}
 
 	@Test

--- a/src/test/java/org/junitpioneer/jupiter/AbstractEntryBasedExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/AbstractEntryBasedExtensionTests.java
@@ -42,7 +42,6 @@ class AbstractEntryBasedExtensionTests {
 
 	@AfterEach
 	void tearDown() {
-		// Revert changes to not affect other tests
 		EnvironmentVariableUtils.clear(SET_ENVVAR_KEY);
 		System.clearProperty(SET_SYSPROP_KEY);
 	}

--- a/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
@@ -50,8 +50,11 @@ class EnvironmentVariableExtensionTests {
 	@AfterAll
 	static void globalTearDown() {
 		assertThat(systemEnvironmentVariable("set envvar A")).isEqualTo("old A");
+		EnvironmentVariableUtils.clear("set envvar A");
 		assertThat(systemEnvironmentVariable("set envvar B")).isEqualTo("old B");
+		EnvironmentVariableUtils.clear("set envvar B");
 		assertThat(systemEnvironmentVariable("set envvar C")).isEqualTo("old C");
+		EnvironmentVariableUtils.clear("set envvar C");
 
 		assertThat(systemEnvironmentVariable("clear envvar D")).isNull();
 		assertThat(systemEnvironmentVariable("clear envvar E")).isNull();

--- a/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
@@ -43,8 +43,11 @@ class SystemPropertyExtensionTests {
 	@AfterAll
 	static void globalTearDown() {
 		assertThat(System.getProperty("set prop A")).isEqualTo("old A");
+		System.clearProperty("set prop A");
 		assertThat(System.getProperty("set prop B")).isEqualTo("old B");
+		System.clearProperty("set prop B");
 		assertThat(System.getProperty("set prop C")).isEqualTo("old C");
+		System.clearProperty("set prop C");
 
 		assertThat(System.getProperty("clear prop D")).isNull();
 		assertThat(System.getProperty("clear prop E")).isNull();


### PR DESCRIPTION
Some of the tests related to the system property and environment variable extension were changing system properties and environment variables manually, but were not reverting the changes afterwards.

I have only added the necessary calls to remove the custom entries. A more extensive solution would be to store the existing value (if any) in a field and restore that value afterwards. However, because custom system property and environment variable names are used, there are most likely no existing old values, so that extra logic would probably be redundant.

Also, should these test classes be annotated with `@WritesSystemProperty` and `@WritesEnvironmentVariable`, or was that intentionally not done to prevent spurious test success in case these annotations behave incorrectly?
(And do the tests currently rely on the fact that the used system property and environment variable names are unique per test?)

Proposed commit message:

```
Fix tests not reverting system property and env variable changes (#578)

PR: #578
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [x] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [x] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [x] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [x] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [x] The `package-info.java` contains information about the new extension

Code
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [x] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
