### PR TITLE
Explain lack of reproducibility for @DisabledUntil

### DIFF
--- a/docs/disabled-until.adoc
+++ b/docs/disabled-until.adoc
@@ -13,6 +13,9 @@ The only problem with this approach is remembering to activate the test again on
 The `@DisabledUntil` annotation may be used to disable a test only for a certain period of time.
 The test will be automatically executed again once the date supplied by the `date` parameter is reached.
 
+WARNING: Applying `@DisabledUntil` can make the test suite non-reproducible.
+If a failing test is disabled during a build that then passes, rerunning that build after the "until" date would fail.
+
 == Usage
 
 To mark a test to be temporarily disabled add the `@DisabledUntil` annotation like so:

--- a/docs/disabled-until.adoc
+++ b/docs/disabled-until.adoc
@@ -15,6 +15,7 @@ The test will be automatically executed again once the date supplied by the `dat
 
 WARNING: Applying `@DisabledUntil` can make the test suite non-reproducible.
 If a failing test is disabled during a build that then passes, rerunning that build after the "until" date would fail.
+A report entry is issued for every test that is disabled until a certain date.
 
 == Usage
 

--- a/src/main/java/org/junitpioneer/jupiter/DisabledUntil.java
+++ b/src/main/java/org/junitpioneer/jupiter/DisabledUntil.java
@@ -28,6 +28,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * <p>{@code @DisabledUntil} can be used on the method and class level. It can only be used once per method or class,
  * but is inherited from higher-level containers.</p>
  *
+ * <p><strong>WARNING:</strong> Applying {@code @DisabledUntil} can make the test suite non-reproducible. If a failing
+ * test is disabled during a build that then passes, rerunning that build after the "until" date would fail. A report
+ * entry is issued for every test that is disabled until a certain date.</p>
+ *
  * @since 1.6.0
  * @see org.junit.jupiter.api.Disabled
  */

--- a/src/main/java/org/junitpioneer/jupiter/DisabledUntilExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/DisabledUntilExtension.java
@@ -62,6 +62,8 @@ class DisabledUntilExtension implements ExecutionCondition {
 		boolean disabled = today.isBefore(untilDate);
 
 		if (disabled) {
+			String reportEntry = format("This test is disabled until %s. If executing it on this commit would fail, the build can't be reproduced after that date.", untilDate.format(ISO_8601));
+			context.publishReportEntry("DisabledUntil", reportEntry);
 			String message = format("The `date` %s is after the current date %s", untilDate.format(ISO_8601),
 				today.format(ISO_8601));
 			return disabled(message);

--- a/src/main/java/org/junitpioneer/jupiter/DisabledUntilExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/DisabledUntilExtension.java
@@ -62,7 +62,9 @@ class DisabledUntilExtension implements ExecutionCondition {
 		boolean disabled = today.isBefore(untilDate);
 
 		if (disabled) {
-			String reportEntry = format("This test is disabled until %s. If executing it on this commit would fail, the build can't be reproduced after that date.", untilDate.format(ISO_8601));
+			String reportEntry = format(
+				"This test is disabled until %s. If executing it on this commit would fail, the build can't be reproduced after that date.",
+				untilDate.format(ISO_8601));
 			context.publishReportEntry("DisabledUntil", reportEntry);
 			String message = format("The `date` %s is after the current date %s", untilDate.format(ISO_8601),
 				today.format(ISO_8601));

--- a/src/test/java/org/junitpioneer/jupiter/DisabledUntilExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DisabledUntilExtensionTests.java
@@ -67,7 +67,10 @@ class DisabledUntilExtensionTests {
 				.executeTestMethod(DisabledUntilTestCases.class, "testIsAnnotatedWithDateInTheFuture");
 		assertThat(results).hasNumberOfStartedTests(0);
 		assertThat(results).hasSingleSkippedTest();
-		assertThat(results).hasNoReportEntries();
+		assertThat(results)
+				.hasSingleReportEntry()
+				.firstValue()
+				.contains("2199-01-01", "reproduce");
 	}
 
 	@Test
@@ -78,7 +81,10 @@ class DisabledUntilExtensionTests {
 		assertThat(results).hasSingleSkippedContainer(); // NestedDummyTestClass is skipped as container
 		assertThat(results).hasNumberOfStartedTests(0);
 		assertThat(results).hasNumberOfSkippedTests(0);
-		assertThat(results).hasNoReportEntries();
+		assertThat(results)
+				.hasSingleReportEntry()
+				.firstValue()
+				.contains("2199-01-01", "reproduce");
 	}
 
 	static class DisabledUntilTestCases {

--- a/src/test/java/org/junitpioneer/jupiter/DisabledUntilExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DisabledUntilExtensionTests.java
@@ -67,10 +67,7 @@ class DisabledUntilExtensionTests {
 				.executeTestMethod(DisabledUntilTestCases.class, "testIsAnnotatedWithDateInTheFuture");
 		assertThat(results).hasNumberOfStartedTests(0);
 		assertThat(results).hasSingleSkippedTest();
-		assertThat(results)
-				.hasSingleReportEntry()
-				.firstValue()
-				.contains("2199-01-01", "reproduce");
+		assertThat(results).hasSingleReportEntry().firstValue().contains("2199-01-01", "reproduce");
 	}
 
 	@Test
@@ -81,10 +78,7 @@ class DisabledUntilExtensionTests {
 		assertThat(results).hasSingleSkippedContainer(); // NestedDummyTestClass is skipped as container
 		assertThat(results).hasNumberOfStartedTests(0);
 		assertThat(results).hasNumberOfSkippedTests(0);
-		assertThat(results)
-				.hasSingleReportEntry()
-				.firstValue()
-				.contains("2199-01-01", "reproduce");
+		assertThat(results).hasSingleReportEntry().firstValue().contains("2199-01-01", "reproduce");
 	}
 
 	static class DisabledUntilTestCases {


### PR DESCRIPTION
---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [x] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [x] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [x] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [x] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [x] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [x] The `package-info.java` contains information about the new extension

Code
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [x] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [ ] A prepared commit message exists
* [x] The list of contributions inside `README.md` mentions the new contribution (real name optional) 
