### PR TITLE
Update Javadoc and visibility of classes

### DIFF
--- a/src/main/java/org/junitpioneer/jupiter/CartesianEnumSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/CartesianEnumSource.java
@@ -183,9 +183,15 @@ public @interface CartesianEnumSource {
 
 	}
 
+	/**
+	 * Containing annotation of repeatable {@code CartesianEnumSource}
+	 *
+	 * @deprecated scheduled to be removed in 2.0
+	 */
 	@Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
 	@Retention(RetentionPolicy.RUNTIME)
 	@Documented
+	@Deprecated
 	@interface CartesianEnumSources {
 
 		CartesianEnumSource[] value();

--- a/src/main/java/org/junitpioneer/jupiter/CartesianEnumSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/CartesianEnumSource.java
@@ -184,7 +184,7 @@ public @interface CartesianEnumSource {
 	}
 
 	/**
-	 * Containing annotation of repeatable {@code CartesianEnumSource}
+	 * Containing annotation of repeatable {@code CartesianEnumSource}.
 	 *
 	 * @deprecated scheduled to be removed in 2.0
 	 */

--- a/src/main/java/org/junitpioneer/jupiter/CartesianProductTest.java
+++ b/src/main/java/org/junitpioneer/jupiter/CartesianProductTest.java
@@ -97,7 +97,9 @@ public @interface CartesianProductTest {
 	 * Class for defining sets to a {@code CartesianProductTest} execution.
 	 *
 	 * @since 1.0
+	 * @deprecated CartesianProductTest has been superseded by CartesianTest
 	 */
+	@Deprecated
 	class Sets {
 
 		private final List<List<?>> sets = new ArrayList<>(); //NOSONAR

--- a/src/main/java/org/junitpioneer/jupiter/CartesianProductTest.java
+++ b/src/main/java/org/junitpioneer/jupiter/CartesianProductTest.java
@@ -97,7 +97,7 @@ public @interface CartesianProductTest {
 	 * Class for defining sets to a {@code CartesianProductTest} execution.
 	 *
 	 * @since 1.0
-	 * @deprecated CartesianProductTest has been superseded by CartesianTest
+	 * @deprecated CartesianProductTest has been superseded by CartesianTest, scheduled to be removed in 2.0
 	 */
 	@Deprecated
 	class Sets {

--- a/src/main/java/org/junitpioneer/jupiter/CartesianValueSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/CartesianValueSource.java
@@ -99,9 +99,15 @@ public @interface CartesianValueSource {
 	 */
 	Class<?>[] classes() default {};
 
+	/**
+	 * Containing annotation of repeatable {@code CartesianValueSource}
+	 *
+	 * @deprecated scheduled to be removed in 2.0
+	 */
 	@Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD })
 	@Retention(RetentionPolicy.RUNTIME)
 	@Documented
+	@Deprecated
 	@interface CartesianValueSources {
 
 		CartesianValueSource[] value();

--- a/src/main/java/org/junitpioneer/jupiter/CartesianValueSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/CartesianValueSource.java
@@ -100,7 +100,7 @@ public @interface CartesianValueSource {
 	Class<?>[] classes() default {};
 
 	/**
-	 * Containing annotation of repeatable {@code CartesianValueSource}
+	 * Containing annotation of repeatable {@code CartesianValueSource}.
 	 *
 	 * @deprecated scheduled to be removed in 2.0
 	 */

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
@@ -31,7 +31,7 @@ import org.junitpioneer.internal.PioneerAnnotationUtils;
 import org.opentest4j.AssertionFailedError;
 import org.opentest4j.TestAbortedException;
 
-public class RetryingTestExtension implements TestTemplateInvocationContextProvider, TestExecutionExceptionHandler {
+class RetryingTestExtension implements TestTemplateInvocationContextProvider, TestExecutionExceptionHandler {
 
 	private static final Namespace NAMESPACE = Namespace.create(RetryingTestExtension.class);
 

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianTest.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianTest.java
@@ -108,6 +108,9 @@ public @interface CartesianTest {
 	 */
 	String name() default "[{index}] {arguments}";
 
+	/**
+	 * Parameter annotation to be used with {@code CartesianTest} for providing simple values.
+	 */
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target({ ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
 	@CartesianArgumentsSource(CartesianValueArgumentsProvider.class)
@@ -165,6 +168,9 @@ public @interface CartesianTest {
 
 	}
 
+	/**
+	 * Parameter annotation to be used with {@code CartesianTest} for providing enum values.
+	 */
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target({ ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
 	@CartesianArgumentsSource(CartesianEnumArgumentsProvider.class)

--- a/src/main/java/org/junitpioneer/jupiter/params/ByteRangeSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/ByteRangeSource.java
@@ -78,6 +78,9 @@ public @interface ByteRangeSource {
 	 */
 	boolean closed() default false;
 
+	/**
+	 * Containing annotation of repeatable {@code ByteRangeSource}.
+	 */
 	@Target(ElementType.METHOD)
 	@Retention(RetentionPolicy.RUNTIME)
 	@Documented

--- a/src/main/java/org/junitpioneer/jupiter/params/DisableIfArgument.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/DisableIfArgument.java
@@ -73,6 +73,9 @@ public @interface DisableIfArgument {
 	 */
 	String[] matches() default {};
 
+	/**
+	 * Containing annotation of repeatable {@code DisableIfArgument}.
+	 */
 	@Target(ElementType.METHOD)
 	@Retention(RetentionPolicy.RUNTIME)
 	@interface DisableIfArguments {

--- a/src/main/java/org/junitpioneer/jupiter/params/DisableIfNameExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/DisableIfNameExtension.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junitpioneer.internal.PioneerAnnotationUtils;
 
-public class DisableIfNameExtension implements ExecutionCondition {
+class DisableIfNameExtension implements ExecutionCondition {
 
 	@Override
 	public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {

--- a/src/main/java/org/junitpioneer/jupiter/params/DoubleRangeSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/DoubleRangeSource.java
@@ -78,6 +78,9 @@ public @interface DoubleRangeSource {
 	 */
 	boolean closed() default false;
 
+	/**
+	 * Containing annotation of repeatable {@code DoubleRangeSource}.
+	 */
 	@Target(ElementType.METHOD)
 	@Retention(RetentionPolicy.RUNTIME)
 	@Documented

--- a/src/main/java/org/junitpioneer/jupiter/params/FloatRangeSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/FloatRangeSource.java
@@ -78,6 +78,9 @@ public @interface FloatRangeSource {
 	 */
 	boolean closed() default false;
 
+	/**
+	 * Containing annotation of repeatable {@code FloatRangeSource}.
+	 */
 	@Target(ElementType.METHOD)
 	@Retention(RetentionPolicy.RUNTIME)
 	@Documented

--- a/src/main/java/org/junitpioneer/jupiter/params/IntRangeSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/IntRangeSource.java
@@ -77,6 +77,9 @@ public @interface IntRangeSource {
 	 */
 	boolean closed() default false;
 
+	/**
+	 * Containing annotation of repeatable {@code IntRangeSource}.
+	 */
 	@Target(ElementType.METHOD)
 	@Retention(RetentionPolicy.RUNTIME)
 	@Documented

--- a/src/main/java/org/junitpioneer/jupiter/params/LongRangeSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/LongRangeSource.java
@@ -77,6 +77,9 @@ public @interface LongRangeSource {
 	 */
 	boolean closed() default false;
 
+	/**
+	 * Containing annotation of repeatable {@code LongRangeSource}.
+	 */
 	@Target(ElementType.METHOD)
 	@Retention(RetentionPolicy.RUNTIME)
 	@Documented

--- a/src/main/java/org/junitpioneer/jupiter/params/package-info.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/package-info.java
@@ -1,4 +1,6 @@
 /**
+ * Several extensions for working with {@code ParameterizedTest}s.
+ *
  * Disable {@code @ParameterizedTest} executions based on conditions.
  * <p>Check out the following types for details:
  * <ul>

--- a/src/main/java/org/junitpioneer/vintage/Test.java
+++ b/src/main/java/org/junitpioneer/vintage/Test.java
@@ -44,6 +44,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @org.junit.jupiter.api.Test
 public @interface Test {
 
+	/**
+	 * Dummy default class for the `expected` parameter.
+	 */
 	class None extends Throwable {
 
 		private static final long serialVersionUID = 1L;

--- a/src/main/java/org/junitpioneer/vintage/Test.java
+++ b/src/main/java/org/junitpioneer/vintage/Test.java
@@ -45,7 +45,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public @interface Test {
 
 	/**
-	 * Dummy default class for the `expected` parameter.
+	 * Dummy default class for the <code>expected</code> parameter.
 	 */
 	class None extends Throwable {
 


### PR DESCRIPTION
Proposed commit message:

```
Update Javadoc #576 / #580

Update the slightly out-of-date or missing Javadoc.

Closes: #576
PR: #580
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [X] There is documentation (Javadoc and site documentation; added or updated)

Contributing
* [X] A prepared commit message exists

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
