### PR TITLE
Remove branch filtering from build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
   # We want to trigger our builds all the time for the default branch
   # except when Shipkit creates a new version tag
   push:
-    branches: 'main'
+    branches: ['main']
     tags-ignore:
       - 'v**'
   # Each pull request is important to us, doesn't matter from which branch.
@@ -15,7 +15,6 @@ on:
   # events, we also want to react onto `labeled` events for our extended
   # build execution
   pull_request:
-    branches: '*'
     types: [labeled, opened, synchronize, reopened]
   # We also utilize this pipeline for releasing. By providing a `version`
   # and setting `releasing` to `true`, we can trigger a release.


### PR DESCRIPTION
Proposed commit message:

```
Remove branch filter on PR triggers (#673 / #674)

This commit removes the branch filtering on PRs. It prevented the
build pipeline from triggering in certain cases but we want to
trigger it for all PRs, so the filtering just did not make sense.

Closes: #673
PR: #674
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [ ] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 
