### PR TITLE
Inherit default locale and timezone annotations

### DIFF
--- a/docs/default-locale-timezone.adoc
+++ b/docs/default-locale-timezone.adoc
@@ -2,7 +2,7 @@
 :page-description: Extends JUnit Jupiter with `@DefaultLocale`, `@DefaultTimeZone`, which change the values returned from Locale.getDefault() and TimeZone.getDefault()
 
 The `@DefaultLocale` and `@DefaultTimeZone` annotations can be used to change the values returned from `Locale.getDefault()` and `TimeZone.getDefault()`.
-Both annotations work on the test class level and on the test method level.
+Both annotations work on the test class level and on the test method level, and are inherited from higher-level containers.
 After the annotated element has been executed the initial default value is restored.
 
 == `@DefaultLocale`

--- a/docs/environment-variables.adoc
+++ b/docs/environment-variables.adoc
@@ -2,7 +2,7 @@
 :page-description: Extends JUnit Jupiter with `@ClearEnvironmentVariable`, `@SetEnvironmentVariable`, which clear and set the values of environment variables
 
 The `@ClearEnvironmentVariable` and `@SetEnvironmentVariable` annotations can be used to clear, respectively, set the values of environment variables for a test execution.
-Both annotations work on the test method and class level, are repeatable as well as combinable.
+Both annotations work on the test method and class level, are repeatable, combinable, and inherited from higher-level containers.
 After the annotated method has been executed, the variables mentioned in the annotation will be restored to their original value or will be cleared if they didn't have one before.
 Other environment variables that are changed during the test, are *not* restored.
 

--- a/docs/system-properties.adoc
+++ b/docs/system-properties.adoc
@@ -2,7 +2,7 @@
 :page-description: Extends JUnit Jupiter with `@ClearSystemProperty`, `@SetSystemProperty`, which clear and set the values of system properties
 
 The `@ClearSystemProperty` and `@SetSystemProperty` annotations can be used to clear, respectively, set the values of system properties for a test execution.
-Both annotations work on the test method and class level, are repeatable as well as combinable.
+Both annotations work on the test method and class level, are repeatable, combinable, and inherited from higher-level containers.
 After the annotated method has been executed, the properties mentioned in the annotation will be restored to their original value or will be cleared if they didn't have one before.
 Other system properties that are changed during the test, are *not* restored.
 

--- a/src/main/java/org/junitpioneer/jupiter/ClearEnvironmentVariable.java
+++ b/src/main/java/org/junitpioneer/jupiter/ClearEnvironmentVariable.java
@@ -26,9 +26,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * <p>The key of the environment variable to be cleared must be specified via {@link #key()}.
  * After the annotated element has been executed, the initial default value is restored.</p>
  *
- * <p>{@code ClearEnvironmentVariable} is repeatable and can be used on the method and
- * on the class level. If a class is annotated, the configured variable will be
- * cleared before every test inside that class.</p>
+ * <p>{@code ClearEnvironmentVariable} can be used on the method and on the class level.
+ * It is repeatable and inherited from higher-level containers. If a class is
+ * annotated, the configured property will be cleared before every test inside that
+ * class.</p>
  *
  * <p>WARNING: Java considers environment variables to be immutable, so this extension
  * uses reflection to change them. This requires that the {@link SecurityManager}

--- a/src/main/java/org/junitpioneer/jupiter/ClearSystemProperty.java
+++ b/src/main/java/org/junitpioneer/jupiter/ClearSystemProperty.java
@@ -26,9 +26,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * <p>The key of the system property to be cleared must be specified via {@link #key()}.
  * After the annotated element has been executed, the initial default value is restored.</p>
  *
- * <p>{@code ClearSystemProperty} is repeatable and can be used on the method and
- * on the class level. If a class is annotated, the configured property will be
- * cleared before every test inside that class.</p>
+ * <p>{@code ClearSystemProperty} can be used on the method and on the class level.
+ * It is repeatable and inherited from higher-level containers. If a class is
+ * annotated, the configured property will be cleared before every test inside that
+ * class.</p>
  *
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
@@ -11,6 +11,7 @@
 package org.junitpioneer.jupiter;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -39,9 +40,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * element has been executed, the default {@code Locale} will be restored to
  * its original value.</p>
  *
- * <p>{@code @DefaultLocale} can be used on the method and on the class level.
- * If a class is annotated, the configured {@code Locale} will be the default
- * {@code Locale} for all tests inside that class. Any method level
+ * <p>{@code @DefaultLocale} can be used on the method and on the class level. It
+ * can only be used once per method or class, but is inherited from higher-level
+ * containers. If a class is annotated, the configured {@code Locale} will be the
+ * default {@code Locale} for all tests inside that class. Any method level
  * configurations will override the class level default {@code Locale}.</p>
  *
  * <p>During
@@ -60,6 +62,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @Target({ ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
+@Inherited
 @WritesDefaultLocale
 @ExtendWith(DefaultLocaleExtension.class)
 public @interface DefaultLocale {

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
@@ -41,8 +41,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * its original value.</p>
  *
  * <p>{@code @DefaultLocale} can be used on the method and on the class level. It
- * can only be used once per method or class, but is inherited from higher-level
- * containers. If a class is annotated, the configured {@code Locale} will be the
+ * is inherited from higher-level containers, but can only be used once per method
+ * or class. If a class is annotated, the configured {@code Locale} will be the
  * default {@code Locale} for all tests inside that class. Any method level
  * configurations will override the class level default {@code Locale}.</p>
  *

--- a/src/main/java/org/junitpioneer/jupiter/DefaultTimeZone.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultTimeZone.java
@@ -29,8 +29,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * original value.</p>
  *
  * <p>{@code @DefaultTimeZone} can be used on the method and on the class
- * level. It can only be used once per method or class, but is inherited from
- * higher-level containers. If a class is annotated, the configured
+ * level. It is inherited from higher-level containers, but can only be used
+ * once per method or class. If a class is annotated, the configured
  * {@code TimeZone} will be the default {@code TimeZone} for all tests inside
  * that class. Any method level configurations will override the class level
  * default {@code TimeZone}.</p>

--- a/src/main/java/org/junitpioneer/jupiter/DefaultTimeZone.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultTimeZone.java
@@ -11,6 +11,7 @@
 package org.junitpioneer.jupiter;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -28,9 +29,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * original value.</p>
  *
  * <p>{@code @DefaultTimeZone} can be used on the method and on the class
- * level. If a class is annotated, the configured {@code TimeZone} will be the
- * default {@code TimeZone} for all tests inside that class. Any method level
- * configurations will override the class level default {@code TimeZone}.</p>
+ * level. It can only be used once per method or class, but is inherited from
+ * higher-level containers. If a class is annotated, the configured
+ * {@code TimeZone} will be the default {@code TimeZone} for all tests inside
+ * that class. Any method level configurations will override the class level
+ * default {@code TimeZone}.</p>
  *
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,
@@ -48,6 +51,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @Target({ ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
+@Inherited
 @WritesDefaultTimeZone
 @ExtendWith(DefaultTimeZoneExtension.class)
 public @interface DefaultTimeZone {

--- a/src/main/java/org/junitpioneer/jupiter/DisabledUntil.java
+++ b/src/main/java/org/junitpioneer/jupiter/DisabledUntil.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * method is disabled.
  *
  * <p>{@code @DisabledUntil} can be used on the method and class level. It can only be used once per method or class,
- * but is inherited from higher level containers.</p>
+ * but is inherited from higher-level containers.</p>
  *
  * @see org.junit.jupiter.api.Disabled
  */

--- a/src/main/java/org/junitpioneer/jupiter/SetEnvironmentVariable.java
+++ b/src/main/java/org/junitpioneer/jupiter/SetEnvironmentVariable.java
@@ -27,10 +27,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * {@link #key()} and {@link #value()}. After the annotated method has been
  * executed, the initial default value is restored.</p>
  *
- * <p>{@code SetEnvironmentVariable} is repeatable and can be used on the method and on
- * the class level. If a class is annotated, the configured variable will be set
- * before every test inside that class. Any method level configurations will
- * override the class level configurations.</p>
+ * <p>{@code SetEnvironmentVariable} can be used on the method and on the class level.
+ * It is repeatable and inherited from higher-level containers. If a class is
+ * annotated, the configured property will be set before every test inside that
+ * class. Any method level configurations will override the class level
+ * configurations.</p>
  *
  * <p>WARNING: Java considers environment variables to be immutable, so this extension
  * uses reflection to change them. This requires that the {@link SecurityManager}

--- a/src/main/java/org/junitpioneer/jupiter/SetSystemProperty.java
+++ b/src/main/java/org/junitpioneer/jupiter/SetSystemProperty.java
@@ -27,10 +27,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * {@link #key()} and {@link #value()}. After the annotated method has been
  * executed, the initial default value is restored.</p>
  *
- * <p>{@code SetSystemProperty} is repeatable and can be used on the method and on
- * the class level. If a class is annotated, the configured property will be set
- * before every test inside that class. Any method level configurations will
- * override the class level configurations.</p>
+ * <p>{@code SetSystemProperty} can be used on the method and on the class level.
+ * It is repeatable and inherited from higher-level containers. If a class is
+ * annotated, the configured property will be set before every test inside that
+ * class. Any method level configurations will override the class level
+ * configurations.</p>
  *
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,

--- a/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
@@ -318,4 +318,21 @@ class DefaultLocaleTests {
 
 	}
 
+	@Nested
+	@DisplayName("used with inheritance")
+	class InheritanceTests extends InheritanceBaseTest {
+
+		@Test
+		@DisplayName("should inherit default locale annotation")
+		void shouldInheritClearAndSetProperty() {
+			assertThat(Locale.getDefault()).isEqualTo(new Locale("fr", "FR"));
+		}
+
+	}
+
+	@DefaultLocale(language = "fr", country = "FR")
+	static class InheritanceBaseTest {
+
+	}
+
 }

--- a/src/test/java/org/junitpioneer/jupiter/DefaultTimeZoneTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultTimeZoneTests.java
@@ -250,4 +250,21 @@ class DefaultTimeZoneTests {
 
 	}
 
+	@Nested
+	@DisplayName("used with inheritance")
+	class InheritanceTests extends InheritanceBaseTest {
+
+		@Test
+		@DisplayName("should inherit default time zone annotation")
+		void shouldInheritClearAndSetProperty() {
+			assertThat(TimeZone.getDefault()).isEqualTo(TimeZone.getTimeZone("GMT-8:00"));
+		}
+
+	}
+
+	@DefaultTimeZone("GMT-8:00")
+	static class InheritanceBaseTest {
+
+	}
+
 }


### PR DESCRIPTION
Relates to #456.

Proposed commit message:

```
Inherit default locale and timezone annotations (#456 / TBA)

`@DefaultLocale` and `@DefaultTimeZone` are now `@Inherited`.

Relates to: #456
PR: #615 
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [ ] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code
* [ ] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional)
