### PR TITLE
Replace Locale constructor by Locale builder (#658 / )

### DIFF
--- a/src/demo/java/org/junitpioneer/jupiter/DefaultLocaleTimezoneExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/DefaultLocaleTimezoneExtensionDemo.java
@@ -19,6 +19,18 @@ import org.junit.jupiter.api.Test;
 
 public class DefaultLocaleTimezoneExtensionDemo {
 
+	protected static Locale createLocale(String language, String country, String variant) {
+		return new Locale.Builder().setLanguage(language).setRegion(country).setVariant(variant).build();
+	}
+
+	protected static Locale createLocale(String language, String country) {
+		return new Locale.Builder().setLanguage(language).setRegion(country).build();
+	}
+
+	protected static Locale createLocale(String language) {
+		return new Locale.Builder().setLanguage(language).build();
+	}
+
 	// tag::default_locale_language[]
 	@Test
 	@DefaultLocale("zh-Hant-TW")
@@ -31,19 +43,19 @@ public class DefaultLocaleTimezoneExtensionDemo {
 	@Test
 	@DefaultLocale(language = "en")
 	void test_with_lanuage_only() {
-		assertThat(Locale.getDefault()).isEqualTo(new Locale("en"));
+		assertThat(Locale.getDefault()).isEqualTo(createLocale("en"));
 	}
 
 	@Test
 	@DefaultLocale(language = "en", country = "EN")
 	void test_with_lanuage_and_country() {
-		assertThat(Locale.getDefault()).isEqualTo(new Locale("en", "EN"));
+		assertThat(Locale.getDefault()).isEqualTo(createLocale("en", "EN"));
 	}
 
 	@Test
-	@DefaultLocale(language = "en", country = "EN", variant = "gb")
+	@DefaultLocale(language = "ja", country = "JP", variant = "japanese")
 	void test_with_lanuage_and_country_and_vairant() {
-		assertThat(Locale.getDefault()).isEqualTo(new Locale("en", "EN", "gb"));
+		assertThat(Locale.getDefault()).isEqualTo(createLocale("ja", "JP", "japanese"));
 	}
 	// end::default_locale_language_alternatives[]
 
@@ -53,13 +65,13 @@ public class DefaultLocaleTimezoneExtensionDemo {
 
 		@Test
 		void test_with_class_level_configuration() {
-			assertThat(Locale.getDefault()).isEqualTo(new Locale("fr"));
+			assertThat(Locale.getDefault()).isEqualTo(createLocale("fr"));
 		}
 
 		@Test
 		@DefaultLocale(language = "en")
 		void test_with_method_level_configuration() {
-			assertThat(Locale.getDefault()).isEqualTo(new Locale("en"));
+			assertThat(Locale.getDefault()).isEqualTo(createLocale("en"));
 		}
 
 	}

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
@@ -68,7 +68,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public @interface DefaultLocale {
 
 	/**
-	 * An language tag string as specified by IETF BCP 47. See
+	 * A language tag string as specified by IETF BCP 47. See
 	 * {@link java.util.Locale#forLanguageTag(String)} for more information
 	 * about valid language tag values.
 	 *

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocaleExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocaleExtension.java
@@ -66,11 +66,11 @@ class DefaultLocaleExtension implements BeforeEachCallback, AfterEachCallback {
 		String country = annotation.country();
 		String variant = annotation.variant();
 		if (!language.isEmpty() && !country.isEmpty() && !variant.isEmpty()) {
-			return new Locale(language, country, variant);
+			return new Locale.Builder().setLanguage(language).setRegion(country).setVariant(variant).build();
 		} else if (!language.isEmpty() && !country.isEmpty()) {
-			return new Locale(language, country);
+			return new Locale.Builder().setLanguage(language).setRegion(country).build();
 		} else if (!language.isEmpty() && variant.isEmpty()) {
-			return new Locale(language);
+			return new Locale.Builder().setLanguage(language).build();
 		} else {
 			throw new ExtensionConfigurationException(
 				"@DefaultLocale not configured correctly. When not using a language tag, specify either"

--- a/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
@@ -35,8 +35,20 @@ class DefaultLocaleTests {
 	@BeforeAll
 	static void globalSetUp() {
 		DEFAULT_LOCALE_BEFORE_TEST = Locale.getDefault();
-		TEST_DEFAULT_LOCALE = new Locale("custom");
+		TEST_DEFAULT_LOCALE = createLocale("custom");
 		Locale.setDefault(TEST_DEFAULT_LOCALE);
+	}
+
+	protected static Locale createLocale(String language, String country, String variant) {
+		return new Locale.Builder().setLanguage(language).setRegion(country).setVariant(variant).build();
+	}
+
+	protected static Locale createLocale(String language, String country) {
+		return new Locale.Builder().setLanguage(language).setRegion(country).build();
+	}
+
+	protected static Locale createLocale(String language) {
+		return new Locale.Builder().setLanguage(language).build();
 	}
 
 	@AfterAll
@@ -63,24 +75,36 @@ class DefaultLocaleTests {
 		}
 
 		@Test
-		@DefaultLocale(language = "en_EN")
+		@DefaultLocale(language = "en")
 		@DisplayName("sets the default locale using a language")
 		void setsLanguage() {
-			assertThat(Locale.getDefault()).isEqualTo(new Locale("en_EN"));
+			assertThat(Locale.getDefault()).isEqualTo(createLocale("en"));
 		}
 
 		@Test
 		@DefaultLocale(language = "en", country = "EN")
 		@DisplayName("sets the default locale using a language and a country")
 		void setsLanguageAndCountry() {
-			assertThat(Locale.getDefault()).isEqualTo(new Locale("en", "EN"));
+			assertThat(Locale.getDefault()).isEqualTo(createLocale("en", "EN"));
 		}
 
+		/**
+		 * A valid variant checked by {@link sun.util.locale.LanguageTag#isVariant} against BCP 47 (or more detailed RFC 5646) matches either {@code [0-9a-Z]{5-8}} or {@code [0-9][0-9a-Z]{3}}.
+		 * It does NOT check if such a variant exists in real.
+		 * <br>
+		 * The Locale-Builder accepts valid variants, concatenated by minus or underscore (minus will be transformed by the builder).
+		 * This means "en-EN" is a valid languageTag, but not a valid IETF BCP 47 variant subtag.
+		 * <br>
+		 * This is very confusing as the <a href="https://www.oracle.com/java/technologies/javase/jdk11-suported-locales.html">official page for supported locales</a> shows that japanese locales return {@code *} or {@code JP} as a variant.
+		 * Even more confusing the enum values {@code Locale.JAPAN} and {@code Locale.JAPANESE} don't return a variant.
+		 *
+		 * @see <a href="https://www.rfc-editor.org/rfc/rfc5646.html">RFC 5646</a>
+		 */
 		@Test
-		@DefaultLocale(language = "en", country = "EN", variant = "gb")
+		@DefaultLocale(language = "ja", country = "JP", variant = "japanese")
 		@DisplayName("sets the default locale using a language, a country and a variant")
 		void setsLanguageAndCountryAndVariant() {
-			assertThat(Locale.getDefault()).isEqualTo(new Locale("en", "EN", "gb"));
+			assertThat(Locale.getDefault()).isEqualTo(createLocale("ja", "JP", "japanese"));
 		}
 
 	}
@@ -100,13 +124,13 @@ class DefaultLocaleTests {
 		@Test
 		@ReadsDefaultLocale
 		void shouldExecuteWithClassLevelLocale() {
-			assertThat(Locale.getDefault()).isEqualTo(new Locale("fr", "FR"));
+			assertThat(Locale.getDefault()).isEqualTo(createLocale("fr", "FR"));
 		}
 
 		@Test
 		@DefaultLocale(language = "de", country = "DE")
 		void shouldBeOverriddenWithMethodLevelLocale() {
-			assertThat(Locale.getDefault()).isEqualTo(new Locale("de", "DE"));
+			assertThat(Locale.getDefault()).isEqualTo(createLocale("de", "DE"));
 		}
 
 	}
@@ -325,7 +349,7 @@ class DefaultLocaleTests {
 		@Test
 		@DisplayName("should inherit default locale annotation")
 		void shouldInheritClearAndSetProperty() {
-			assertThat(Locale.getDefault()).isEqualTo(new Locale("fr", "FR"));
+			assertThat(Locale.getDefault()).isEqualTo(createLocale("fr", "FR"));
 		}
 
 	}


### PR DESCRIPTION
Proposed commit message:

```
Replace Locale constructor by Locale builder (#658 / )

The Locale constructor gets deprecated in newer Java version.
Therefore we replace it by the Locale builder.

closed: #658
PR: ${pull-request}
```
