### PR TITLE
Rename label "merge-ready" to "full-build" (#679 / #682)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,9 +108,9 @@ jobs:
   # Our full integration job, which will build for a matrix out of our supported
   # Java versions, operating systems, modular or not, and various JUnit versions.
   # This build is executed on all tags and the default branch. Furthermore, we will
-  # also execute this for pull requests with the label `merge-ready`.
+  # also execute this for pull requests with the label `full-build`.
   full-featured:
-    if: (contains(github.event.pull_request.labels.*.name, 'merge-ready') || !github.event.pull_request)
+    if: (contains(github.event.pull_request.labels.*.name, 'full-build') || !github.event.pull_request)
     needs: basic
     runs-on: ${{ matrix.os }}-latest
     timeout-minutes: 15
@@ -139,7 +139,7 @@ jobs:
   # Furthermore, we also would love to see our build working with the latest Gradle version.
   # As those builds might fail, they are allowed to fail, and should not prevent merges.
   experimental:
-    if: (contains(github.event.pull_request.labels.*.name, 'merge-ready') || !github.event.pull_request)
+    if: (contains(github.event.pull_request.labels.*.name, 'full-build') || !github.event.pull_request)
     needs: full-featured
     runs-on: ${{ matrix.os }}-latest
     continue-on-error: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -391,7 +391,7 @@ To enforce the [branching strategy](#branching-strategy) pull requests from `mai
 ### Full Testing
 
 In order to minimize the delay between a push and feedback, the default build is only run on a small subset of all possible builds (which include different operating system, Java versions and so on).
-Once a pull request is ready to be merged, a maintainer needs to apply the _merge-ready_ label to trigger a full build.
+To get more wider feedback, for example once a pull request is ready to be merged, a maintainer needs to apply the _full-build_ label to trigger just that.
 
 ### Merging
 


### PR DESCRIPTION
Switching from the reduced, faster build to the full build of all Java/OS/etc combinations requires adding a specific label to the PR. It was called "merge-ready", which marks the PR as being ready to be merged once the build is green, but that is (at least) occasionally not the case.

To avoid confusion, we rename the label to the less leading name "full-build".

Proposed commit message:

```
Rename label "merge-ready" to "full-build" (#679 / #682)
    
Switching from the reduced, faster build to the full build of all
Java/OS/etc combinations requires adding a specific label to the PR.
It was called "merge-ready", which marks the PR as being ready to be
merged once the build is green, but that is (at least) occasionally
not the case.
    
To avoid confusion, we rename the label to the less leading name
"full-build".
    
Closes: #679
PR: #682
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [x] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [x] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [x] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [x] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [x] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [x] The `package-info.java` contains information about the new extension

Code
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [x] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [x] The list of contributions inside `README.md` mentions the new contribution (real name optional) 
