### PR TITLE
Add configuration option to entry-based extensions

### DIFF
--- a/src/main/java/org/junitpioneer/jupiter/ApplyMode.java
+++ b/src/main/java/org/junitpioneer/jupiter/ApplyMode.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2016-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junitpioneer.jupiter;
+
+public enum ApplyMode {
+	TEST, CLASS
+}

--- a/src/main/java/org/junitpioneer/jupiter/ClearEnvironmentVariable.java
+++ b/src/main/java/org/junitpioneer/jupiter/ClearEnvironmentVariable.java
@@ -65,6 +65,11 @@ public @interface ClearEnvironmentVariable {
 	String key();
 
 	/**
+	 * Optional configuration option when to apply the extension.
+	 */
+	ApplyMode mode() default ApplyMode.TEST;
+
+	/**
 	 * Containing annotation of repeatable {@code @ClearEnvironmentVariable}.
 	 */
 	@Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/org/junitpioneer/jupiter/ClearSystemProperty.java
+++ b/src/main/java/org/junitpioneer/jupiter/ClearSystemProperty.java
@@ -57,6 +57,11 @@ public @interface ClearSystemProperty {
 	String key();
 
 	/**
+	 * Optional configuration option when to apply the extension.
+	 */
+	ApplyMode mode() default ApplyMode.TEST;
+
+	/**
 	 * Containing annotation of repeatable {@code @ClearSystemProperty}.
 	 */
 	@Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
@@ -12,6 +12,7 @@ package org.junitpioneer.jupiter;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -22,6 +23,16 @@ class EnvironmentVariableExtension
 	static final AtomicBoolean REPORTED_WARNING = new AtomicBoolean(false);
 	static final String WARNING_KEY = EnvironmentVariableExtension.class.getSimpleName();
 	static final String WARNING_VALUE = "This extension uses reflection to mutate JDK-internal state, which is fragile. Check the Javadoc or documentation for more details.";
+
+	@Override
+	protected Predicate<ClearEnvironmentVariable> filterClearAnnotationsByMode(ApplyMode mode) {
+		return annotation -> annotation.mode().equals(mode);
+	}
+
+	@Override
+	protected Predicate<SetEnvironmentVariable> filterSetAnnotationsByMode(ApplyMode mode) {
+		return annotation -> annotation.mode().equals(mode);
+	}
 
 	@Override
 	protected Function<ClearEnvironmentVariable, String> clearKeyMapper() {

--- a/src/main/java/org/junitpioneer/jupiter/SetEnvironmentVariable.java
+++ b/src/main/java/org/junitpioneer/jupiter/SetEnvironmentVariable.java
@@ -72,6 +72,11 @@ public @interface SetEnvironmentVariable {
 	String value();
 
 	/**
+	 * Optional configuration option when to apply the extension.
+	 */
+	ApplyMode mode() default ApplyMode.TEST;
+
+	/**
 	 * Containing annotation of repeatable {@code @SetEnvironmentVariable}.
 	 */
 	@Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/org/junitpioneer/jupiter/SetSystemProperty.java
+++ b/src/main/java/org/junitpioneer/jupiter/SetSystemProperty.java
@@ -64,6 +64,11 @@ public @interface SetSystemProperty {
 	String value();
 
 	/**
+	 * Optional configuration option when to apply the extension.
+	 */
+	ApplyMode mode() default ApplyMode.TEST;
+
+	/**
 	 * Containing annotation of repeatable {@code @SetSystemProperty}.
 	 */
 	@Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/org/junitpioneer/jupiter/SystemPropertyExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/SystemPropertyExtension.java
@@ -11,9 +11,20 @@
 package org.junitpioneer.jupiter;
 
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 class SystemPropertyExtension
 		extends AbstractEntryBasedExtension<String, String, ClearSystemProperty, SetSystemProperty> {
+
+	@Override
+	protected Predicate<ClearSystemProperty> filterClearAnnotationsByMode(ApplyMode mode) {
+		return annotation -> annotation.mode().equals(mode);
+	}
+
+	@Override
+	protected Predicate<SetSystemProperty> filterSetAnnotationsByMode(ApplyMode mode) {
+		return annotation -> annotation.mode().equals(mode);
+	}
 
 	@Override
 	protected Function<ClearSystemProperty, String> clearKeyMapper() {

--- a/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
@@ -247,7 +247,13 @@ class EnvironmentVariableExtensionTests {
 		@Nested
 		@SetEnvironmentVariable(key = "set envvar A", value = "newer A")
 		@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-		class ResettingEnvironmentVariableNestedTests {
+		class ResettingEnvironmentVariableAfterEachNestedTests {
+
+			@BeforeAll
+			@ReadsEnvironmentVariable
+			void changeShouldNotBeVisible() {
+				assertThat(System.getenv("set envvar A")).isEqualTo("old A");
+			}
 
 			@Test
 			@SetEnvironmentVariable(key = "set envvar A", value = "newest A")
@@ -259,6 +265,31 @@ class EnvironmentVariableExtensionTests {
 			@ReadsEnvironmentVariable
 			void resetAfterTestMethodExecution() {
 				assertThat(System.getenv("set envvar A")).isEqualTo("old A");
+			}
+
+		}
+
+		@Nested
+		@SetEnvironmentVariable(key = "set envvar A", value = "newer A", mode = ApplyMode.CLASS)
+		@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+		class ResettingEnvironmentVariableAfterAllNestedTests {
+
+			@BeforeAll
+			@ReadsEnvironmentVariable
+			void changeShouldBeVisible() {
+				assertThat(System.getenv("set envvar A")).isEqualTo("newer A");
+			}
+
+			@Test
+			@SetEnvironmentVariable(key = "set envvar A", value = "newest A")
+			void setForTestMethod() {
+				assertThat(System.getenv("set envvar A")).isEqualTo("newest A");
+			}
+
+			@AfterAll
+			@ReadsEnvironmentVariable
+			void resetAfterTestMethodExecution() {
+				assertThat(System.getenv("set envvar A")).isEqualTo("newer A");
 			}
 
 		}

--- a/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
@@ -236,7 +236,12 @@ class SystemPropertyExtensionTests {
 		@Nested
 		@SetSystemProperty(key = "A", value = "newer A")
 		@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-		class ResettingSystemPropertyNestedTests {
+		class ResettingSystemPropertyAfterEachNestedTests {
+
+			@BeforeAll
+			void changeShouldNotBeVisible() {
+				assertThat(System.getProperty("A")).isEqualTo("old A");
+			}
 
 			@Test
 			@SetSystemProperty(key = "A", value = "newest A")
@@ -248,6 +253,30 @@ class SystemPropertyExtensionTests {
 			@ReadsSystemProperty
 			void resetAfterTestMethodExecution() {
 				assertThat(System.getProperty("A")).isEqualTo("old A");
+			}
+
+		}
+
+		@Nested
+		@SetSystemProperty(key = "A", value = "newer A", mode = ApplyMode.CLASS)
+		@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+		class ResettingSystemPropertyAfterAllNestedTests {
+
+			@BeforeAll
+			void changeShouldBeVisible() {
+				assertThat(System.getProperty("A")).isEqualTo("newer A");
+			}
+
+			@Test
+			@SetSystemProperty(key = "A", value = "newest A")
+			void setForTestMethod() {
+				assertThat(System.getProperty("A")).isEqualTo("newest A");
+			}
+
+			@AfterAll
+			@ReadsSystemProperty
+			void resetAfterTestMethodExecution() {
+				assertThat(System.getProperty("A")).isEqualTo("newer A");
 			}
 
 		}


### PR DESCRIPTION
Related to #623 so we can move forward with it.

@JoergSiebahn could you share your opinion about this approach? Would this work for you?

Proposed commit message:

```
${action} (${issues} / ${pull-request}) [max 70 characters]

${body} [max 70 characters per line]

${references}: ${issues}
PR: ${pull-request}
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [ ] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 
