### PR TITLE
Fix module descriptor

### DIFF
--- a/src/main/module/module-info.java
+++ b/src/main/module/module-info.java
@@ -9,6 +9,10 @@ module org.junitpioneer {
 	exports org.junitpioneer.jupiter.cartesian;
 	exports org.junitpioneer.jupiter.params;
 
+	opens org.junitpioneer.jupiter to org.junit.platform.commons;
+	opens org.junitpioneer.jupiter.cartesian to org.junit.platform.commons;
+	opens org.junitpioneer.jupiter.params to org.junit.platform.commons;
+
 	provides org.junit.platform.launcher.TestExecutionListener
 			with org.junitpioneer.jupiter.issue.IssueExtensionExecutionListener;
 	uses org.junitpioneer.jupiter.IssueProcessor;

--- a/src/main/module/module-info.java
+++ b/src/main/module/module-info.java
@@ -9,6 +9,7 @@ module org.junitpioneer {
 	exports org.junitpioneer.jupiter.cartesian;
 	exports org.junitpioneer.jupiter.params;
 
+	opens org.junitpioneer.vintage to org.junit.platform.commons;
 	opens org.junitpioneer.jupiter to org.junit.platform.commons;
 	opens org.junitpioneer.jupiter.cartesian to org.junit.platform.commons;
 	opens org.junitpioneer.jupiter.params to org.junit.platform.commons;

--- a/src/main/module/module-info.java
+++ b/src/main/module/module-info.java
@@ -6,6 +6,7 @@ module org.junitpioneer {
 
 	exports org.junitpioneer.vintage;
 	exports org.junitpioneer.jupiter;
+	exports org.junitpioneer.jupiter.cartesian;
 	exports org.junitpioneer.jupiter.params;
 
 	provides org.junit.platform.launcher.TestExecutionListener


### PR DESCRIPTION
Closes #539. Follow-up #596 for proper integration tests.

Proposed commit message:

```
Fix module descriptor (#539 / #597)

This PR fixes Pioneer's `module-info.java` as follows:

* Add missing cartesian package `org.junitpioneer.jupiter.cartesian`.
* Open Pioneer packages to module `org.junit.platform.commons`, as
they contain types that use JUnit Platform's reflection support via
`PioneerAnnotationUtils`. Without the `opens` directive,
`InaccessibleObjectException`s may occur, if Pioneer is consumed on
the module path.

Closes: #539
PR: #597
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
