### PR TITLE
Allow non-static Cartesian factory methods with PER_CLASS lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ The least we can do is to thank them and list some of their accomplishments here
 
 * [Pankaj Kumar](https://github.com/p1729) contributed towards improving GitHub actions (#587 / #611)
 * [Filip Hrisafov](https://github.com/filiphr) contributed the [JSON Argument Source](https://junit-pioneer.org/docs/json-argument-source/) support (#101 / #492)
+* [Rob Spoor](https://github.com/robtimus) made it possible to use non-static factory methods for `@CartesianTest.MethodFactory`, as long as the test class is annotated with `@TestInstance(Lifecycle.PER_CLASS)` (#628)
 
 #### 2021
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ The least we can do is to thank them and list some of their accomplishments here
 
 * [Pankaj Kumar](https://github.com/p1729) contributed towards improving GitHub actions (#587 / #611)
 * [Filip Hrisafov](https://github.com/filiphr) contributed the [JSON Argument Source](https://junit-pioneer.org/docs/json-argument-source/) support (#101 / #492)
-* [Rob Spoor](https://github.com/robtimus) made it possible to use non-static factory methods for `@CartesianTest.MethodFactory`, as long as the test class is annotated with `@TestInstance(Lifecycle.PER_CLASS)` (#628)
+* [Rob Spoor](https://github.com/robtimus) enabled non-static factory methods for `@CartesianTest.MethodFactory` (#628)
 
 #### 2021
 

--- a/docs/cartesian-product.adoc
+++ b/docs/cartesian-product.adoc
@@ -288,12 +288,19 @@ You can reuse the same argument provider method multiple times.
 include::{demo}[tag=cartesian_argument_sets_reuse]
 ----
 
+You can use an argument provider method in nested classes, as long as these are annotated with `@TestInstance(Lifecycle.PER_CLASS)`.
+
+[source,java,indent=0]
+----
+include::{demo}[tag=cartesian_argument_sets_with_nested_classes]
+----
+
 ==== Requirements for the factory method
 
 There are multiple requirements the factory method has to fulfill to qualify:
 
 - must have the same name as the test method (or its name must be specified via the `factory` attribute)
-- must be `static` (unless the test class is annotated with `@TestInstance(Lifecycle.PER_CLASS)`)
+- must be `static` (unless the test class is annotated with `@TestInstance(Lifecycle.PER_CLASS)` and the factory method is defined in the test class)
 - must have **no** parameters
 - must return `ArgumentSets`
 - must register values for every parameter exactly once

--- a/docs/cartesian-product.adoc
+++ b/docs/cartesian-product.adoc
@@ -16,7 +16,7 @@ From Wikipedia:
 What does all this mean?
 
 The Cartesian product of sets is all the possible combinations where you take a single element from each set.
-If you have two sets, `{ 1, 2 }` and `{ 3, 4 }`, their cartesian product is `{ { 1, 3 }, { 1, 4 }, { 2, 3 }, { 2, 4 } }`.
+If you have two sets, `{ 1, 2 }` and `{ 3, 4 }`, their Cartesian product is `{ { 1, 3 }, { 1, 4 }, { 2, 3 }, { 2, 4 } }`.
 
 Sometimes it's useful to test all possible combinations of parameter sets.
 Normally, this results in a lot of written test data parameters.
@@ -239,7 +239,7 @@ You can annotate your test method to supply arguments to all parameters simultan
 
 === `@CartesianTest.MethodFactory`
 
-`@CartesianTest.MethodFactory` can be used to name a static factory method that supplies your arguments.
+`@CartesianTest.MethodFactory` can be used to name a factory method that supplies your arguments.
 The `value` annotation parameter is mandatory.
 Just like with JUnit's `@MethodSource`, you can specify the factory method with its fully-qualified name (including the class), e.g. `com.example.Class#factory`.
 This method must return `ArgumentSets`.
@@ -288,23 +288,23 @@ You can reuse the same argument provider method multiple times.
 include::{demo}[tag=cartesian_argument_sets_reuse]
 ----
 
-==== Requirements for the static factory method
+==== Requirements for the factory method
 
-There are multiple requirements the static factory method has to fulfill to qualify:
+There are multiple requirements the factory method has to fulfill to qualify:
 
 - must have the same name as the test method (or its name must be specified via the `factory` attribute)
-- must be `static`
+- must be `static` (unless the test class is annotated with `@TestInstance(Lifecycle.PER_CLASS)`)
 - must have **no** parameters
 - must return `ArgumentSets`
 - must register values for every parameter exactly once
 - must register values in order
 
-==== Returning wrong `ArgumentSets` in the static factory method
+==== Returning wrong `ArgumentSets` in the factory method
 
 If you register too few, too many, or conflicting parameters, you will get an https://junit.org/junit5/docs/current/api/org.junit.jupiter.api/org/junit/jupiter/api/extension/ParameterResolutionException.html[`ParameterResolutionException`].
 "Conflicting parameters" means your test method has a parameter that should be injected by JUnit (e.g.: `TestReporter`) but you also try to inject it.
 
-Examples of badly configured tests/static factory method:
+Examples of badly configured tests/factory method:
 
 [source,java,indent=0]
 ----

--- a/src/demo/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtensionDemo.java
@@ -29,6 +29,9 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.TestReporter;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junitpioneer.jupiter.cartesian.CartesianTest.Enum;
@@ -278,5 +281,31 @@ public class CartesianTestExtensionDemo {
 
 	}
 	// end::cartesian_testWithCustomDisplayName[]
+
+	// tag::cartesian_argument_sets_with_nested_classes[]
+	class MyCartesianTestClassWithNestedClasses {
+
+		@Nested
+		// the next annotation is required to allow a non-static factory method
+		@TestInstance(Lifecycle.PER_CLASS)
+		class MyNestedCartesianTestClass {
+
+			@CartesianTest
+			@CartesianTest.MethodFactory("provideArguments")
+			void testNeedingArguments(String string, int i) {
+				// passing test code
+			}
+
+			// this provider method doesn't have to be static
+			ArgumentSets provideArguments() {
+				return ArgumentSets
+						.argumentsForFirstParameter("Mercury", "Earth", "Venus")
+						.argumentsForNextParameter(1, 12, 144);
+			}
+
+		}
+
+	}
+	// end::cartesian_argument_sets_with_nested_classes[]
 
 }

--- a/src/demo/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtensionDemo.java
@@ -11,10 +11,8 @@
 package org.junitpioneer.jupiter.cartesian;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junitpioneer.jupiter.cartesian.CartesianTest.Enum;
 import static org.junitpioneer.jupiter.cartesian.CartesianTest.Enum.Mode.EXCLUDE;
 import static org.junitpioneer.jupiter.cartesian.CartesianTest.Enum.Mode.MATCH_ALL;
-import static org.junitpioneer.jupiter.cartesian.CartesianTest.Values;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -33,6 +31,8 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.TestReporter;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junitpioneer.jupiter.cartesian.CartesianTest.Enum;
+import org.junitpioneer.jupiter.cartesian.CartesianTest.Values;
 import org.junitpioneer.jupiter.params.LongRangeSource;
 import org.junitpioneer.jupiter.params.ShortRangeSource;
 
@@ -220,7 +220,7 @@ public class CartesianTestExtensionDemo {
 		@CartesianTest
 		@CartesianTest.MethodFactory("resolveParameters")
 		void wrongOrderParameters(int i, String string) {
-			// fails because the static factory method declared parameter sets in the wrong order
+			// fails because the factory method declared parameter sets in the wrong order
 		}
 
 		@CartesianTest

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianFactoryArgumentsProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianFactoryArgumentsProvider.java
@@ -35,12 +35,12 @@ class CartesianFactoryArgumentsProvider
 		Method testMethod = context.getRequiredTestMethod();
 		Object testInstance = context.getTestInstance().orElse(null);
 		TestInstance.Lifecycle lifecycle = context.getTestInstanceLifecycle().orElse(null);
-		boolean factoryMustBeStatic = testInstance == null || lifecycle != TestInstance.Lifecycle.PER_CLASS;
-		Method factory = findMethodFactory(testMethod, methodFactoryName, factoryMustBeStatic);
+		Method factory = findMethodFactory(testMethod, methodFactoryName, testInstance, lifecycle);
 		return invokeMethodFactory(testMethod, factory, testInstance);
 	}
 
-	private static Method findMethodFactory(Method testMethod, String methodFactoryName, boolean factoryMustBeStatic) {
+	private static Method findMethodFactory(Method testMethod, String methodFactoryName, Object testInstance,
+			TestInstance.Lifecycle lifecycle) {
 		String factoryName = extractMethodFactoryName(methodFactoryName);
 		Class<?> declaringClass = findExplicitOrImplicitClass(testMethod, methodFactoryName);
 		Method factory = PioneerUtils
@@ -48,7 +48,7 @@ class CartesianFactoryArgumentsProvider
 				.orElseThrow(() -> new ExtensionConfigurationException("Method `Stream<? extends Arguments> "
 						+ factoryName + "()` not found in " + declaringClass + " or any enclosing class."));
 		String method = "Method `" + factory + "`";
-		if (factoryMustBeStatic && !Modifier.isStatic(factory.getModifiers()))
+		if (factoryMustBeStatic(factory, testInstance, lifecycle) && !Modifier.isStatic(factory.getModifiers()))
 			throw new ExtensionConfigurationException(method + " must be static.");
 		if (!ArgumentSets.class.isAssignableFrom(factory.getReturnType()))
 			throw new ExtensionConfigurationException(
@@ -84,8 +84,14 @@ class CartesianFactoryArgumentsProvider
 					format("Class %s not found, referenced in method %s", className, testMethod.getName()), ex));
 	}
 
+	private static boolean factoryMustBeStatic(Method factory, Object testInstance, TestInstance.Lifecycle lifecycle) {
+		return testInstance == null || !factory.getDeclaringClass().isInstance(testInstance)
+				|| lifecycle != TestInstance.Lifecycle.PER_CLASS;
+	}
+
 	private ArgumentSets invokeMethodFactory(Method testMethod, Method factory, Object testInstance) {
-		ArgumentSets argumentSets = (ArgumentSets) invokeMethod(factory, testInstance);
+		Object target = factory.getDeclaringClass().isInstance(testInstance) ? testInstance : null;
+		ArgumentSets argumentSets = (ArgumentSets) invokeMethod(factory, target);
 		long count = argumentSets.getArguments().size();
 		if (count > testMethod.getParameterCount()) {
 			// If arguments count == parameters but one of the parameters should be auto-injected by JUnit

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianFactoryArgumentsProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianFactoryArgumentsProvider.java
@@ -16,6 +16,7 @@ import static org.junit.platform.commons.support.ReflectionSupport.invokeMethod;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
@@ -32,11 +33,14 @@ class CartesianFactoryArgumentsProvider
 	@Override
 	public ArgumentSets provideArguments(ExtensionContext context) throws Exception {
 		Method testMethod = context.getRequiredTestMethod();
-		Method factory = findMethodFactory(testMethod, methodFactoryName);
-		return invokeMethodFactory(testMethod, factory);
+		Object testInstance = context.getTestInstance().orElse(null);
+		TestInstance.Lifecycle lifecycle = context.getTestInstanceLifecycle().orElse(null);
+		boolean factoryMustBeStatic = testInstance == null || lifecycle != TestInstance.Lifecycle.PER_CLASS;
+		Method factory = findMethodFactory(testMethod, methodFactoryName, factoryMustBeStatic);
+		return invokeMethodFactory(testMethod, factory, testInstance);
 	}
 
-	private static Method findMethodFactory(Method testMethod, String methodFactoryName) {
+	private static Method findMethodFactory(Method testMethod, String methodFactoryName, boolean factoryMustBeStatic) {
 		String factoryName = extractMethodFactoryName(methodFactoryName);
 		Class<?> declaringClass = findExplicitOrImplicitClass(testMethod, methodFactoryName);
 		Method factory = PioneerUtils
@@ -44,7 +48,7 @@ class CartesianFactoryArgumentsProvider
 				.orElseThrow(() -> new ExtensionConfigurationException("Method `Stream<? extends Arguments> "
 						+ factoryName + "()` not found in " + declaringClass + " or any enclosing class."));
 		String method = "Method `" + factory + "`";
-		if (!Modifier.isStatic(factory.getModifiers()))
+		if (factoryMustBeStatic && !Modifier.isStatic(factory.getModifiers()))
 			throw new ExtensionConfigurationException(method + " must be static.");
 		if (!ArgumentSets.class.isAssignableFrom(factory.getReturnType()))
 			throw new ExtensionConfigurationException(
@@ -80,8 +84,8 @@ class CartesianFactoryArgumentsProvider
 					format("Class %s not found, referenced in method %s", className, testMethod.getName()), ex));
 	}
 
-	private ArgumentSets invokeMethodFactory(Method testMethod, Method factory) {
-		ArgumentSets argumentSets = (ArgumentSets) invokeMethod(factory, null);
+	private ArgumentSets invokeMethodFactory(Method testMethod, Method factory, Object testInstance) {
+		ArgumentSets argumentSets = (ArgumentSets) invokeMethod(factory, testInstance);
 		long count = argumentSets.getArguments().size();
 		if (count > testMethod.getParameterCount()) {
 			// If arguments count == parameters but one of the parameters should be auto-injected by JUnit

--- a/src/test/java/org/junitpioneer/jupiter/cartesian/CartesianTestFactoryTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/cartesian/CartesianTestFactoryTests.java
@@ -93,11 +93,22 @@ public class CartesianTestFactoryTests {
 		@DisplayName("when factory is non-static with lifecyle PER_CLASS")
 		void nonStaticWithLifecylePerClass() {
 			ExecutionResults results = PioneerTestKit
-					.executeTestMethodWithParameterTypes(CorrectFactoryTestCases.PerClassLifecycle.class, "nonStatic",
-						String.class, String.class);
+					.executeNestedTestMethodWithParameterTypes(List.of(CorrectFactoryTestCases.class),
+						CorrectFactoryTestCases.PerClassLifecycle.class, "nonStatic", String.class, String.class);
 
 			assertThat(results).hasNumberOfSucceededTests(4);
 			assertThat(results).hasNumberOfReportEntries(4).withValues("A,C", "A,D", "B,C", "B,D");
+		}
+
+		@Test
+		@DisplayName("finds very explicitly specified class and method with lifecycle PER_CLASS")
+		void findsExactWithLifecyclePerClass() {
+			ExecutionResults results = PioneerTestKit
+					.executeNestedTestMethodWithParameterTypes(List.of(CorrectFactoryTestCases.class),
+						CorrectFactoryTestCases.PerClassLifecycle.class, "findsExact", String.class, String.class);
+
+			assertThat(results).hasNumberOfSucceededTests(4);
+			assertThat(results).hasNumberOfReportEntries(4).withValues("AC", "AD", "BC", "BD");
 		}
 
 	}
@@ -187,6 +198,23 @@ public class CartesianTestFactoryTests {
 								message -> message.matches("^No ParameterResolver registered for parameter .*$")));
 		}
 
+		@Test
+		@DisplayName("finds very explicitly specified class and non-static method with lifecyle PER_CLASS")
+		void findNonStaticExactWithLifecylePerClass() {
+			ExecutionResults results = PioneerTestKit
+					.executeNestedTestMethodWithParameterTypes(List.of(WrongFactoryTestCases.class),
+						WrongFactoryTestCases.PerClassLifecycle.class, "findsNonStaticExact", String.class,
+						String.class);
+
+			assertThat(results)
+					.hasSingleFailedContainer()
+					.andThenCheckException(exception -> assertThat(exception)
+							.extracting(Throwable::getCause)
+							.isExactlyInstanceOf(ExtensionConfigurationException.class)
+							.extracting(Throwable::getMessage)
+							.matches(message -> message.matches("^Method .* must be static.$")));
+		}
+
 	}
 
 	static class WrongFactoryTestCases {
@@ -237,6 +265,18 @@ public class CartesianTestFactoryTests {
 
 		static ArgumentSets withNull() {
 			return ArgumentSets.argumentsForFirstParameter(1, 2).argumentsForNextParameter((Object) null);
+		}
+
+		@Nested
+		@TestInstance(Lifecycle.PER_CLASS)
+		class PerClassLifecycle {
+
+			@CartesianTest
+			@CartesianTest.MethodFactory("org.junitpioneer.jupiter.cartesian.CartesianTestFactoryTests$WrongFactoryTestCases#nonStatic")
+			@ReportEntry("{0},{1}")
+			void findsNonStaticExact(String s1, String s2) {
+			}
+
 		}
 
 	}
@@ -293,13 +333,20 @@ public class CartesianTestFactoryTests {
 
 		}
 
+		@Nested
 		@TestInstance(Lifecycle.PER_CLASS)
-		static class PerClassLifecycle {
+		class PerClassLifecycle {
 
 			@CartesianTest
 			@CartesianTest.MethodFactory("nonStatic")
 			@ReportEntry("{0},{1}")
 			void nonStatic(String s1, String s2) {
+			}
+
+			@CartesianTest
+			@CartesianTest.MethodFactory("org.junitpioneer.jupiter.cartesian.CartesianTestFactoryTests$CorrectFactoryTestCases$Inner#exact")
+			@ReportEntry("{0}{1}")
+			void findsExact(String s1, String s2) {
 			}
 
 			ArgumentSets nonStatic() {

--- a/src/test/java/org/junitpioneer/jupiter/cartesian/CartesianTestFactoryTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/cartesian/CartesianTestFactoryTests.java
@@ -20,6 +20,8 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junitpioneer.jupiter.ReportEntry;
@@ -85,6 +87,17 @@ public class CartesianTestFactoryTests {
 
 			assertThat(results).hasNumberOfSucceededTests(2);
 			assertThat(results).hasNumberOfReportEntries(2).withValues("A,null", "B,null");
+		}
+
+		@Test
+		@DisplayName("when factory is non-static with lifecyle PER_CLASS")
+		void nonStaticWithLifecylePerClass() {
+			ExecutionResults results = PioneerTestKit
+					.executeTestMethodWithParameterTypes(CorrectFactoryTestCases.PerClassLifecycle.class, "nonStatic",
+						String.class, String.class);
+
+			assertThat(results).hasNumberOfSucceededTests(4);
+			assertThat(results).hasNumberOfReportEntries(4).withValues("A,C", "A,D", "B,C", "B,D");
 		}
 
 	}
@@ -275,6 +288,21 @@ public class CartesianTestFactoryTests {
 		static class Inner {
 
 			static ArgumentSets exact() {
+				return ArgumentSets.argumentsForFirstParameter("A", "B").argumentsForNextParameter("C", "D");
+			}
+
+		}
+
+		@TestInstance(Lifecycle.PER_CLASS)
+		static class PerClassLifecycle {
+
+			@CartesianTest
+			@CartesianTest.MethodFactory("nonStatic")
+			@ReportEntry("{0},{1}")
+			void nonStatic(String s1, String s2) {
+			}
+
+			ArgumentSets nonStatic() {
 				return ArgumentSets.argumentsForFirstParameter("A", "B").argumentsForNextParameter("C", "D");
 			}
 

--- a/src/test/java/org/junitpioneer/testkit/ExecutionResults.java
+++ b/src/test/java/org/junitpioneer/testkit/ExecutionResults.java
@@ -10,6 +10,8 @@
 
 package org.junitpioneer.testkit;
 
+import java.util.List;
+
 import org.junit.platform.engine.discovery.DiscoverySelectors;
 import org.junit.platform.testkit.engine.EngineExecutionResults;
 import org.junit.platform.testkit.engine.EngineTestKit;
@@ -42,6 +44,29 @@ public class ExecutionResults {
 	ExecutionResults(Class<?> testClass, String testMethodName, String methodParameterTypes) {
 		executionResults = getConfiguredJupiterEngine()
 				.selectors(DiscoverySelectors.selectMethod(testClass, testMethodName, methodParameterTypes))
+				.execute();
+	}
+
+	ExecutionResults(List<Class<?>> enclosingClasses, Class<?> testClass) {
+		executionResults = EngineTestKit
+				.engine(JUPITER_ENGINE_NAME)
+				.selectors(DiscoverySelectors.selectNestedClass(enclosingClasses, testClass))
+				.execute();
+	}
+
+	ExecutionResults(List<Class<?>> enclosingClasses, Class<?> testClass, String testMethodName) {
+		executionResults = EngineTestKit
+				.engine(JUPITER_ENGINE_NAME)
+				.selectors(DiscoverySelectors.selectNestedMethod(enclosingClasses, testClass, testMethodName))
+				.execute();
+	}
+
+	ExecutionResults(List<Class<?>> enclosingClasses, Class<?> testClass, String testMethodName,
+			String methodParameterTypes) {
+		executionResults = EngineTestKit
+				.engine(JUPITER_ENGINE_NAME)
+				.selectors(DiscoverySelectors
+						.selectNestedMethod(enclosingClasses, testClass, testMethodName, methodParameterTypes))
 				.execute();
 	}
 

--- a/src/test/java/org/junitpioneer/testkit/PioneerTestKit.java
+++ b/src/test/java/org/junitpioneer/testkit/PioneerTestKit.java
@@ -13,6 +13,8 @@ package org.junitpioneer.testkit;
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.joining;
 
+import java.util.List;
+
 import org.opentest4j.TestAbortedException;
 
 public class PioneerTestKit {
@@ -52,6 +54,56 @@ public class PioneerTestKit {
 	public static ExecutionResults executeTestMethodWithParameterTypes(Class<?> testClass, String testMethodName,
 			Class<?>... methodParameterTypes) {
 
+		String allTypeNames = toMethodParameterTypesString(methodParameterTypes);
+
+		return new ExecutionResults(testClass, testMethodName, allTypeNames);
+	}
+
+	/**
+	 * Returns the execution results of the given nested test class.
+	 *
+	 * @param enclosingClasses List of the enclosing classes
+	 * @param testClass Name of the test class, the results should be returned
+	 * @return The execution results
+	 */
+	public static ExecutionResults executeNestedTestClass(List<Class<?>> enclosingClasses, Class<?> testClass) {
+		return new ExecutionResults(enclosingClasses, testClass);
+	}
+
+	/**
+	 * Returns the execution results of the given method of a given nested test class.
+	 *
+	 * @param enclosingClasses List of the enclosing classes
+	 * @param testClass Name of the test class
+	 * @param testMethodName Name of the test method (of the given class)
+	 * @return The execution results
+	 */
+	public static ExecutionResults executeNestedTestMethod(List<Class<?>> enclosingClasses, Class<?> testClass,
+			String testMethodName) {
+		return new ExecutionResults(enclosingClasses, testClass, testMethodName);
+	}
+
+	/**
+	 * Returns the execution results of the given method of a given nested test class.
+	 *
+	 * @param enclosingClasses List of the enclosing classes
+	 * @param testClass Name of the test class
+	 * @param testMethodName Name of the test method (of the given class)
+	 * @param methodParameterTypes Class type(s) of the parameter(s)
+	 * @return The execution results
+	 * @throws IllegalArgumentException when methodParameterTypes is null
+	 *			This method only checks parameters which are not part of the underlying
+	 *			Jupiter TestKit. The Jupiter TestKit may throw other exceptions!
+	 */
+	public static ExecutionResults executeNestedTestMethodWithParameterTypes(List<Class<?>> enclosingClasses,
+			Class<?> testClass, String testMethodName, Class<?>... methodParameterTypes) {
+
+		String allTypeNames = toMethodParameterTypesString(methodParameterTypes);
+
+		return new ExecutionResults(enclosingClasses, testClass, testMethodName, allTypeNames);
+	}
+
+	private static String toMethodParameterTypesString(Class<?>... methodParameterTypes) {
 		// throw IllegalArgumentException for a `null` array instead of NPE
 		// (hence no use of `Objects::requireNonNull`)
 		if (methodParameterTypes == null) {
@@ -59,9 +111,7 @@ public class PioneerTestKit {
 		}
 
 		// Concatenating all type names, because DiscoverySelectors.selectMethod only takes String as a parameter.
-		String allTypeNames = stream(methodParameterTypes).map(Class::getName).collect(joining(","));
-
-		return new ExecutionResults(testClass, testMethodName, allTypeNames);
+		return stream(methodParameterTypes).map(Class::getName).collect(joining(","));
 	}
 
 	/**


### PR DESCRIPTION
```
Allow non-static Cartesian factory methods with PER_CLASS (#628)

JUnit allows non-static factory methods as long as the test class is
annotated with `@Testinstance(Lifecycle.PER_CLASS)`. The same is
currently not true for `@CartesianTest.MethodFactory`.
This commit fixes that.

The existing non-static test is unmodified, indicating that
non-static is still not allowed if the test class is not annotated
with `@Testinstance(Lifecycle.PER_CLASS)`.

PR: #628
```

---
**PR checklist**

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Code
* [X] Code adheres to code style, naming conventions etc.
* [X] Successful tests cover all changes
* [X] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [X] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [X] A prepared commit message exists
* [X] The list of contributions inside `README.md` mentions the new contribution (real name optional) 