### PR TITLE
Add StdErr to StdIoExtension

### DIFF
--- a/docs/standard-input-output.adoc
+++ b/docs/standard-input-output.adoc
@@ -61,7 +61,7 @@ A combination of the two previous cases - `System.in` and `System.out` get repla
 include::{demo}[tag=stdio_both_replaced_and_verify]
 ----
 
-NOTE:: Omitted from these examples is `StdErr` which behaves exactly the same way as `StdOut` and works in combination with it.
+NOTE: Omitted from these examples is `StdErr` which behaves exactly the same way as `StdOut` and works in combination with it.
 
 The remaining combinations of the annotation, its values, and `StdIn`/`StdOut`/`StdErr` are considered misconfigurations and lead to exceptions.
 

--- a/docs/standard-input-output.adoc
+++ b/docs/standard-input-output.adoc
@@ -13,7 +13,7 @@ This becomes particularly important when running tests in parallel, where other 
 The extension consists of two parts:
 
 * The annotation `@StdIo`. It allows defining input that is read from `System.in` without having to wait for user input.
-* Parameters `StdIn`, `StdOut` and `StdErr`, which you can have injected into your test.
+* Parameters `StdIn`, `StdOut`, and `StdErr`, which you can have injected into your test.
   Their `capturedLines()` methods allow you to access lines read from `System.in` or written to `System.out` or `System.err`, so you can verify them with common assertions.
 
 For example, after calling `System.out.println("Hello")` and `System.out.println("World")`,  the `StdOut::capturedLines` method would return an array ["Hello", "World"].
@@ -61,9 +61,9 @@ A combination of the two previous cases - `System.in` and `System.out` get repla
 include::{demo}[tag=stdio_both_replaced_and_verify]
 ----
 
-Omitted from these examples is `StdErr` which behaves exactly the same way as `StdOut` and works in combination with it.
+NOTE:: Omitted from these examples is `StdErr` which behaves exactly the same way as `StdOut` and works in combination with it.
 
-The remaining combinations of the annotation, its values, and `StdIn`/`StdOut` are considered misconfigurations and lead to exceptions.
+The remaining combinations of the annotation, its values, and `StdIn`/`StdOut`/`StdErr` are considered misconfigurations and lead to exceptions.
 
 == Thread-Safety
 

--- a/docs/standard-input-output.adoc
+++ b/docs/standard-input-output.adoc
@@ -3,9 +3,9 @@
 :xp-demo-dir: ../src/demo/java
 :demo: {xp-demo-dir}/org/junitpioneer/jupiter/StdInOutExtensionDemo.java
 
-The standard IO extension adds a simple way to test classes that read from the standard input (`System.in`) or write to the standard output (`System.out`).
+The standard IO extension adds a simple way to test classes that read from the standard input (`System.in`) or write to the standard output (`System.out` or `System.err`).
 
-WARNING: Depending on the configuration, the extension redirects the standard input and/or output, in which case nothing gets forwarded to the original `System.in` and/or `System.out`.
+WARNING: Depending on the configuration, the extension redirects the standard input and/or output, in which case nothing gets forwarded to the original `System.in` and/or `System.out` / `System.err`.
 This becomes particularly important when running tests in parallel, where other tests may interfere with tests annotated with `@StdIo`.
 
 == Basic use
@@ -13,8 +13,8 @@ This becomes particularly important when running tests in parallel, where other 
 The extension consists of two parts:
 
 * The annotation `@StdIo`. It allows defining input that is read from `System.in` without having to wait for user input.
-* Parameters `StdIn` and `StdOut`, which you can have injected into your test.
-  Their `capturedLines()` methods allow you to access lines read from `System.in` or written to `System.out`, so you can verify them with common assertions.
+* Parameters `StdIn`, `StdOut` and `StdErr`, which you can have injected into your test.
+  Their `capturedLines()` methods allow you to access lines read from `System.in` or written to `System.out` or `System.err`, so you can verify them with common assertions.
 
 For example, after calling `System.out.println("Hello")` and `System.out.println("World")`,  the `StdOut::capturedLines` method would return an array ["Hello", "World"].
 With `System.out.print("Hello")` and `System.out.println("World")` (note that the first method does not print a line break), it would return `["HelloWorld"]`.
@@ -60,6 +60,8 @@ A combination of the two previous cases - `System.in` and `System.out` get repla
 ----
 include::{demo}[tag=stdio_both_replaced_and_verify]
 ----
+
+Omitted from these examples is `StdErr` which behaves exactly the same way as `StdOut` and works in combination with it.
 
 The remaining combinations of the annotation, its values, and `StdIn`/`StdOut` are considered misconfigurations and lead to exceptions.
 

--- a/src/demo/java/org/junitpioneer/jupiter/StdInOutExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/StdInOutExtensionDemo.java
@@ -70,7 +70,7 @@ public class StdInOutExtensionDemo {
 	// end::stdio_both_replaced_and_verify[]
 
 	// tag::stdio_edge_cases_ExampleConsoleReader[]
-	class ExampleConsoleReader {
+	class ConsoleReader {
 
 		private List<String> lines = new ArrayList<>();
 
@@ -91,7 +91,7 @@ public class StdInOutExtensionDemo {
 
 		@Test
 		@StdIo({ "line1", "line2", "line3" })
-		void testReadLines(StdIn in) {
+		void testReadLines(StdIn in) throws IOException {
 			ConsoleReader consoleReader = new ConsoleReader();
 
 			consoleReader.readLines();
@@ -107,13 +107,5 @@ public class StdInOutExtensionDemo {
 
 	}
 	// end::stdio_edge_cases_ConsoleReaderTest[]
-
-	class ConsoleReader {
-
-		public void readLines() {
-			// demo stuff
-		}
-
-	}
 
 }

--- a/src/main/java/org/junitpioneer/jupiter/ReadsStdIo.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReadsStdIo.java
@@ -41,5 +41,6 @@ import org.junit.jupiter.api.parallel.Resources;
 @Inherited
 @ResourceLock(value = "java.lang.System.in", mode = ResourceAccessMode.READ)
 @ResourceLock(value = Resources.SYSTEM_OUT, mode = ResourceAccessMode.READ)
+@ResourceLock(value = Resources.SYSTEM_ERR, mode = ResourceAccessMode.READ)
 public @interface ReadsStdIo {
 }

--- a/src/main/java/org/junitpioneer/jupiter/ReadsStdIo.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReadsStdIo.java
@@ -21,8 +21,8 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.api.parallel.Resources;
 
 /**
- * Marks tests that read the static fields {@code System.in} or {@code System.out}
- * but don't call {@code System.setIn()} or {@code System.setOut()}.
+ * Marks tests that read the static fields {@code System.in}, {@code System.out} or {@code System.err}
+ * but don't call {@code System.setIn()}, {@code System.setOut()} or {@code System.setErr()}.
  *
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,

--- a/src/main/java/org/junitpioneer/jupiter/StdErr.java
+++ b/src/main/java/org/junitpioneer/jupiter/StdErr.java
@@ -17,5 +17,5 @@ package org.junitpioneer.jupiter;
  *
  * @see StdIo
  */
-public class StdErr extends StdIoStream {
+public class StdErr extends StdOutputStream {
 }

--- a/src/main/java/org/junitpioneer/jupiter/StdErr.java
+++ b/src/main/java/org/junitpioneer/jupiter/StdErr.java
@@ -10,12 +10,5 @@
 
 package org.junitpioneer.jupiter;
 
-/**
- * <p>For details and examples, see
- * <a href="https://junit-pioneer.org/docs/standard-input-output/" target="_top">the documentation on <code>Standard input/output</code></a>
- * </p>
- *
- * @see StdIo
- */
-public class StdOut extends StdIoStream {
+public class StdErr extends StdIoStream {
 }

--- a/src/main/java/org/junitpioneer/jupiter/StdErr.java
+++ b/src/main/java/org/junitpioneer/jupiter/StdErr.java
@@ -10,5 +10,12 @@
 
 package org.junitpioneer.jupiter;
 
+/**
+ * <p>For details and examples, see
+ * <a href="https://junit-pioneer.org/docs/standard-input-output/" target="_top">the documentation on <code>Standard input/output</code></a>
+ * </p>
+ *
+ * @see StdIo
+ */
 public class StdErr extends StdIoStream {
 }

--- a/src/main/java/org/junitpioneer/jupiter/StdIoStream.java
+++ b/src/main/java/org/junitpioneer/jupiter/StdIoStream.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junitpioneer.jupiter;
+
+import java.io.OutputStream;
+import java.io.StringWriter;
+import java.nio.charset.Charset;
+
+abstract class StdIoStream extends OutputStream {
+
+	private final StringWriter writer = new StringWriter();
+
+	public StdIoStream() {
+		// recreate default constructor to prevent compiler warning
+	}
+
+	@Override
+	public void write(int i) {
+		writer.write(i);
+	}
+
+	@Override
+	public final void write(byte[] b, int off, int len) {
+		writer.write(new String(b, Charset.defaultCharset()), off, len);
+	}
+
+	/**
+	 * @return the lines that were written to {@code System.out}
+	 */
+	public String[] capturedLines() {
+		return writer.toString().split(StdIoExtension.SEPARATOR);
+	}
+
+}

--- a/src/main/java/org/junitpioneer/jupiter/StdIoStream.java
+++ b/src/main/java/org/junitpioneer/jupiter/StdIoStream.java
@@ -33,7 +33,7 @@ abstract class StdIoStream extends OutputStream {
 	}
 
 	/**
-	 * @return the lines that were written to {@code System.out}
+	 * @return the lines that were written to {@code System.out} or {@code System.err}
 	 */
 	public String[] capturedLines() {
 		return writer.toString().split(StdIoExtension.SEPARATOR);

--- a/src/main/java/org/junitpioneer/jupiter/StdOut.java
+++ b/src/main/java/org/junitpioneer/jupiter/StdOut.java
@@ -17,5 +17,5 @@ package org.junitpioneer.jupiter;
  *
  * @see StdIo
  */
-public class StdOut extends StdIoStream {
+public class StdOut extends StdOutputStream {
 }

--- a/src/main/java/org/junitpioneer/jupiter/StdOutputStream.java
+++ b/src/main/java/org/junitpioneer/jupiter/StdOutputStream.java
@@ -14,11 +14,11 @@ import java.io.OutputStream;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
 
-abstract class StdIoStream extends OutputStream {
+abstract class StdOutputStream extends OutputStream {
 
 	private final StringWriter writer = new StringWriter();
 
-	public StdIoStream() {
+	public StdOutputStream() {
 		// recreate default constructor to prevent compiler warning
 	}
 

--- a/src/main/java/org/junitpioneer/jupiter/WritesStdIo.java
+++ b/src/main/java/org/junitpioneer/jupiter/WritesStdIo.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.api.parallel.Resources;
 
 /**
- * Marks tests that call {@code System.setIn()} or {@code System.setOut()} to set the static fields {@code System.in}/{@code System.out}.
+ * Marks tests that call {@code System.setIn()}, {@code System.setOut()} or {@code System.setErr()} to
+ * set the static fields {@code System.in}/{@code System.out}/{@code System.err}.
  *
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,

--- a/src/main/java/org/junitpioneer/jupiter/WritesStdIo.java
+++ b/src/main/java/org/junitpioneer/jupiter/WritesStdIo.java
@@ -40,5 +40,6 @@ import org.junit.jupiter.api.parallel.Resources;
 @Inherited
 @ResourceLock(value = "java.lang.System.in", mode = ResourceAccessMode.READ_WRITE)
 @ResourceLock(value = Resources.SYSTEM_OUT, mode = ResourceAccessMode.READ_WRITE)
+@ResourceLock(value = Resources.SYSTEM_ERR, mode = ResourceAccessMode.READ_WRITE)
 public @interface WritesStdIo {
 }

--- a/src/test/java/org/junitpioneer/jupiter/StdIoExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/StdIoExtensionTests.java
@@ -134,7 +134,7 @@ public class StdIoExtensionTests {
 		@Test
 		@ReadsStdIo
 		@Order(1)
-		@DisplayName("1: System.in, System.err and System.out is untouched")
+		@DisplayName("1: System.in, System.out and System.err is untouched")
 		void untouched() {
 			assertThat(System.in).isEqualTo(STDIN);
 			assertThat(System.out).isEqualTo(STDOUT);
@@ -144,7 +144,7 @@ public class StdIoExtensionTests {
 		@Test
 		@StdIo({ "From his low tract, and look another way:", "So thou, thyself outgoing in thy noon" })
 		@Order(2)
-		@DisplayName("2: System.in, System.err and System.out is redirected")
+		@DisplayName("2: System.in, System.out and System.err is redirected")
 		void redirected(StdIn in, StdOut out, StdErr err) throws IOException {
 			BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
 
@@ -168,7 +168,7 @@ public class StdIoExtensionTests {
 		@Test
 		@ReadsStdIo
 		@Order(3)
-		@DisplayName("3: System.in, System.err and System.out is reset to their original value")
+		@DisplayName("3: System.in, System.out and System.err is reset to their original value")
 		void reset() {
 			assertThat(System.in).isEqualTo(STDIN);
 			assertThat(System.out).isEqualTo(STDOUT);

--- a/src/test/java/org/junitpioneer/jupiter/StdIoExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/StdIoExtensionTests.java
@@ -43,6 +43,7 @@ public class StdIoExtensionTests {
 	private final BasicCommandLineApp app = new BasicCommandLineApp();
 
 	private final static PrintStream STDOUT = System.out;
+	private final static PrintStream STDERR = System.err;
 	private final static InputStream STDIN = System.in;
 
 	@Nested
@@ -56,6 +57,17 @@ public class StdIoExtensionTests {
 			app.write();
 
 			assertThat(out.capturedLines())
+					.containsExactly("Lo! in the orient when the gracious light",
+						"Lifts up his burning head, each under eye");
+		}
+
+		@Test
+		@StdIo
+		@DisplayName("catches the output on the standard err as lines")
+		void catchesErr(StdErr err) {
+			app.writeErr();
+
+			assertThat(err.capturedLines())
 					.containsExactly("Lo! in the orient when the gracious light",
 						"Lifts up his burning head, each under eye");
 		}
@@ -100,7 +112,7 @@ public class StdIoExtensionTests {
 			app.read();
 
 			assertThat(app.lines)
-					.containsExactlyInAnyOrder("But when from highmost pitch, with weary car,",
+					.containsExactly("But when from highmost pitch, with weary car,",
 						"Like feeble age, he reeleth from the day,");
 		}
 
@@ -122,21 +134,23 @@ public class StdIoExtensionTests {
 		@Test
 		@ReadsStdIo
 		@Order(1)
-		@DisplayName("1: System.in and System.out is untouched")
+		@DisplayName("1: System.in, System.err and System.out is untouched")
 		void untouched() {
 			assertThat(System.in).isEqualTo(STDIN);
 			assertThat(System.out).isEqualTo(STDOUT);
+			assertThat(System.err).isEqualTo(STDERR);
 		}
 
 		@Test
 		@StdIo({ "From his low tract, and look another way:", "So thou, thyself outgoing in thy noon" })
 		@Order(2)
-		@DisplayName("2: System.in and System.out is redirected")
-		void redirected(StdIn in, StdOut out) throws IOException {
+		@DisplayName("2: System.in, System.err and System.out is redirected")
+		void redirected(StdIn in, StdOut out, StdErr err) throws IOException {
 			BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
 
 			String line = reader.readLine();
 			System.out.println(line);
+			System.err.println(line);
 
 			// even though `BufferedReader::readLine` was called just once,
 			// both lines were read because the reader buffers
@@ -144,18 +158,21 @@ public class StdIoExtensionTests {
 					.containsExactlyInAnyOrder("From his low tract, and look another way:",
 						"So thou, thyself outgoing in thy noon");
 			assertThat(out.capturedLines()).containsExactlyInAnyOrder("From his low tract, and look another way:");
+			assertThat(err.capturedLines()).containsExactlyInAnyOrder("From his low tract, and look another way:");
 
 			assertThat(System.in).isNotEqualTo(STDIN);
 			assertThat(System.out).isNotEqualTo(STDOUT);
+			assertThat(System.err).isNotEqualTo(STDERR);
 		}
 
 		@Test
 		@ReadsStdIo
 		@Order(3)
-		@DisplayName("3: System.in and System.out is reset to their original value")
+		@DisplayName("3: System.in, System.err and System.out is reset to their original value")
 		void reset() {
 			assertThat(System.in).isEqualTo(STDIN);
 			assertThat(System.out).isEqualTo(STDOUT);
+			assertThat(System.err).isEqualTo(STDERR);
 		}
 
 		@Test
@@ -176,10 +193,11 @@ public class StdIoExtensionTests {
 		@Test
 		@ReadsStdIo
 		@Order(5)
-		@DisplayName("5: System.in is reset, System.out is unaffected.")
+		@DisplayName("5: System.in is reset, System.out and System.err is unaffected.")
 		void reset_single_in() {
 			assertThat(System.in).isEqualTo(STDIN);
 			assertThat(System.out).isEqualTo(STDOUT);
+			assertThat(System.err).isEqualTo(STDERR);
 		}
 
 		@Test
@@ -193,16 +211,43 @@ public class StdIoExtensionTests {
 			assertThat(out.capturedLines()).containsExactlyInAnyOrder("Shakespeare", "Sonnet VII");
 
 			assertThat(System.in).isEqualTo(STDIN);
+			assertThat(System.err).isEqualTo(STDERR);
 			assertThat(System.out).isNotEqualTo(STDOUT);
 		}
 
 		@Test
 		@ReadsStdIo
 		@Order(7)
-		@DisplayName("7: System.out is reset, System.in is unaffected.")
+		@DisplayName("7: System.out is reset, System.in and System.err is unaffected.")
 		void reset_single_out() {
 			assertThat(System.in).isEqualTo(STDIN);
 			assertThat(System.out).isEqualTo(STDOUT);
+			assertThat(System.err).isEqualTo(STDERR);
+		}
+
+		@Test
+		@StdIo
+		@Order(6)
+		@DisplayName("6: Only System.err is redirected.")
+		void redirected_single_err(StdErr err) {
+			System.err.println("Mortal beauty");
+			System.err.println("Gracious light");
+
+			assertThat(err.capturedLines()).containsExactlyInAnyOrder("Mortal beauty", "Gracious light");
+
+			assertThat(System.in).isEqualTo(STDIN);
+			assertThat(System.out).isEqualTo(STDOUT);
+			assertThat(System.err).isNotEqualTo(STDERR);
+		}
+
+		@Test
+		@ReadsStdIo
+		@Order(7)
+		@DisplayName("7: System.err is reset, System.in and System.out is unaffected.")
+		void reset_single_err() {
+			assertThat(System.in).isEqualTo(STDIN);
+			assertThat(System.out).isEqualTo(STDOUT);
+			assertThat(System.err).isEqualTo(STDERR);
 		}
 
 	}
@@ -283,6 +328,12 @@ public class StdIoExtensionTests {
 			System.out.print("Lo! in the orient ");
 			System.out.println("when the gracious light");
 			System.out.println("Lifts up his burning head, each under eye");
+		}
+
+		public void writeErr() {
+			System.err.print("Lo! in the orient ");
+			System.err.println("when the gracious light");
+			System.err.println("Lifts up his burning head, each under eye");
 		}
 
 		public void read() throws IOException {


### PR DESCRIPTION
Closes #650

Proposed commit message:

```
Add StdErr to StdIoExtension (#650 / #653)

Adds a new parameter to the StdIoExtension, StdErr, which
replaces System.err the same way StdOut replaces
System.out.

Closes: #650
PR: #653
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [x] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [x] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [x] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [x] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style

Code
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [x] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
