### PR TITLE
Replace Locale constructor by Locale builder (#658 / #662)

### DIFF
--- a/docs/default-locale-timezone.adoc
+++ b/docs/default-locale-timezone.adoc
@@ -16,11 +16,13 @@ The default `Locale` can be specified using an https://docs.oracle.com/javase/8/
 include::{demo}[tag=default_locale_language]
 ----
 
-Alternatively the default `Locale` can be specified according to https://docs.oracle.com/javase/8/docs/api/java/util/Locale.html#constructor.summary[its constructors] - it needs either:
+Alternatively the default `Locale` can be created using the following attributes of which a https://docs.oracle.com/javase/8/docs/api/java/util/Locale.Builder.html[Locale Builder] can create an instance with:
 
 * `language` or
 * `language` and `country` or
 * `language`, `country`, and `variant`
+
+Note:: The variant needs to be a string which follows the https://www.rfc-editor.org/rfc/rfc5646.html[IETF BCP 47 / RFC 5646] syntax!
 
 [source,java,indent=0]
 ----
@@ -28,7 +30,7 @@ include::{demo}[tag=default_locale_language_alternatives]
 ----
 
 Note that mixing language tag configuration and constructor based configuration will cause an `ExtensionConfigurationException` to be thrown.
-Furthermore a `variant` can only be specified if `country` is also specified.
+Furthermore, a `variant` can only be specified if `country` is also specified.
 If `variant` is specified without `country`, an `ExtensionConfigurationException` will be thrown.
 
 Any method level `@DefaultLocale` configurations will override class level configurations.

--- a/docs/default-locale-timezone.adoc
+++ b/docs/default-locale-timezone.adoc
@@ -22,7 +22,7 @@ Alternatively the default `Locale` can be created using the following attributes
 * `language` and `country` or
 * `language`, `country`, and `variant`
 
-Note:: The variant needs to be a string which follows the https://www.rfc-editor.org/rfc/rfc5646.html[IETF BCP 47 / RFC 5646] syntax!
+NOTE: The variant needs to be a string which follows the https://www.rfc-editor.org/rfc/rfc5646.html[IETF BCP 47 / RFC 5646] syntax!
 
 [source,java,indent=0]
 ----

--- a/src/demo/java/org/junitpioneer/jupiter/DefaultLocaleTimezoneExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/DefaultLocaleTimezoneExtensionDemo.java
@@ -31,19 +31,20 @@ public class DefaultLocaleTimezoneExtensionDemo {
 	@Test
 	@DefaultLocale(language = "en")
 	void test_with_lanuage_only() {
-		assertThat(Locale.getDefault()).isEqualTo(new Locale("en"));
+		assertThat(Locale.getDefault()).isEqualTo(new Locale.Builder().setLanguage("en").build());
 	}
 
 	@Test
 	@DefaultLocale(language = "en", country = "EN")
 	void test_with_lanuage_and_country() {
-		assertThat(Locale.getDefault()).isEqualTo(new Locale("en", "EN"));
+		assertThat(Locale.getDefault()).isEqualTo(new Locale.Builder().setLanguage("en").setRegion("EN").build());
 	}
 
 	@Test
-	@DefaultLocale(language = "en", country = "EN", variant = "gb")
+	@DefaultLocale(language = "ja", country = "JP", variant = "japanese")
 	void test_with_lanuage_and_country_and_vairant() {
-		assertThat(Locale.getDefault()).isEqualTo(new Locale("en", "EN", "gb"));
+		assertThat(Locale.getDefault())
+				.isEqualTo(new Locale.Builder().setLanguage("ja").setRegion("JP").setVariant("japanese").build());
 	}
 	// end::default_locale_language_alternatives[]
 
@@ -53,13 +54,13 @@ public class DefaultLocaleTimezoneExtensionDemo {
 
 		@Test
 		void test_with_class_level_configuration() {
-			assertThat(Locale.getDefault()).isEqualTo(new Locale("fr"));
+			assertThat(Locale.getDefault()).isEqualTo(new Locale.Builder().setLanguage("fr").build());
 		}
 
 		@Test
 		@DefaultLocale(language = "en")
 		void test_with_method_level_configuration() {
-			assertThat(Locale.getDefault()).isEqualTo(new Locale("en"));
+			assertThat(Locale.getDefault()).isEqualTo(new Locale.Builder().setLanguage("en").build());
 		}
 
 	}

--- a/src/main/java/org/junitpioneer/internal/PioneerUtils.java
+++ b/src/main/java/org/junitpioneer/internal/PioneerUtils.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collector;
@@ -162,6 +163,18 @@ public class PioneerUtils {
 			}
 		}
 		return resultLists;
+	}
+
+	public static Locale createLocale(String language, String country, String variant) {
+		return new Locale.Builder().setLanguage(language).setRegion(country).setVariant(variant).build();
+	}
+
+	public static Locale createLocale(String language, String country) {
+		return new Locale.Builder().setLanguage(language).setRegion(country).build();
+	}
+
+	public static Locale createLocale(String language) {
+		return new Locale.Builder().setLanguage(language).build();
 	}
 
 }

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
@@ -27,10 +27,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *
  * <ul>
  *     <li>using a {@link java.util.Locale#forLanguageTag(String) language tag}</li>
- *     <li>using a {@link java.util.Locale#Locale(String) language}</li>
- *     <li>using a {@link java.util.Locale#Locale(String, String) language and a county}</li>
- *     <li>using a {@link java.util.Locale#Locale(String, String, String) language, a county, and a variant}</li>
+ *     <li>using a {@link java.util.Locale.Builder} Locale.Builder} together with
+ *         <ul>
+ *            <li>a language</li>
+ * 		      <li>a language and a county</li>
+ * 			  <li>a language, a county, and a variant</li>
+ *         </ul>
+ *     </li>
  * </ul>
+ *
+ * <p>Please keep in mind the the {@code Locale.Builder} does a syntax check, if you use a variant!
+ * The given string must match the BCP 47 (or more detailed <a href="https://www.rfc-editor.org/rfc/rfc5646.html">RFC 5646</a>) syntax.</p>
  *
  * <p>If a language tag is set, none of the other fields must be set. Otherwise an
  * {@link org.junit.jupiter.api.extension.ExtensionConfigurationException} will
@@ -91,8 +98,8 @@ public @interface DefaultLocale {
 	String country() default "";
 
 	/**
-	 * Any arbitrary value used to indicate a variation of a {@code Locale}.
-	 * See the {@link java.util.Locale} class description for the details.
+	 * An IETF BCP 47 language string that matches the <a href="https://www.rfc-editor.org/rfc/rfc5646.html">RFC 5646</a> syntax.
+	 * It's validated by the {@code Locale.Builder}, using {@code sun.util.locale.LanguageTag#isVariant}.
 	 */
 	String variant() default "";
 

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
@@ -10,13 +10,13 @@
 
 package org.junitpioneer.jupiter;
 
-import org.junit.jupiter.api.extension.ExtendWith;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * {@code @DefaultLocale} is a JUnit Jupiter extension to change the value

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
@@ -10,13 +10,13 @@
 
 package org.junitpioneer.jupiter;
 
+import org.junit.jupiter.api.extension.ExtendWith;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
-import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * {@code @DefaultLocale} is a JUnit Jupiter extension to change the value
@@ -68,7 +68,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public @interface DefaultLocale {
 
 	/**
-	 * An language tag string as specified by IETF BCP 47. See
+	 * A language tag string as specified by IETF BCP 47. See
 	 * {@link java.util.Locale#forLanguageTag(String)} for more information
 	 * about valid language tag values.
 	 *

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocaleExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocaleExtension.java
@@ -62,9 +62,6 @@ class DefaultLocaleExtension implements BeforeEachCallback, AfterEachCallback {
 		return Locale.forLanguageTag(annotation.value());
 	}
 
-	// On Java 19+, `Locale` constructors are deprecated.
-	// We ignore them until they're removed in #658
-	@SuppressWarnings("deprecation")
 	private static Locale createFromParts(DefaultLocale annotation) {
 		String language = annotation.language();
 		String country = annotation.country();

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocaleExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocaleExtension.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junitpioneer.internal.PioneerAnnotationUtils;
+import org.junitpioneer.internal.PioneerUtils;
 
 class DefaultLocaleExtension implements BeforeEachCallback, AfterEachCallback {
 
@@ -69,11 +70,11 @@ class DefaultLocaleExtension implements BeforeEachCallback, AfterEachCallback {
 		String country = annotation.country();
 		String variant = annotation.variant();
 		if (!language.isEmpty() && !country.isEmpty() && !variant.isEmpty()) {
-			return new Locale(language, country, variant);
+			return PioneerUtils.createLocale(language, country, variant);
 		} else if (!language.isEmpty() && !country.isEmpty()) {
-			return new Locale(language, country);
+			return PioneerUtils.createLocale(language, country);
 		} else if (!language.isEmpty() && variant.isEmpty()) {
-			return new Locale(language);
+			return PioneerUtils.createLocale(language);
 		} else {
 			throw new ExtensionConfigurationException(
 				"@DefaultLocale not configured correctly. When not using a language tag, specify either"

--- a/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
@@ -27,9 +27,6 @@ import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junitpioneer.internal.PioneerUtils;
 import org.junitpioneer.testkit.ExecutionResults;
 
-// On Java 19+, `Locale` constructors are deprecated.
-// We ignore them until they're removed in #658
-@SuppressWarnings("deprecation")
 @DisplayName("DefaultLocale extension")
 class DefaultLocaleTests {
 

--- a/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
+import org.junitpioneer.internal.PioneerUtils;
 import org.junitpioneer.testkit.ExecutionResults;
 
 // On Java 19+, `Locale` constructors are deprecated.
@@ -38,7 +39,7 @@ class DefaultLocaleTests {
 	@BeforeAll
 	static void globalSetUp() {
 		DEFAULT_LOCALE_BEFORE_TEST = Locale.getDefault();
-		TEST_DEFAULT_LOCALE = new Locale("custom");
+		TEST_DEFAULT_LOCALE = PioneerUtils.createLocale("custom");
 		Locale.setDefault(TEST_DEFAULT_LOCALE);
 	}
 
@@ -66,24 +67,36 @@ class DefaultLocaleTests {
 		}
 
 		@Test
-		@DefaultLocale(language = "en_EN")
+		@DefaultLocale(language = "en")
 		@DisplayName("sets the default locale using a language")
 		void setsLanguage() {
-			assertThat(Locale.getDefault()).isEqualTo(new Locale("en_EN"));
+			assertThat(Locale.getDefault()).isEqualTo(PioneerUtils.createLocale("en"));
 		}
 
 		@Test
 		@DefaultLocale(language = "en", country = "EN")
 		@DisplayName("sets the default locale using a language and a country")
 		void setsLanguageAndCountry() {
-			assertThat(Locale.getDefault()).isEqualTo(new Locale("en", "EN"));
+			assertThat(Locale.getDefault()).isEqualTo(PioneerUtils.createLocale("en", "EN"));
 		}
 
+		/**
+		 * A valid variant checked by {@link sun.util.locale.LanguageTag#isVariant} against BCP 47 (or more detailed RFC 5646) matches either {@code [0-9a-Z]{5-8}} or {@code [0-9][0-9a-Z]{3}}.
+		 * It does NOT check if such a variant exists in real.
+		 * <br>
+		 * The Locale-Builder accepts valid variants, concatenated by minus or underscore (minus will be transformed by the builder).
+		 * This means "en-EN" is a valid languageTag, but not a valid IETF BCP 47 variant subtag.
+		 * <br>
+		 * This is very confusing as the <a href="https://www.oracle.com/java/technologies/javase/jdk11-suported-locales.html">official page for supported locales</a> shows that japanese locales return {@code *} or {@code JP} as a variant.
+		 * Even more confusing the enum values {@code Locale.JAPAN} and {@code Locale.JAPANESE} don't return a variant.
+		 *
+		 * @see <a href="https://www.rfc-editor.org/rfc/rfc5646.html">RFC 5646</a>
+		 */
 		@Test
-		@DefaultLocale(language = "en", country = "EN", variant = "gb")
+		@DefaultLocale(language = "ja", country = "JP", variant = "japanese")
 		@DisplayName("sets the default locale using a language, a country and a variant")
 		void setsLanguageAndCountryAndVariant() {
-			assertThat(Locale.getDefault()).isEqualTo(new Locale("en", "EN", "gb"));
+			assertThat(Locale.getDefault()).isEqualTo(PioneerUtils.createLocale("ja", "JP", "japanese"));
 		}
 
 	}
@@ -103,13 +116,13 @@ class DefaultLocaleTests {
 		@Test
 		@ReadsDefaultLocale
 		void shouldExecuteWithClassLevelLocale() {
-			assertThat(Locale.getDefault()).isEqualTo(new Locale("fr", "FR"));
+			assertThat(Locale.getDefault()).isEqualTo(PioneerUtils.createLocale("fr", "FR"));
 		}
 
 		@Test
 		@DefaultLocale(language = "de", country = "DE")
 		void shouldBeOverriddenWithMethodLevelLocale() {
-			assertThat(Locale.getDefault()).isEqualTo(new Locale("de", "DE"));
+			assertThat(Locale.getDefault()).isEqualTo(PioneerUtils.createLocale("de", "DE"));
 		}
 
 	}
@@ -263,6 +276,17 @@ class DefaultLocaleTests {
 						.withExceptionInstanceOf(ExtensionConfigurationException.class);
 			}
 
+			@Test
+			@DisplayName("should fail when invalid BCP 47 variant is set")
+			void shouldFailIfNoValidBCP47VariantIsSet() {
+				ExecutionResults results = executeTestMethod(MethodLevelInitializationFailureTestCases.class,
+					"shouldFailNoValidBCP47Variant");
+
+				assertThat(results)
+						.hasSingleFailedTest()
+						.withExceptionInstanceOf(ExtensionConfigurationException.class);
+			}
+
 		}
 
 		@Nested
@@ -310,6 +334,11 @@ class DefaultLocaleTests {
 		void shouldFailLanguageTagAndVariant() {
 		}
 
+		@Test
+		@DefaultLocale(variant = "en-GB")
+		void shouldFailNoValidBCP47Variant() {
+		}
+
 	}
 
 	@DefaultLocale(language = "de", variant = "ch")
@@ -328,7 +357,7 @@ class DefaultLocaleTests {
 		@Test
 		@DisplayName("should inherit default locale annotation")
 		void shouldInheritClearAndSetProperty() {
-			assertThat(Locale.getDefault()).isEqualTo(new Locale("fr", "FR"));
+			assertThat(Locale.getDefault()).isEqualTo(PioneerUtils.createLocale("fr", "FR"));
 		}
 
 	}


### PR DESCRIPTION
Proposed commit message:

```
Replace Locale constructor by Locale builder (#658 / #662)

The Locale constructor gets deprecated in newer Java version.
Therefore we replace it by the Locale builder.

closed: #658
PR: #662
```
linked issue: #658 