### PR TITLE
Add @Inherited

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,6 +183,19 @@ How to write the code itself.
 * design code to avoid optionality wherever feasibly possible
 * in all remaining cases, prefer `Optional` over `null`
 
+#### Reusability
+
+We strive to make our extensions reusable and extensible.
+
+A key ingredient in that is making sure that annotations work as meta-annotations (i.e. users can apply _our_ annotations to _their_ annotations and our extensions still work).
+To achieve this, apply `@Target({ ElementType.ANNOTATION_TYPE })` to annotations and prefer `org.junitpioneer.internal.PioneerAnnotationUtils` and `org.junit.platform.commons.support.AnnotationSupport` when searching for annotations.
+
+Another aspect is that annotations that apply to classes (i.e. those marked with `@Target({ ElementType.TYPE })`) should be inherited by subclasses.
+For that, also add the annotation `@Inherited`.
+
+**NOTE**:
+`ElementType.TYPE` includes annotations, so there's no need to apply it _and_ `ElementType.ANNOTATION_TYPE`.
+
 #### Thread-safety
 
 It must be safe to use Pioneer's extensions in a test suite that is executed in parallel.

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
@@ -60,8 +60,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @see java.util.Locale#getDefault()
  * @see DefaultTimeZone
  */
-@Target({ ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.TYPE })
 @Inherited
 @WritesDefaultLocale
 @ExtendWith(DefaultLocaleExtension.class)

--- a/src/main/java/org/junitpioneer/jupiter/DefaultTimeZone.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultTimeZone.java
@@ -49,8 +49,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @see java.util.TimeZone#getDefault()
  * @see DefaultLocale
  */
-@Target({ ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.TYPE })
 @Inherited
 @WritesDefaultTimeZone
 @ExtendWith(DefaultTimeZoneExtension.class)

--- a/src/main/java/org/junitpioneer/jupiter/DisableIfTestFails.java
+++ b/src/main/java/org/junitpioneer/jupiter/DisableIfTestFails.java
@@ -10,9 +10,7 @@
 
 package org.junitpioneer.jupiter;
 
-import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
-import static java.lang.annotation.ElementType.TYPE;
-
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -46,9 +44,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * ... then, only remaining tests in {@code SpecificTests} are disabled and other implementations
  * of {@code Tests} remain unaffected, i.e. their tests are not disabled.
  */
-@Target({ TYPE, ANNOTATION_TYPE })
-@Inherited
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE })
+@Inherited
 @ExtendWith(DisableIfTestFailsExtension.class)
 public @interface DisableIfTestFails {
 

--- a/src/main/java/org/junitpioneer/jupiter/DisabledUntil.java
+++ b/src/main/java/org/junitpioneer/jupiter/DisabledUntil.java
@@ -30,8 +30,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *
  * @see org.junit.jupiter.api.Disabled
  */
-@Target({ ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.TYPE })
 @Inherited
 @ExtendWith(DisabledUntilExtension.class)
 public @interface DisabledUntil {

--- a/src/main/java/org/junitpioneer/jupiter/Issue.java
+++ b/src/main/java/org/junitpioneer/jupiter/Issue.java
@@ -11,6 +11,7 @@
 package org.junitpioneer.jupiter;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -35,8 +36,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @since 1.1
  * @see IssueProcessor
  */
-@Target({ ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Inherited
 @ExtendWith(IssueExtension.class)
 public @interface Issue {
 

--- a/src/main/java/org/junitpioneer/jupiter/ReadsDefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReadsDefaultLocale.java
@@ -11,6 +11,7 @@
 package org.junitpioneer.jupiter;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -34,9 +35,9 @@ import org.junit.jupiter.api.parallel.Resources;
  *
  * @since 0.9
  */
-@ResourceLock(value = Resources.LOCALE, mode = ResourceAccessMode.READ)
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE,
-		ElementType.TYPE })
+@Target({ ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE, ElementType.TYPE })
+@Inherited
+@ResourceLock(value = Resources.LOCALE, mode = ResourceAccessMode.READ)
 public @interface ReadsDefaultLocale {
 }

--- a/src/main/java/org/junitpioneer/jupiter/ReadsDefaultTimeZone.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReadsDefaultTimeZone.java
@@ -11,6 +11,7 @@
 package org.junitpioneer.jupiter;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -34,9 +35,9 @@ import org.junit.jupiter.api.parallel.Resources;
  *
  * @since 0.9
  */
-@ResourceLock(value = Resources.TIME_ZONE, mode = ResourceAccessMode.READ)
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE,
-		ElementType.TYPE })
+@Target({ ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE, ElementType.TYPE })
+@Inherited
+@ResourceLock(value = Resources.TIME_ZONE, mode = ResourceAccessMode.READ)
 public @interface ReadsDefaultTimeZone {
 }

--- a/src/main/java/org/junitpioneer/jupiter/ReadsEnvironmentVariable.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReadsEnvironmentVariable.java
@@ -11,6 +11,7 @@
 package org.junitpioneer.jupiter;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -33,9 +34,9 @@ import org.junit.jupiter.api.parallel.ResourceLock;
  *
  * @since 0.9
  */
-@ResourceLock(value = "java.lang.System.environment", mode = ResourceAccessMode.READ)
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE,
-		ElementType.TYPE })
+@Target({ ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE, ElementType.TYPE })
+@Inherited
+@ResourceLock(value = "java.lang.System.environment", mode = ResourceAccessMode.READ)
 public @interface ReadsEnvironmentVariable {
 }

--- a/src/main/java/org/junitpioneer/jupiter/ReadsStdIo.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReadsStdIo.java
@@ -11,6 +11,7 @@
 package org.junitpioneer.jupiter;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -35,10 +36,10 @@ import org.junit.jupiter.api.parallel.Resources;
  *
  * @since 0.9
  */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE, ElementType.TYPE })
+@Inherited
 @ResourceLock(value = "java.lang.System.in", mode = ResourceAccessMode.READ)
 @ResourceLock(value = Resources.SYSTEM_OUT, mode = ResourceAccessMode.READ)
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE,
-		ElementType.TYPE })
 public @interface ReadsStdIo {
 }

--- a/src/main/java/org/junitpioneer/jupiter/ReadsSystemProperty.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReadsSystemProperty.java
@@ -11,6 +11,7 @@
 package org.junitpioneer.jupiter;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -34,9 +35,9 @@ import org.junit.jupiter.api.parallel.Resources;
  *
  * @since 0.9
  */
-@ResourceLock(value = Resources.SYSTEM_PROPERTIES, mode = ResourceAccessMode.READ)
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE,
-		ElementType.TYPE })
+@Target({ ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE, ElementType.TYPE })
+@Inherited
+@ResourceLock(value = Resources.SYSTEM_PROPERTIES, mode = ResourceAccessMode.READ)
 public @interface ReadsSystemProperty {
 }

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTest.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTest.java
@@ -10,10 +10,9 @@
 
 package org.junitpioneer.jupiter;
 
-import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
-import static java.lang.annotation.ElementType.METHOD;
 import static org.junit.jupiter.api.parallel.ExecutionMode.SAME_THREAD;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -68,7 +67,7 @@ import org.junitpioneer.internal.TestNameFormatter;
  *
  * @since 0.4
  */
-@Target({ METHOD, ANNOTATION_TYPE })
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 // the extension is inherently thread-unsafe (has to wait for one execution before starting the next),
 // so it forces execution of all retries onto the same thread

--- a/src/main/java/org/junitpioneer/jupiter/Stopwatch.java
+++ b/src/main/java/org/junitpioneer/jupiter/Stopwatch.java
@@ -11,6 +11,7 @@
 package org.junitpioneer.jupiter;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -27,6 +28,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE })
+@Inherited
 @ExtendWith(StopwatchExtension.class)
 public @interface Stopwatch {
 

--- a/src/main/java/org/junitpioneer/jupiter/WritesDefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/WritesDefaultLocale.java
@@ -11,6 +11,7 @@
 package org.junitpioneer.jupiter;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -34,9 +35,9 @@ import org.junit.jupiter.api.parallel.Resources;
  *
  * @since 0.9
  */
-@ResourceLock(value = Resources.LOCALE, mode = ResourceAccessMode.READ_WRITE)
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE,
-		ElementType.TYPE })
+@Target({ ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE, ElementType.TYPE })
+@Inherited
+@ResourceLock(value = Resources.LOCALE, mode = ResourceAccessMode.READ_WRITE)
 public @interface WritesDefaultLocale {
 }

--- a/src/main/java/org/junitpioneer/jupiter/WritesDefaultTimeZone.java
+++ b/src/main/java/org/junitpioneer/jupiter/WritesDefaultTimeZone.java
@@ -11,6 +11,7 @@
 package org.junitpioneer.jupiter;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -34,9 +35,9 @@ import org.junit.jupiter.api.parallel.Resources;
  *
  * @since 0.9
  */
-@ResourceLock(value = Resources.TIME_ZONE, mode = ResourceAccessMode.READ_WRITE)
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE,
-		ElementType.TYPE })
+@Target({ ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE, ElementType.TYPE })
+@Inherited
+@ResourceLock(value = Resources.TIME_ZONE, mode = ResourceAccessMode.READ_WRITE)
 public @interface WritesDefaultTimeZone {
 }

--- a/src/main/java/org/junitpioneer/jupiter/WritesEnvironmentVariable.java
+++ b/src/main/java/org/junitpioneer/jupiter/WritesEnvironmentVariable.java
@@ -11,6 +11,7 @@
 package org.junitpioneer.jupiter;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -33,9 +34,9 @@ import org.junit.jupiter.api.parallel.ResourceLock;
  *
  * @since 0.9
  */
-@ResourceLock(value = "java.lang.System.environment", mode = ResourceAccessMode.READ_WRITE)
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE,
-		ElementType.TYPE })
+@Target({ ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE, ElementType.TYPE })
+@Inherited
+@ResourceLock(value = "java.lang.System.environment", mode = ResourceAccessMode.READ_WRITE)
 public @interface WritesEnvironmentVariable {
 }

--- a/src/main/java/org/junitpioneer/jupiter/WritesStdIo.java
+++ b/src/main/java/org/junitpioneer/jupiter/WritesStdIo.java
@@ -11,6 +11,7 @@
 package org.junitpioneer.jupiter;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -34,10 +35,10 @@ import org.junit.jupiter.api.parallel.Resources;
  *
  * @since 0.9
  */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE, ElementType.TYPE })
+@Inherited
 @ResourceLock(value = "java.lang.System.in", mode = ResourceAccessMode.READ_WRITE)
 @ResourceLock(value = Resources.SYSTEM_OUT, mode = ResourceAccessMode.READ_WRITE)
-@Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE,
-		ElementType.TYPE })
 public @interface WritesStdIo {
 }

--- a/src/main/java/org/junitpioneer/jupiter/WritesSystemProperty.java
+++ b/src/main/java/org/junitpioneer/jupiter/WritesSystemProperty.java
@@ -11,6 +11,7 @@
 package org.junitpioneer.jupiter;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -34,9 +35,9 @@ import org.junit.jupiter.api.parallel.Resources;
  *
  * @since 0.9
  */
-@ResourceLock(value = Resources.SYSTEM_PROPERTIES, mode = ResourceAccessMode.READ_WRITE)
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE,
-		ElementType.TYPE })
+@Target({ ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE, ElementType.TYPE })
+@Inherited
+@ResourceLock(value = Resources.SYSTEM_PROPERTIES, mode = ResourceAccessMode.READ_WRITE)
 public @interface WritesSystemProperty {
 }

--- a/src/test/java/org/junitpioneer/internal/PioneerAnnotationUtilsTestCases.java
+++ b/src/test/java/org/junitpioneer/internal/PioneerAnnotationUtilsTestCases.java
@@ -20,7 +20,7 @@ import java.lang.annotation.Target;
 public class PioneerAnnotationUtilsTestCases {
 
 	@Retention(RetentionPolicy.RUNTIME)
-	@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+	@Target({ ElementType.TYPE, ElementType.METHOD })
 	@Inherited
 	public @interface NonRepeatableTestAnnotation {
 
@@ -29,7 +29,7 @@ public class PioneerAnnotationUtilsTestCases {
 	}
 
 	@Retention(RetentionPolicy.RUNTIME)
-	@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+	@Target({ ElementType.TYPE, ElementType.METHOD })
 	@Inherited
 	@Repeatable(PioneerAnnotationUtilsTestCases.RepeatableTestAnnotation.Container.class)
 	public @interface RepeatableTestAnnotation {
@@ -37,7 +37,7 @@ public class PioneerAnnotationUtilsTestCases {
 		String value() default "";
 
 		@Retention(RetentionPolicy.RUNTIME)
-		@Target({ ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+		@Target({ ElementType.TYPE, ElementType.METHOD })
 		@Inherited
 		@interface Container {
 

--- a/src/test/java/org/junitpioneer/jupiter/RetryingTestExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/RetryingTestExtensionTests.java
@@ -10,12 +10,11 @@
 
 package org.junitpioneer.jupiter;
 
-import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
-import static java.lang.annotation.ElementType.METHOD;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
 import static org.junitpioneer.testkit.PioneerTestKit.abort;
 import static org.junitpioneer.testkit.assertion.PioneerAssert.assertThat;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -417,7 +416,7 @@ class RetryingTestExtensionTests {
 
 	}
 
-	@Target({ METHOD, ANNOTATION_TYPE })
+	@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 	@Retention(RetentionPolicy.RUNTIME)
 	@TestTemplate
 	public @interface DummyTestTemplate {


### PR DESCRIPTION
Proposed commit message:

```
Document and improve reusability of various extensions (#456 / #634)

Expand contribution guide with explanation how to make extensions
reusable, namely:

* allow as meta-annotation and use our and Jupiter's tools to find
  annotations
* allow inheritance by applying `@Inherited`

This change also applies `@Inherited` where it wasn't already.

Closes: #456
PR: #634
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [x] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [x] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [x] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [x] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [x] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [x] The `package-info.java` contains information about the new extension

Code
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [x] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [x] The list of contributions inside `README.md` mentions the new contribution (real name optional) 
