### PR TITLE
Make RangeClass package-private

### DIFF
--- a/src/main/java/org/junitpioneer/jupiter/params/RangeClass.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/RangeClass.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 @Target(ElementType.ANNOTATION_TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-public @interface RangeClass {
+@interface RangeClass {
 
 	Class<? extends Range> value();
 

--- a/src/main/java/org/junitpioneer/jupiter/params/RangeClass.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/RangeClass.java
@@ -10,7 +10,6 @@
 
 package org.junitpioneer.jupiter.params;
 
-import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/src/main/java/org/junitpioneer/jupiter/params/RangeClass.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/RangeClass.java
@@ -23,7 +23,6 @@ import java.lang.annotation.Target;
  */
 @Target(ElementType.ANNOTATION_TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@Documented
 @interface RangeClass {
 
 	Class<? extends Range> value();


### PR DESCRIPTION
Closes #564

Proposed commit message:

```
Make `RangeClass` package-private (#564/#598)

This commit makes `RangeClass` package-private.
The `RangeClass` annotation is only used internally, as a
meta-annotation. It references the internal class `Range`.

Closes: #564
PR: #598
```

---

Contributing
* [X] A prepared commit message exists

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
