### PR TITLE
Document use of transitive dependencies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -483,6 +483,12 @@ Follow these steps when updating JUnit 5:
 	* ... should be structured and worded as defined above
 	* ... should reference the upstream issue and pull request (if any)
 
+JUnit Jupiter has few external dependencies, but occasionally uses them in its own API and thus has the `requires transitive` directive in [its module declaration](https://github.com/junit-team/junit5/blob/main/junit-jupiter-api/src/module/org.junit.jupiter.api/module-info.java) (for example, `requires transitive org.opentest4j_`).
+That means, while JUnit Pioneer _could_ list these dependencies in its build configuration and require these modules in its module declaration, it doesn't _have to_.
+It is generally recommended not to rely on transitive dependencies when they're used directly and instead manage them yourself, but this does not apply very well to Pioneer and Jupiter:
+We can't choose a different dependency version than Jupiter and if Jupiter stops using one of these dependencies, there is no point for us to keep using it as we only need them to integrate with Jupiter.
+We hence stick to only depending on / requiring the specific Jupiter artifacts / modules we need but not their dependencies.
+
 ### Others
 
 JUnit Pioneer handles dependencies beyond JUnit 5 differently depending on how they impact its users.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -470,6 +470,26 @@ JUnit Pioneer has an uncharacteristically strong relationship to the JUnit 5 pro
 It not only depends on it, it also uses its internal APIs, copies source code that is not released in any artifact, mimics code style, unit testing, build and CI setup, and more.
 As such it will frequently have to adapt to upstream changes, so it makes sense to provision for that in the development strategy.
 
+#### Declaring Dependencies
+
+JUnit Jupiter has few external dependencies, but occasionally uses them in its own API and thus has the `requires transitive` directive in [its module declaration](https://github.com/junit-team/junit5/blob/main/junit-jupiter-api/src/module/org.junit.jupiter.api/module-info.java) (for example, `requires transitive org.opentest4j_`).
+That means, while JUnit Pioneer _could_ list these dependencies in its build configuration and require these modules in its module declaration, it doesn't _have to_.
+
+It is generally recommended not to rely on transitive dependencies when they're used directly and instead manage them yourself, but this does not apply very well to Pioneer and Jupiter:
+
+* If Jupiter stops using one of these dependencies, there is no point for us to keep using it as we only need them to integrate with Jupiter.
+* If Jupiter refactors these module relationships (e.g. by removing the OpenTest4J module from its dependencies and pulling its code into a Jupiter module), we might not be compatible with that new version (e.g. because we still require the removed module, which now results in a split package)
+* We can't choose a different dependency version than Jupiter
+
+We hence only depend on "core Jupiter" explicitly.
+That is:
+
+* core API: _org.junit.jupiter.api_
+* additional APIs as needed, e.g. _org.junit.jupiter.params_
+* additional functionality as needed, e.g. _org.junit.platform.launcher_
+
+#### Updating JUnit 5
+
 As [documented](README.md#dependencies) Pioneer aims to use the lowest JUnit 5 version that supports Pioneer's feature set.
 At the same time, there is no general reason to hesitate with updating the dependency if a new feature requires a newer version or the old version has a severe bug.
 Follow these steps when updating JUnit 5:
@@ -482,12 +502,6 @@ Follow these steps when updating JUnit 5:
 * the commit message...
 	* ... should be structured and worded as defined above
 	* ... should reference the upstream issue and pull request (if any)
-
-JUnit Jupiter has few external dependencies, but occasionally uses them in its own API and thus has the `requires transitive` directive in [its module declaration](https://github.com/junit-team/junit5/blob/main/junit-jupiter-api/src/module/org.junit.jupiter.api/module-info.java) (for example, `requires transitive org.opentest4j_`).
-That means, while JUnit Pioneer _could_ list these dependencies in its build configuration and require these modules in its module declaration, it doesn't _have to_.
-It is generally recommended not to rely on transitive dependencies when they're used directly and instead manage them yourself, but this does not apply very well to Pioneer and Jupiter:
-We can't choose a different dependency version than Jupiter and if Jupiter stops using one of these dependencies, there is no point for us to keep using it as we only need them to integrate with Jupiter.
-We hence stick to only depending on / requiring the specific Jupiter artifacts / modules we need but not their dependencies.
 
 ### Others
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,7 +60,6 @@ dependencies {
 
 	implementation(group = "org.junit.jupiter", name = "junit-jupiter-api")
 	implementation(group = "org.junit.jupiter", name = "junit-jupiter-params")
-	implementation(group = "org.junit.platform", name = "junit-platform-commons")
 	implementation(group = "org.junit.platform", name = "junit-platform-launcher")
 	"jacksonImplementation"(group = "com.fasterxml.jackson.core", name = "jackson-databind", version = jacksonVersion)
 

--- a/src/main/module/module-info.java
+++ b/src/main/module/module-info.java
@@ -13,7 +13,6 @@ module org.junitpioneer {
 	// see Javadoc for why these aren't transitive
 	requires org.junit.jupiter.api;
 	requires org.junit.jupiter.params;
-	requires org.junit.platform.commons;
 	requires org.junit.platform.launcher;
 
 	requires static com.fasterxml.jackson.core;


### PR DESCRIPTION
---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [x] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [x] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [x] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [x] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [x] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [x] The `package-info.java` contains information about the new extension

Code
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [x] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [ ] A prepared commit message exists
* [x] The list of contributions inside `README.md` mentions the new contribution (real name optional) 
