### PR TITLE
Depose Nicolai as benevolent dictator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -638,11 +638,3 @@ A few examples:
 * when a PR is merged, the commit message summarizes what it is about (see [_Commit Message_](#commit-message) above)
 * when a decision regarding the project structure or the development processes is made, it is reflected in `README.md`, `CONTRIBUTING.md`, or another suitable file or even the website
 * when a new feature is merged, documentation is added to the website
-
-### Where The Buck Stops
-
-This project was founded by [Nicolai Parlog](https://github.com/nicolaiparlog) (together with [Steve Moyer](https://github.com/smoyer64)) and I (surprise, it's me writing this section) maintained it almost exclusively for the first two years.
-As such, I have the right to overrule any decision that was made by other maintainers.
-This also translates to a duty to do that with any decision that could end up harming the project in any form.
-On other words, the buck stops with me and, ultimately, I bare responsibility for all mistakes.
-(Moral responsibility, that is - legally, nobody has any responsibility. 😉)


### PR DESCRIPTION
It appears that we did this right and the only documentation of my special status was at the end of CONTRIBUTING.md. To make sure, I also searched for "Nicolai", "benevolent", and "dictator" but couldn't find any pertinent results. Would be nice for somebody else to take a closer look at whether I caught everything.

Proposed commit message:

```
Depose Nicolai as benevolent dictator (#683 / #684)

With the release of version 2.0, Nicolai no longer has any special
role in the maintainer team.

Closes: #683
PR: #684
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [x] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [x] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [x] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [x] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [x] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [x] The `package-info.java` contains information about the new extension

Code
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [x] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [x] The list of contributions inside `README.md` mentions the new contribution (real name optional) 
