### PR TITLE
Document handling of optional dependencies

### DIFF
--- a/.infra/checkstyle/checkstyle.xml
+++ b/.infra/checkstyle/checkstyle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module PUBLIC "-//Puppy Crawl//DTD Check Configuration 1.3//EN" "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
 <module name="Checker">
 	<module name="SuppressionFilter">
 		<property name="file" value="${config_loc}/suppressions.xml"/>
@@ -7,7 +8,6 @@
 	<property name="severity" value="error" />
 	<module name="TreeWalker">
 		<module name="SuppressWarningsHolder" />
-
 		<module name="JavadocMethod">
 			<property name="allowMissingJavadoc" value="true" />
 			<property name="allowMissingParamTags" value="true" />
@@ -20,14 +20,14 @@
 			<property name="tagOrder" value="@param, @return, @throws, @exception, @since, @author, @see" />
 		</module>
 		<module name="NonEmptyAtclauseDescription" />
-
 		<module name="UnusedImports">
 			<property name="processJavadoc" value="true" />
 		</module>
 		<module name="AvoidStarImport" />
-
+		<module name="ImportControl">
+			<property name="file" value="${config_loc}/import-control.xml"/>
+		</module>
 	</module>
-
 	<module name="JavadocPackage" />
 	<module name="SuppressWarningsFilter" />
 	<module name="BeforeExecutionExclusionFileFilter">

--- a/.infra/checkstyle/import-control.xml
+++ b/.infra/checkstyle/import-control.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE import-control PUBLIC "-//Checkstyle//DTD ImportControl Configuration 1.4//EN" "https://checkstyle.org/dtds/import_control_1_4.dtd">
+
+<import-control pkg="org.junitpioneer">
+
+	<allow pkg=".*" regex="true" />
+
+</import-control>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ To get started, check [these good first issues](https://github.com/junit-pioneer
 
 ## Writing Code
 
-We have a few guidelines on how to organize, style, and document extensions. 
+We have a few guidelines on how to organize, style, and document extensions.
 Everything related to branches, commits, and more is described [further below](#fixing-bugs-developing-features).
 
 ### Code Organization
@@ -374,11 +374,38 @@ Follow these steps when updating JUnit 5:
 
 ### Others
 
-Pioneer does not take on run-time dependencies outside of JUnit 5.
-Of course test dependencies like AssertJ and build dependencies on Gradle plugins are fair game.
-To keep them updated, run `gradle dependencyUpdates`, which lists all dependencies for which a newer version exists.
-Updates still need to be done manually.
+JUnit Pioneer handles dependencies beyond JUnit 5 differently depending on how they impact its users.
 
+#### For Execution
+
+Pioneer avoids adding to users' dependency hell and hence doesn't take on dependencies beyond JUnit 5 that are _required_ at run time.
+_Optional_ dependencies are acceptable if they are needed to provide specific features, particularly:
+
+* to _integrate_ with other tools, frameworks, and libraries by offering features that directly interact with them (a hypothetical example is [Playwright](https://playwright.dev/))
+* for _ease of use_ when recreating functionality would be too complex or otherwise out of scope for Pioneer (a hypothetical example is Jackson for JSON parsing)
+
+Unless we see reports of optional dependencies causing unexpected problems for users, there is no particularly high hurdle for taking them on, given each provides more than marginal value.
+They should only be used by specifically chosen features that require them, though, and care needs to be taken to prevent them from creeping into the rest of the code base - CheckStyle rules need to be configured for each that fail the build on accidental use of these dependencies.
+
+Optional dependencies are implemented with [Gradle's feature variants](https://docs.gradle.org/current/userguide/feature_variants.html).
+Pioneer's module declaration must be extended with a matching `requires static` clause, which limits optional dependencies to those that have at least an explicit automatic module name.
+Note that `requires static` does not suffice to pull in the optional dependency's module if no user code depends on it as well.
+
+Each Pioneer feature that depends on them must profusely document that:
+
+* in the feature documentation with configuration examples for Maven and Gradle (Kotlin suffices), including for the case where Pioneer is used on the module path and no other module depends on the optional dependency (i.e. explain how to configure `--add-modules`)
+* in the Javadoc with a mention of the needed dependencies and the potential `--add-modules` directive (but no detailed guide how to accomplish either - link to website instead)
+* in the case that the dependency is missing, with a clear error message that echoes the Javadoc
+
+#### For Test and Build
+
+Test dependencies like AssertJ and build dependencies on Gradle plugins do not impact users and are fair game.
+Of course, we want to avoid our own dependency hell, so each dependency should still be carefully considered.
+
+#### Updates
+
+To keep dependencies up to date, run `gradle dependencyUpdates`, which lists all dependencies for which a newer version exists.
+Updates then need to be done manually.
 To keep the commit history clean, these should be done in bulk every few weeks.
 
 
@@ -457,7 +484,7 @@ While maintainers will naturally gravitate towards tasks they prefer working on,
 
 We all have a soft spot for the project, but we also have jobs, families, hobbies, and other human afflictions.
 There's no expectation of availability!
-This applies to users opening issues, contributors providing PRs, and other maintainers - none of them can _expect_ a maintainer to have time to reply to their request. 
+This applies to users opening issues, contributors providing PRs, and other maintainers - none of them can _expect_ a maintainer to have time to reply to their request.
 
 ### Communication
 
@@ -478,7 +505,7 @@ A few examples:
 * when we discover a problem or possible feature on stream, a new GitHub issue will be created
 * when a team call or Discord discussion shapes our opinion on an issue or PR, the discussion (not just the conclusion!) is summarized in the issue or PR (see [the comments on the ShipKit evaluation](https://github.com/junit-pioneer/junit-pioneer/issues/193#issuecomment-611620554) for an example)
 * when a PR is merged, the commit message summarizes what it is about (see [_Commit Message_](#commit-message) above)
-* when a decision regarding the project structure or the development processes is made, it is reflected in `README.md`, `CONTRIBUTING.md`, or another suitable file or even the website  
+* when a decision regarding the project structure or the development processes is made, it is reflected in `README.md`, `CONTRIBUTING.md`, or another suitable file or even the website
 * when a new feature is merged, documentation is added to the website
 
 ### Where The Buck Stops

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -381,8 +381,8 @@ JUnit Pioneer handles dependencies beyond JUnit 5 differently depending on how t
 Pioneer avoids adding to users' dependency hell and hence doesn't take on dependencies beyond JUnit 5 that are _required_ at run time.
 _Optional_ dependencies are acceptable if they are needed to provide specific features, particularly:
 
-* to _integrate_ with other tools, frameworks, and libraries by offering features that directly interact with them (a hypothetical example is [Playwright](https://playwright.dev/))
-* for _ease of use_ when recreating functionality would be too complex or otherwise out of scope for Pioneer (a hypothetical example is Jackson for JSON parsing)
+* to _integrate_ with other tools, frameworks, and libraries by offering features that directly interact with them (a hypothetical example is [Playwright](https://playwright.dev) for E2E testing)
+* for _ease of use_ when recreating functionality would be too complex or otherwise out of scope for Pioneer (a hypothetical example is [Jackson](https://github.com/FasterXML/jackson) for JSON parsing)
 
 Unless we see reports of optional dependencies causing unexpected problems for users, there is no particularly high hurdle for taking them on, given each provides more than marginal value.
 They should only be used by specifically chosen features that require them, though, and care needs to be taken to prevent them from creeping into the rest of the code base - CheckStyle rules need to be configured for each that fail the build on accidental use of these dependencies.


### PR DESCRIPTION
Commit message comes later...

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [x] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style

Code
* [x] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks

Contributing
* [ ] A prepared commit message exists

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
