### PR TITLE
Return type-aware assertion on `withExceptionInstanceOf`

### DIFF
--- a/src/test/java/org/junitpioneer/testkit/assertion/TestCaseAssertBase.java
+++ b/src/test/java/org/junitpioneer/testkit/assertion/TestCaseAssertBase.java
@@ -17,7 +17,7 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 
 import org.assertj.core.api.AbstractThrowableAssert;
-import org.assertj.core.api.ThrowableAssert;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.testkit.engine.Events;
 import org.junitpioneer.testkit.assertion.single.TestCaseFailureAssert;
@@ -31,17 +31,15 @@ class TestCaseAssertBase extends AbstractPioneerAssert<TestCaseAssertBase, Event
 	}
 
 	@Override
-	public AbstractThrowableAssert<?, ? extends Throwable> withExceptionInstanceOf(
-			Class<? extends Throwable> exceptionType) {
+	public <T extends Throwable> AbstractThrowableAssert<?, T> withExceptionInstanceOf(Class<T> exceptionType) {
 		Throwable thrown = getRequiredThrowable();
-		assertThat(thrown).isInstanceOf(exceptionType);
-		return new ThrowableAssert<>(thrown);
+		return assertThat(thrown).asInstanceOf(InstanceOfAssertFactories.throwable(exceptionType));
 	}
 
 	@Override
 	public AbstractThrowableAssert<?, ? extends Throwable> withException() {
 		Throwable thrown = getRequiredThrowable();
-		return new ThrowableAssert<>(thrown);
+		return assertThat(thrown);
 	}
 
 	@Override

--- a/src/test/java/org/junitpioneer/testkit/assertion/single/TestCaseFailureAssert.java
+++ b/src/test/java/org/junitpioneer/testkit/assertion/single/TestCaseFailureAssert.java
@@ -26,7 +26,7 @@ public interface TestCaseFailureAssert {
 	 * @param exceptionType the expected type of the thrown exception
 	 * @return an {@link AbstractThrowableAssert} for further assertions
 	 */
-	AbstractThrowableAssert<?, ? extends Throwable> withExceptionInstanceOf(Class<? extends Throwable> exceptionType);
+	<T extends Throwable> AbstractThrowableAssert<?, T> withExceptionInstanceOf(Class<T> exceptionType);
 
 	/**
 	 * Asserts that the test/container failed because an exception was thrown.


### PR DESCRIPTION
This targets the branch of #619.

I'm not sure if this is what @nipafx meant at https://github.com/junit-pioneer/junit-pioneer/issues/618#issuecomment-1094266234, but it's an improvement I would add with the new version of AssertJ.

A benefit of this change is chaining `extracting` calls that would target the throwable concrete type (some examples at assertj/assertj-core#2242).

I also replaced `new ThrowableAssert<>` with `assertThat` - no obvious difference here but I suggest sticking to the factory methods instead of instantiating assertion classes directly.