### PR TITLE
Update AssertJ

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,7 +67,7 @@ dependencies {
 	testImplementation(group = "org.junit.jupiter", name = "junit-jupiter-engine")
 	testImplementation(group = "org.junit.platform", name = "junit-platform-testkit")
 
-	testImplementation(group = "org.assertj", name = "assertj-core", version = "3.20.2")
+	testImplementation(group = "org.assertj", name = "assertj-core", version = "3.22.0")
 	testImplementation(group = "org.mockito", name = "mockito-core", version = "4.4.0")
 	testImplementation(group = "com.google.jimfs", name = "jimfs", version = "1.2")
 	testImplementation(group = "nl.jqno.equalsverifier", name = "equalsverifier", version = "3.10")

--- a/src/test/java/org/junitpioneer/testkit/assertion/TestCaseAssertBase.java
+++ b/src/test/java/org/junitpioneer/testkit/assertion/TestCaseAssertBase.java
@@ -35,13 +35,13 @@ class TestCaseAssertBase extends AbstractPioneerAssert<TestCaseAssertBase, Event
 			Class<? extends Throwable> exceptionType) {
 		Throwable thrown = getRequiredThrowable();
 		assertThat(thrown).isInstanceOf(exceptionType);
-		return new ThrowableAssert(thrown);
+		return new ThrowableAssert<>(thrown);
 	}
 
 	@Override
 	public AbstractThrowableAssert<?, ? extends Throwable> withException() {
 		Throwable thrown = getRequiredThrowable();
-		return new ThrowableAssert(thrown);
+		return new ThrowableAssert<>(thrown);
 	}
 
 	@Override

--- a/src/test/java/org/junitpioneer/testkit/assertion/TestCaseAssertBase.java
+++ b/src/test/java/org/junitpioneer/testkit/assertion/TestCaseAssertBase.java
@@ -17,7 +17,7 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 import org.assertj.core.api.AbstractThrowableAssert;
-import org.assertj.core.api.ThrowableAssert;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.testkit.engine.Events;
 import org.junitpioneer.testkit.assertion.single.TestCaseFailureAssert;
@@ -31,17 +31,15 @@ class TestCaseAssertBase extends AbstractPioneerAssert<TestCaseAssertBase, Event
 	}
 
 	@Override
-	public AbstractThrowableAssert<?, ? extends Throwable> withExceptionInstanceOf(
-			Class<? extends Throwable> exceptionType) {
+	public <T extends Throwable> AbstractThrowableAssert<?, T> withExceptionInstanceOf(Class<T> exceptionType) {
 		Throwable thrown = getRequiredThrowable();
-		assertThat(thrown).isInstanceOf(exceptionType);
-		return new ThrowableAssert<>(thrown);
+		return assertThat(thrown).asInstanceOf(InstanceOfAssertFactories.throwable(exceptionType));
 	}
 
 	@Override
 	public AbstractThrowableAssert<?, ? extends Throwable> withException() {
 		Throwable thrown = getRequiredThrowable();
-		return new ThrowableAssert<>(thrown);
+		return assertThat(thrown);
 	}
 
 	@Override

--- a/src/test/java/org/junitpioneer/testkit/assertion/single/TestCaseFailureAssert.java
+++ b/src/test/java/org/junitpioneer/testkit/assertion/single/TestCaseFailureAssert.java
@@ -26,7 +26,7 @@ public interface TestCaseFailureAssert {
 	 * @param exceptionType the expected type of the thrown exception
 	 * @return an {@link AbstractThrowableAssert} for further assertions
 	 */
-	AbstractThrowableAssert<?, ? extends Throwable> withExceptionInstanceOf(Class<? extends Throwable> exceptionType);
+	<T extends Throwable> AbstractThrowableAssert<?, T> withExceptionInstanceOf(Class<T> exceptionType);
 
 	/**
 	 * Asserts that the test/container failed because an exception was thrown.


### PR DESCRIPTION
Proposed commit message:

```
${action} (${issues} / ${pull-request}) [max 70 characters]

${body} [max 70 characters per line]

${references}: ${issues}
PR: ${pull-request}
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [ ] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 
