### PR TITLE
Update Checkstyle and JaCoCo to fix build

### DIFF
--- a/.infra/checkstyle/checkstyle.xml
+++ b/.infra/checkstyle/checkstyle.xml
@@ -9,7 +9,6 @@
 	<module name="TreeWalker">
 		<module name="SuppressWarningsHolder" />
 		<module name="JavadocMethod">
-			<property name="allowMissingJavadoc" value="true" />
 			<property name="allowMissingParamTags" value="true" />
 			<property name="allowMissingReturnTag" value="true" />
 			<property name="validateThrows" value="true" />

--- a/.infra/checkstyle/checkstyle.xml
+++ b/.infra/checkstyle/checkstyle.xml
@@ -11,7 +11,6 @@
 		<module name="JavadocMethod">
 			<property name="allowMissingParamTags" value="true" />
 			<property name="allowMissingReturnTag" value="true" />
-			<property name="validateThrows" value="true" />
 		</module>
 		<module name="AtclauseOrder">
 			<property name="tagOrder" value="@param, @return, @throws, @exception, @since, @author, @see" />

--- a/.infra/checkstyle/checkstyle.xml
+++ b/.infra/checkstyle/checkstyle.xml
@@ -3,7 +3,7 @@
 
 <module name="Checker">
 	<module name="SuppressionFilter">
-		<property name="file" value="${config_loc}/suppressions.xml"/>
+		<property name="file" value="${config_loc}/suppressions.xml" />
 	</module>
 	<property name="severity" value="error" />
 	<module name="TreeWalker">
@@ -25,12 +25,12 @@
 		</module>
 		<module name="AvoidStarImport" />
 		<module name="ImportControl">
-			<property name="file" value="${config_loc}/import-control.xml"/>
+			<property name="file" value="${config_loc}/import-control.xml" />
 		</module>
 	</module>
 	<module name="JavadocPackage" />
 	<module name="SuppressWarningsFilter" />
 	<module name="BeforeExecutionExclusionFileFilter">
-		<property name="fileNamePattern" value="module\-info\.java$"/>
+		<property name="fileNamePattern" value="module\-info\.java$" />
 	</module>
 </module>

--- a/.infra/checkstyle/checkstyle.xml
+++ b/.infra/checkstyle/checkstyle.xml
@@ -12,8 +12,6 @@
 			<property name="allowMissingJavadoc" value="true" />
 			<property name="allowMissingParamTags" value="true" />
 			<property name="allowMissingReturnTag" value="true" />
-			<property name="allowMissingThrowsTags" value="true" />
-			<property name="allowUndeclaredRTE" value="true" />
 			<property name="validateThrows" value="true" />
 		</module>
 		<module name="AtclauseOrder">

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -100,7 +100,7 @@ yamlValidator {
 }
 
 jacoco {
-	toolVersion = "0.8.7"
+	toolVersion = "0.8.8"
 }
 
 sonarqube {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -90,7 +90,7 @@ spotless {
 }
 
 checkstyle {
-	toolVersion = "7.8.2"
+	toolVersion = "10.2"
 	configDirectory.set(rootProject.file(".infra/checkstyle"))
 }
 


### PR DESCRIPTION
Please pay attention to the commit messages, which include links to the corresponding Checkstyle release notes / PRs.

Regarding the message of the last commit, which removes `validateThrows`:

>Remove `validateThrows`
>
>Since the property `allowMissingThrowsTags` has been removed,
>`validateThrows` now means you can no longer omit `@throws` in Javadoc.
>Whenever a method declares `throws`, it must be documented.
>
>Furthermore, Checkstyle authors say:
>
>>If you need to validate `@throws` please enable property
>>`validateThrows` but please read documentation as there some
>>limitations -
>>https://checkstyle.org/config_javadoc.html#JavadocMethod .
>>Old documentation is at
>>https://checkstyle.sourceforge.io/version/8.27/config_javadoc.html#JavadocMethod

Keeping `validateThrows` would cause the following 8 violations:

**File /.../junit-pioneer/src/main/java/org/junitpioneer/internal/PioneerPreconditions.java**

Error Description | Line
-- | --
Erwartetes Tag `@throws` für 'PreconditionViolationException'. | 36
Erwartetes Tag `@throws` für 'PreconditionViolationException'. | 50
Erwartetes Tag `@throws` für 'PreconditionViolationException'. | 64
Erwartetes Tag `@throws` für 'PreconditionViolationException'. | 77
Erwartetes Tag `@throws` für 'PreconditionViolationException'. | 90
Erwartetes Tag `@throws` für 'PreconditionViolationException'. | 103

**File 
/.../junit-pioneer/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianMethodArgumentsProvider.java**

Error Description | Line
-- | --
Erwartetes Tag `@throws` für 'Exception'. | 30

**File 
/.../junit-pioneer/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianParameterArgumentsProvider.java**

Error Description | Line
-- | --
Erwartetes Tag `@throws` für 'Exception'. | 33

---

If we want to keep `validateThrows` – which would be a trade-off as we are no longer able to omit `@throws` (`allowMissingThrowsTags` has been removed) – I'm happy to create a separate issue. But I would suggest to first get this PR merged, so that `main` is stable again.

Side note: I have added the `merge-ready` label by myself to see if experimentals are passing.

Proposed commit message:

```
Update Checkstyle from 7.8.2 to 10.2 (#637)

This PR updates Checkstyle to the most recent version and removes
deleted/replaced/changed properties. In addition, JaCoCo is updated.

Both updates support Java 18, which fixes the currently failing build.

# Deleted

`allowMissingThrowsTags` and `allowUndeclaredRTE`:

>properties `allowMissingThrowsTags`, `allowUndeclaredRTE` [...] should
>be just removed from configs.
>Behavior will change as there will be less violations in code, such
>properties did not work well so their removal should be ok, as there
>will be less false-positives.

See:

* https://checkstyle.sourceforge.io/releasenotes.html#Release_8.21
* https://github.com/checkstyle/checkstyle/issues/6703

# Replaced

`allowMissingJavadoc`:

Replaced by
[`MissingJavadocMethod`](https://checkstyle.org/config_javadoc.html#MissingJavadocMethod).
That is, missing Javadoc is now allowed by default.

See:

* https://checkstyle.sourceforge.io/releasenotes.html#Release_8.28
* https://github.com/checkstyle/checkstyle/issues/7329

# Changed

`allowMissingThrowsTags`:

`validateThrows` now means we can no longer omit `@throws` in Javadoc.
Whenever a method declares `throws`, it must be documented.

Furthermore, Checkstyle authors say:

>If you need to validate `@throws` please enable property
>`validateThrows` but please read documentation as there some
>limitations -
>https://checkstyle.org/config_javadoc.html#JavadocMethod .
>Old documentation is at
>https://checkstyle.sourceforge.io/version/8.27/config_javadoc.html#JavadocMethod

See:

* https://checkstyle.sourceforge.io/releasenotes.html#Release_8.21
* https://github.com/checkstyle/checkstyle/issues/6703

---

PR: #637
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 
