### PR TITLE
Fix CartesianProductResolver::supportsParameter

### DIFF
--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianProductResolver.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianProductResolver.java
@@ -14,7 +14,6 @@ import static org.junitpioneer.internal.PioneerUtils.wrap;
 
 import java.util.List;
 
-import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolver;
@@ -48,10 +47,7 @@ class CartesianProductResolver implements ParameterResolver {
 		// parameter with correct type (or `null`)
 		if (parameter == null)
 			return true;
-		if (parameterClass.isAssignableFrom(parameter.getClass()))
-			return true;
-		throw new ExtensionConfigurationException(
-			"CartesianTest was supplied arguments but parameter is not supported.");
+		return parameterClass.isAssignableFrom(parameter.getClass());
 	}
 
 	@Override

--- a/src/test/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtensionTests.java
@@ -380,6 +380,22 @@ public class CartesianTestExtensionTests {
 						"Look on my works, ye Mighty, and despair!The lone and level sands stretch far away.");
 		}
 
+		@Test
+		@DisplayName("ignores 'oversupplied' parameters")
+		void factorySourceWithTestReporterNoSecondParam() {
+			ExecutionResults results = PioneerTestKit
+					.executeTestMethodWithParameterTypes(CartesianFactorySourceTestCases.class, "ignoredParam",
+						String.class, TestReporter.class);
+
+			assertThat(results)
+					.hasNumberOfReportEntries(9)
+					.withValues("And on the pedestal these words appear:", "My name is Ozymandias, king of kings;",
+						"Look on my works, ye Mighty, and despair!", "And on the pedestal these words appear:",
+						"My name is Ozymandias, king of kings;", "Look on my works, ye Mighty, and despair!",
+						"And on the pedestal these words appear:", "My name is Ozymandias, king of kings;",
+						"Look on my works, ye Mighty, and despair!");
+		}
+
 		@Nested
 		@DisplayName("removes redundant parameters from input sets")
 		class CartesianProductRedundancyTests {
@@ -742,23 +758,6 @@ public class CartesianTestExtensionTests {
 		}
 
 		@Test
-		@DisplayName("there is an auto-injected param but arguments were supplied")
-		void factorySourceWithTestReporter() {
-			ExecutionResults results = PioneerTestKit
-					.executeTestMethodWithParameterTypes(CartesianFactorySourceTestCases.class, "competingInject",
-						String.class, TestReporter.class);
-
-			assertThat(results)
-					.hasNumberOfDynamicallyRegisteredTests(9)
-					.hasNumberOfFailedTests(9)
-					.andThenCheckExceptions(exceptions -> assertThat(exceptions)
-							.extracting(Throwable::getCause)
-							.hasOnlyElementsOfType(ExtensionConfigurationException.class)
-							.extracting(Throwable::getMessage)
-							.containsOnly("CartesianTest was supplied arguments but parameter is not supported."));
-		}
-
-		@Test
 		@DisplayName("parameter annotation arguments provider implements CartesianMethodArgumentsProvider")
 		void mismatchingInterfaceParam() {
 			ExecutionResults results = PioneerTestKit
@@ -1033,7 +1032,8 @@ public class CartesianTestExtensionTests {
 
 		@CartesianTest
 		@CartesianTest.MethodFactory("poem")
-		void competingInject(String line, TestReporter reporter) {
+		void ignoredParam(String line, TestReporter reporter) {
+			reporter.publishEntry(line);
 		}
 
 		static ArgumentSets poem() {


### PR DESCRIPTION
Proposed commit message:

```
Fix CartesianTest supportsParameter check (#633 / #???)

CartesianTest throws an exception if it encounters a parameter it
does not support. This commit fixes that, now it just returns false.

Closes: #633
PR: #???
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [ ] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 
