### PR TITLE
Update JUnit to 5.8 (#594 / #612)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11, 17 ]
-        junit-version: [ '5.7.2', '5.8.2' ]
+        junit-version: [ '5.8.2' ]
         modular: [true, false]
         os: [ubuntu, macos, windows]
     name: with Java ${{ matrix.java }}, JUnit ${{ matrix.junit-version }}, Modular ${{ matrix.modular }} on ${{ matrix.os }}
@@ -127,7 +127,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        junit-version: [ '5.7.2', '5.8.1' ]
+        junit-version: [ '5.8.2' ]
         modular: [true, false]
         os: [ubuntu, macos, windows]
     name: Experimental build with newest JDK early-access build and Gradle release candidate

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-junitVersion=5.7.2
+junitVersion=5.8.2
 
 # Ensure sufficient heap size, especially for Sonar.
 org.gradle.jvmargs=-Xmx8g


### PR DESCRIPTION
The temporary directory/resource extension proposed in #348 / #491
requires parameter-level extension registration, which was added in
JUnit Jupiter 5.8.0[^1].

[^1]: https://junit.org/junit5/docs/5.8.0/release-notes/index.html

Closes: #594
PR: #612

---

I hereby agree to the terms of the [JUnit Pioneer Contributor License Agreement](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#junit-pioneer-contributor-license-agreement).
