### PR TITLE
Add issues templates for feature requests and bug reports (#589 / #667)

### DIFF
--- a/.github/feature_request.md
+++ b/.github/feature_request.md
@@ -1,0 +1,32 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FR]"
+labels: ["🚦 status: in discussion", "🏗️ type: new feature"]
+assignees: ''
+
+---
+
+**Please give information what category your feature request is about**
+
+Examples:
+- An extension
+- The build or infrastructure (IDE, Github, Gradle)
+- The documentation
+- Something different
+
+**Please describe the cause of your feature request? What do you try to do and realize that a tool / functionality is missing?**
+
+For example:
+- I tried to use extension Y to do X, but with the current implementation I can only do Z
+- I read about this fancy thing, Gradle can do now!
+
+**Please describe, what you would like to be changed/ added / improved. If you want to add code or pseudo-code snippets, feel free to do so. If you have knowledge about possible side effects or problems or have considered any alternative solutions, please add information about them, too**
+
+Example:
+- I would like to see the possibility to use a new annotation, maybe `@fancy("value")` to do X
+- I suggest to update to Java 2042 to use the new feature Z, but this also means, that the Gradle version has to be updated, and it's only a RC so far.
+
+**Additional context**
+
+Add any other context or screenshots about the feature request here.

--- a/.github/feature_request.md
+++ b/.github/feature_request.md
@@ -21,7 +21,7 @@ For example:
 - I tried to use extension Y to do X, but with the current implementation I can only do Z
 - I read about this fancy thing, Gradle can do now!
 
-**Please describe, what you would like to be changed/ added / improved. If you want to add code or pseudo-code snippets, feel free to do so. If you have knowledge about possible side effects or problems or have considered any alternative solutions, please add information about them, too**
+**Please describe, what you would like to be changed / added / improved. If you want to add code or pseudo-code snippets, feel free to do so. If you have knowledge about possible side effects or problems or have considered any alternative solutions, please add information about them, too**
 
 Example:
 - I would like to see the possibility to use a new annotation, maybe `@fancy("value")` to do X

--- a/.github/feature_request.md
+++ b/.github/feature_request.md
@@ -24,7 +24,7 @@ For example:
 **Please describe, what you would like to be changed / added / improved. If you want to add code or pseudo-code snippets, feel free to do so. If you have knowledge about possible side effects or problems or have considered any alternative solutions, please add information about them, too**
 
 Example:
-- I would like to see the possibility to use a new annotation, maybe `@fancy("value")` to do X
+- I would like to see the possibility to use a new annotation, maybe `@Fancy("value")` to do X
 - I suggest to update to Java 2042 to use the new feature Z, but this also means, that the Gradle version has to be updated, and it's only a RC so far.
 
 **Additional context**

--- a/.github/feature_request.md
+++ b/.github/feature_request.md
@@ -25,7 +25,7 @@ For example:
 
 Example:
 - I would like to see the possibility to use a new annotation, maybe `@Fancy("value")` to do X
-- I suggest to update to Java 2042 to use the new feature Z, but this also means, that the Gradle version has to be updated, and it's only a RC so far.
+- I suggest to update to Java 2042 to use the new feature Z, but this also means, that the Gradle version has to be updated, and it's only a release candidate (RC) so far
 
 **Additional context**
 

--- a/.github/issue--bug-report.md
+++ b/.github/issue--bug-report.md
@@ -1,5 +1,5 @@
 ---
-name: 'Issue: Bug report'
+name: 'Bug report'
 about: Please use this template if you want to report a bug
 title: "[BUG]"
 labels: ["🚦 status: in discussion", "🏗️ type: bug"]

--- a/.github/issue--bug-report.md
+++ b/.github/issue--bug-report.md
@@ -1,0 +1,36 @@
+---
+name: 'Issue: Bug report'
+about: Please use this template if you want to report a bug
+title: "[BUG]"
+labels: ["🚦 status: in discussion", "🏗️ type: bug"]
+assignees: ''
+
+---
+
+**Describe the bug**
+
+Please provide a detailed description for the bug, containing the current and expected behavior as well as code to reproduce.
+
+**Description**
+
+**Current behavior**
+
+**Expected behavior**
+
+**Code to Reproduce**
+
+Please provide an example code (using the code markdown) to demonstrate the bug in praxis.
+
+**Versions**
+
+Please provide information about the versions of the following tools you use, when the bug occurs:
+
+* Which JUnit Pioneer version do you use, when the bug occurs?
+* Which JUnit Jupiter (JUnit 5) version do you use?
+* Which Java version do you use?
+
+If the bug occurs after an update to a newer version of these, please also note the older version you could use without having the bug.
+
+**Additional context**
+
+Add any other context about the problem here.

--- a/.github/issue--bug-report.md
+++ b/.github/issue--bug-report.md
@@ -19,7 +19,7 @@ Please provide a detailed description for the bug, containing the current and ex
 
 **Code to Reproduce**
 
-Please provide an example code (using the code markdown) to demonstrate the bug in praxis.
+Please provide example code (using markdown) to demonstrate the bug in practice.
 
 **Versions**
 

--- a/.github/issue--bug-report.md
+++ b/.github/issue--bug-report.md
@@ -25,7 +25,7 @@ Please provide example code (using markdown) to demonstrate the bug in practice.
 
 Please provide information about the versions of the following tools you use, when the bug occurs:
 
-* Which JUnit Pioneer version do you use, when the bug occurs?
+* Which JUnit Pioneer version do you use?
 * Which JUnit Jupiter (JUnit 5) version do you use?
 * Which Java version do you use?
 

--- a/.github/issue--bug-report.md
+++ b/.github/issue--bug-report.md
@@ -1,6 +1,6 @@
 ---
 name: 'Bug report'
-about: Please use this template if you want to report a bug
+about: Report a bug for this project
 title: "[BUG]"
 labels: ["🚦 status: in discussion", "🏗️ type: bug"]
 assignees: ''

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ We really appreciate that you consider contributing to JUnit Pioneer.
 We know that this can be quite daunting at first:
 Everybody uses a vocabulary and techniques that appear quite cryptic to those not steeped in them.
 We can't fix that in a short file like this, but we want to provide some pointers to get you started.
-If anything that follows in this document isn't clear, [open an issue](https://github.com/junit-pioneer/junit-pioneer/issues/new) and ask us to explain it better.
+If anything that follows in this document isn't clear, [open an issue](https://github.com/junit-pioneer/junit-pioneer/issues/new/choose) and ask us to explain it better.
 
 To get you started, have a look at the [Open Source Guide](https://opensource.guide/) article [_How to Contribute to Open Source_](https://opensource.guide/how-to-contribute/).
 We particularly recommend the following sections:
@@ -199,7 +199,7 @@ For that, also add the annotation `@Inherited`.
 #### Thread-safety
 
 It must be safe to use Pioneer's extensions in a test suite that is executed in parallel.
-To that end it is necessary to understand [JUnit Jupiter's parallel execution](https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution)), particularly [the synchronization mechanisms it offers](https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution-synchronization): `@Execution` and `@ResourceLock`.
+To that end it is necessary to understand [JUnit Jupiter's parallel execution](https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution), particularly [the synchronization mechanisms it offers](https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution-synchronization): `@Execution` and `@ResourceLock`.
 
 For extensions touching global state (like default locales or environment variables), we've chosen the following approach:
 
@@ -420,7 +420,7 @@ PR: ${pull-request}
 
 `${action}` should succinctly describe what the PR does in good Git style.
 Ideally, this title line (without issue and PR numbers) should not exceed 50 characters - 70 is the absolute maximum.
-It is followed, in parenthesis, by a comma-separated list of all related issues, a slash, and the pull request (to make all of them easy to find from a look at the log).
+It is followed, in parentheses, by a comma-separated list of all related issues, a slash, and the pull request (to make all of them easy to find from a look at the log).
 
 `${body}` should outline the problem the pull request was solving - it should focus on _why_ the code was written, not on _how_ it works.
 This can usually be a summary of the issue description and discussion as well as commit messages.
@@ -622,7 +622,7 @@ This applies to users opening issues, contributors providing PRs, and other main
 These are the channels we use to communicate with one another, our contributors, and users - in decreasing order of importance:
 
 1. [project website](https://junit-pioneer.org)
-2. files in the repository (like [`README.md`](README.md) and and this `CONTRIBUTING.md`)
+2. files in the repository (like [`README.md`](README.md) and this `CONTRIBUTING.md`)
 3. Git commit messages
 4. issues/PRs [on GitHub](https://github.com/junit-pioneer/junit-pioneer)
 5. _#junit-pioneer_ channel [in Discord](https://discord.gg/rHfJeCF)


### PR DESCRIPTION
Proposed commit message:

```
Add issue templates for feature requests and bug reports (#589 / #667)

This PR adds issue templates for feature requests and bug reports
as discussed and previewed in the issue.

closed: #589
PR: #667
```

#589

Also fixing the minor errors (one grammar, one double `and` and a stand alone `)` in the docs.
The changed "new issue" link can be verified here in an example project of me: https://github.com/Bukama/MvnDependencyResolving/issues/new/choose