### PR TITLE
Improve documentation of JSON argument source

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -480,7 +480,7 @@ Pioneer avoids adding to users' dependency hell and hence doesn't take on depend
 _Optional_ dependencies are acceptable if they are needed to provide specific features, particularly:
 
 * to _integrate_ with other tools, frameworks, and libraries by offering features that directly interact with them (a hypothetical example is [Playwright](https://playwright.dev) for E2E testing)
-* for _ease of use_ when recreating functionality would be too complex or otherwise out of scope for Pioneer (a hypothetical example is [Jackson](https://github.com/FasterXML/jackson) for JSON parsing)
+* for _ease of use_ when recreating functionality would be too complex or otherwise out of scope for Pioneer (an example is [Jackson](https://github.com/FasterXML/jackson) for JSON parsing)
 
 Unless we see reports of optional dependencies causing unexpected problems for users, there is no particularly high hurdle for taking them on, given each provides more than marginal value.
 They should only be used by specifically chosen features that require them, though, and care needs to be taken to prevent them from creeping into the rest of the code base - CheckStyle rules need to be configured for each that fail the build on accidental use of these dependencies.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,9 @@ repositories {
 }
 
 val junitVersion : String by project
+// IMPORTANT:
+// This version is mentioned in json-argument-source.adoc
+// and needs to be updated there if changed here!
 val jacksonVersion: String = "2.13.2.2"
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,9 +53,6 @@ repositories {
 }
 
 val junitVersion : String by project
-// IMPORTANT:
-// This version is mentioned in json-argument-source.adoc
-// and needs to be updated there if changed here!
 val jacksonVersion: String = "2.13.2.2"
 
 dependencies {

--- a/docs/json-argument-source.adoc
+++ b/docs/json-argument-source.adoc
@@ -150,9 +150,9 @@ This parametrized test will generate the following tests:
 To not make users' dependency management more complex, JUnit Pioneer has no run-time dependencies.
 At the same time, it's not parsing JSON itself and relies on third-party libraries for that.
 For this extension that means that projects who want to use it need to pull in a JSON parser themselves.
-This is the list of supported parsers (with the version used when building Pioneer although compatible versions should work as well):
+This is the list of supported parsers:
 
-* Jackson: com.fasterxml.jackson.core:jackson-databind:2.13.2.2
+* https://search.maven.org/artifact/com.fasterxml.jackson.core/jackson-databind[Jackson]
 
 If you need support for another parser, please https://github.com/junit-pioneer/junit-pioneer/issues/new/choose[open an issue].
 If your project does not already depend on a supported JSON parser, you can add it as follows.
@@ -173,7 +173,7 @@ testRuntimeOnly("org.junit-pioneer:junit-pioneer") {
 Alternatively, the dependency can be added directly:
 
 ```kotlin
-testImplementation("com.fasterxml.jackson.core:jackson-databind:$VERSION")
+testImplementation("com.fasterxml.jackson.core:jackson-databind:$CURRENT_VERSION")
 ```
 
 === Maven
@@ -184,7 +184,7 @@ In Maven, add the parser as a test dependency:
 <dependency>
     <groupId>com.fasterxml.jackson.core</groupId>
     <artifactId>jackson-databind</artifactId>
-    <version>$VERSION</version>
+    <version>$CURRENT_VERSION</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/docs/json-argument-source.adoc
+++ b/docs/json-argument-source.adoc
@@ -7,7 +7,7 @@
 The JSON argument sources let you provide arguments for parameterized tests from JSON.
 There are three annotations:
 
-* `@JsonSource` for lenient inline JSON
+* `@JsonSource` for lenient inline JSON, works with regular string literals and text blocks
 * `@JsonFileSource` for JSON files from the local file system
 * `@JsonClasspathSource` for JSON files from the classpath
 
@@ -144,6 +144,59 @@ This parametrized test will generate the following tests:
 
 * [1] Snowspeeder, 4.5
 * [2] Imperial Speeder Bike, 3
+
+== JSON Parser Integration
+
+To not make users' dependency management more complex, JUnit Pioneer has no run-time dependencies.
+At the same time, it's not parsing JSON itself and relies on third-party libraries for that.
+For this extensions that means that projects who want to use it need to pull in a JSON parser themselves.
+This is the list of supported parsers (with the version used when building Pioneer although compatible versions should work as well):
+
+* Jackson: com.fasterxml.jackson.core:jackson-databind:2.13.2.2
+
+If you need support for another parser, please https://github.com/junit-pioneer/junit-pioneer/issues/new/choose[open an issue].
+If your project does not already depend on a supported JSON parser, you can add it as follows.
+
+=== Gradle
+
+Gradle offers two ways to pull in a parser.
+The recommended one is to use https://docs.gradle.org/current/userguide/feature_variants.html[feature variants]:
+
+```kotlin
+testRuntimeOnly("org.junit-pioneer:junit-pioneer") {
+    capabilities {
+        requireCapability("org.junit-pioneer:junit-pioneer-jackson")
+    }
+}
+```
+
+Alternatively, the dependency can be added directly:
+
+```kotlin
+testImplementation("com.fasterxml.jackson.core:jackson-databind:$VERSION")
+```
+
+=== Maven
+
+In Maven, add the parser as a test dependency:
+
+```xml
+<dependency>
+    <groupId>com.fasterxml.jackson.core</groupId>
+    <artifactId>jackson-databind</artifactId>
+    <version>$VERSION</version>
+    <scope>test</scope>
+</dependency>
+```
+
+=== Java Modules
+
+If your test code runs as a module, the JSON parser must make it into the module graph.
+That means (1) it must be on the module path and (2) it must be resolved.
+
+The steps above ensure that your build tool knows about the parser and should accomplish (1), but if no other module depends on the parser (directly or indirectly), (2) requires additional work.
+In that case, you need to manually resolve the module by applying the command line option `--add-modules=com.fasterxml.jackson.databind` to the Java process that executes the tests.
+
 
 == Thread-Safety
 

--- a/docs/json-argument-source.adoc
+++ b/docs/json-argument-source.adoc
@@ -149,7 +149,7 @@ This parametrized test will generate the following tests:
 
 To not make users' dependency management more complex, JUnit Pioneer has no run-time dependencies.
 At the same time, it's not parsing JSON itself and relies on third-party libraries for that.
-For this extensions that means that projects who want to use it need to pull in a JSON parser themselves.
+For this extension that means that projects who want to use it need to pull in a JSON parser themselves.
 This is the list of supported parsers (with the version used when building Pioneer although compatible versions should work as well):
 
 * Jackson: com.fasterxml.jackson.core:jackson-databind:2.13.2.2

--- a/src/demo/java/org/junitpioneer/jupiter/json/JsonArgumentSourceExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/json/JsonArgumentSourceExtensionDemo.java
@@ -29,7 +29,8 @@ class JsonArgumentSourceExtensionDemo {
 		// tag::classpath_source_with_property[]
 		@ParameterizedTest
 		@JsonClasspathSource("jedis.json")
-		void singleJediProperty(@Property("name") String jediName) {
+		void singleJediProperty(
+				@Property("name") String jediName) {
 			// YOUR TEST CODE HERE
 		}
 		// end::classpath_source_with_property[]
@@ -37,15 +38,20 @@ class JsonArgumentSourceExtensionDemo {
 		// tag::classpath_source_deconstruct_from_array[]
 		@ParameterizedTest
 		@JsonClasspathSource("jedis.json")
-		void deconstructFromArray(@Property("name") String name, @Property("height") int height) {
+		void deconstructFromArray(
+				@Property("name") String name,
+				@Property("height") int height) {
 			// YOUR TEST CODE HERE
 		}
 		// end::classpath_source_deconstruct_from_array[]
 
 		// tag::classpath_source_nested_data[]
 		@ParameterizedTest
-		@JsonClasspathSource(value = "luke.json", data = "vehicles")
-		void lukeVehicles(@Property("name") String name, @Property("length") double length) {
+		@JsonClasspathSource(
+				value = "luke.json", data = "vehicles")
+		void lukeVehicles(
+				@Property("name") String name,
+				@Property("length") double length) {
 			// YOUR TEST CODE HERE
 		}
 		// end::classpath_source_nested_data[]
@@ -75,7 +81,8 @@ class JsonArgumentSourceExtensionDemo {
 				"{ name: 'Luke', height: 172  }",
 				"{ name: 'Yoda', height: 66 }"
 		})
-		void singleJediProperty(@Property("name") String jediName) {
+		void singleJediProperty(
+				@Property("name") String jediName) {
 			// YOUR TEST CODE HERE
 		}
 		// end::inline_source_with_property[]
@@ -88,7 +95,9 @@ class JsonArgumentSourceExtensionDemo {
 				"{ name: 'Yoda', height: 66 }",
 				"{ name: 'Luke', height: 172 }",
 		})
-		void deconstructFromArray(@Property("name") String name, @Property("height") int height) {
+		void deconstructFromArray(
+				@Property("name") String name,
+				@Property("height") int height) {
 			// YOUR TEST CODE HERE
 		}
 		// @formatter:on

--- a/src/demo/java/org/junitpioneer/jupiter/json/JsonArgumentSourceExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/json/JsonArgumentSourceExtensionDemo.java
@@ -26,6 +26,7 @@ class JsonArgumentSourceExtensionDemo {
 		}
 		// end::classpath_source[]
 
+		// @formatter:off
 		// tag::classpath_source_with_property[]
 		@ParameterizedTest
 		@JsonClasspathSource("jedis.json")
@@ -34,7 +35,9 @@ class JsonArgumentSourceExtensionDemo {
 			// YOUR TEST CODE HERE
 		}
 		// end::classpath_source_with_property[]
+		// @formatter:on
 
+		// @formatter:off
 		// tag::classpath_source_deconstruct_from_array[]
 		@ParameterizedTest
 		@JsonClasspathSource("jedis.json")
@@ -44,7 +47,9 @@ class JsonArgumentSourceExtensionDemo {
 			// YOUR TEST CODE HERE
 		}
 		// end::classpath_source_deconstruct_from_array[]
+		// @formatter:on
 
+		// @formatter:off
 		// tag::classpath_source_nested_data[]
 		@ParameterizedTest
 		@JsonClasspathSource(
@@ -55,6 +60,7 @@ class JsonArgumentSourceExtensionDemo {
 			// YOUR TEST CODE HERE
 		}
 		// end::classpath_source_nested_data[]
+		// @formatter:on
 
 	}
 

--- a/src/main/java/org/junitpioneer/jupiter/json/JsonClasspathSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/json/JsonClasspathSource.java
@@ -28,9 +28,10 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  * the annotation has to be on the method itself as any other {@link ArgumentsSource}.
  * </p>
  *
- * <p>
- * For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/json/" target="_top">the documentation on <code>JSON tests</code></a>
+ * <p>Note that this extension requires a JSON parser to be available at run time,
+ * which may include adding it to the module graph with {@code --add-modules}.
+ * For details on that as well as how to use this extension, see
+ * <a href="https://junit-pioneer.org/docs/json-argument-source" target="_top">the documentation on <code>JSON tests</code></a>
  * </p>
  *
  * @since 1.7.0

--- a/src/main/java/org/junitpioneer/jupiter/json/JsonFileSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/json/JsonFileSource.java
@@ -28,9 +28,10 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  * the annotation has to be on the method itself as any other {@link ArgumentsSource}.
  * </p>
  *
- * <p>
- * For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/json/" target="_top">the documentation on <code>JSON tests</code></a>
+ * <p>Note that this extension requires a JSON parser to be available at run time,
+ * which may include adding it to the module graph with {@code --add-modules}.
+ * For details on that as well as how to use this extension, see
+ * <a href="https://junit-pioneer.org/docs/json-argument-source" target="_top">the documentation on <code>JSON tests</code></a>
  * </p>
  *
  * @since 1.7.0

--- a/src/main/java/org/junitpioneer/jupiter/json/JsonSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/json/JsonSource.java
@@ -27,9 +27,11 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  * If used with {@link org.junit.jupiter.params.ParameterizedTest},
  * the annotation has to be on the method itself as any other {@link ArgumentsSource}.
  * </p>
- * <p>
- * For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/json/" target="_top">the documentation on <code>JSON tests</code></a>
+ *
+ * <p>Note that this extension requires a JSON parser to be available at run time,
+ * which may include adding it to the module graph with {@code --add-modules}.
+ * For details on that as well as how to use this extension, see
+ * <a href="https://junit-pioneer.org/docs/json-argument-source" target="_top">the documentation on <code>JSON tests</code></a>
  * </p>
  *
  * @since 1.7.0

--- a/src/main/java/org/junitpioneer/jupiter/json/NoJsonParserConfiguredException.java
+++ b/src/main/java/org/junitpioneer/jupiter/json/NoJsonParserConfiguredException.java
@@ -19,10 +19,11 @@ import org.junit.platform.commons.JUnitException;
  */
 public class NoJsonParserConfiguredException extends JUnitException {
 
-	static final long serialVersionUID = 5399969575022498446L;
+	private static final long serialVersionUID = 5399969575022498446L;
+	private static final String ERROR_MESSAGE = "No JSON parsing library found. Make sure a supported JSON parser (currently only Jackson) is on your test class/module path. For more information, see https://junit-pioneer.org/docs/json-argument-source/";
 
 	NoJsonParserConfiguredException() {
-		super("No JSON parsing library found. Make sure a supported JSON parser (currently only Jackson) is on your test class/module path.");
+		super(ERROR_MESSAGE);
 	}
 
 }

--- a/src/main/java/org/junitpioneer/jupiter/json/NoJsonParserConfiguredException.java
+++ b/src/main/java/org/junitpioneer/jupiter/json/NoJsonParserConfiguredException.java
@@ -22,7 +22,7 @@ public class NoJsonParserConfiguredException extends JUnitException {
 	static final long serialVersionUID = 5399969575022498446L;
 
 	NoJsonParserConfiguredException() {
-		super("There is no available JSON parsing library. Currently supported library is Jackson");
+		super("No JSON parsing library found. Make sure a supported JSON parser (currently only Jackson) is on your test class/module path.");
 	}
 
 }

--- a/src/main/java/org/junitpioneer/jupiter/json/package-info.java
+++ b/src/main/java/org/junitpioneer/jupiter/json/package-info.java
@@ -1,5 +1,11 @@
 /**
- * Argument providers for Json Source.
+ * Provides parameterized test arguments from JSON (inline or file).
+ *
+ * <p>Note that these extensions require a JSON parser to be available at run time,
+ * which may include adding it to the module graph with {@code --add-modules}.
+ * For details on that, see
+ * <a href="https://junit-pioneer.org/docs/json-argument-source" target="_top">the documentation on <code>JSON tests</code></a>
+ * </p>
  *
  * <p>Check out the following types for details on providing values for parameterized tests:
  * <ul>


### PR DESCRIPTION
Proposed commit message:

```
Improve documentation of JSON argument source (#621 / #631)

* mention that text blocks work
* reduce code snippet line length to max ~60, so they fit into the
  narrow code boxes on the website (i.e. no horizontal scroll bar)
* explain parser integration work:
	* so far only Jackson
	* optional dependency
	* force module resolution

Closes: #621
PR: #631
```
---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [x] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [x] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [x] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [x] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [x] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [x] The `package-info.java` contains information about the new extension

Code
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [x] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [x] The list of contributions inside `README.md` mentions the new contribution (real name optional) 
