### PR TITLE
Fix minor typos

### DIFF
--- a/.github/feature_request.md
+++ b/.github/feature_request.md
@@ -21,7 +21,7 @@ For example:
 - I tried to use extension Y to do X, but with the current implementation I can only do Z
 - I read about this fancy thing, Gradle can do now!
 
-**Please describe, what you would like to be changed / added / improved. If you want to add code or pseudo-code snippets, feel free to do so. If you have knowledge about possible side effects or problems or have considered any alternative solutions, please add information about them, too**
+**Please describe, what you would like to be changed / added / improved. If you want to add code or pseudocode snippets, feel free to do so. If you have knowledge about possible side effects or problems or have considered any alternative solutions, please add information about them, too**
 
 Example:
 - I would like to see the possibility to use a new annotation, maybe `@Fancy("value")` to do X

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -573,7 +573,7 @@ JUnit Pioneer uses semantic versioning, i.e. _major.minor.patch_ as follows:
 * _patch_: resets to 0 when _minor_ changes and increases otherwise
 
 The Javadoc `@since` tag can guide whether a change is non-trivial.
-If such a tag was added, _minor_ must increased - if not, it's up for debate (which is best held in a high-fidelity tool like Discord or Twitch chat).
+If such a tag was added, _minor_ must be increased - if not, it's up for debate (which is best held in a high-fidelity tool like Discord or Twitch chat).
 
 For contributors that means that when they add members that require such a tag, they should generally put the next _minor_ version next to it.
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ The least we can do is to thank them and list some of their accomplishments here
 * [Mathieu Fortin](https://github.com/mathieufortin01) contributed the `suspendForMs` attribute in [retrying tests](https://junit-pioneer.org/docs/retrying-test/) (#407 / #604)
 * [Pankaj Kumar](https://github.com/p1729) contributed towards improving GitHub actions (#587 / #611)
 * [Rob Spoor](https://github.com/robtimus) enabled non-static factory methods for `@CartesianTest.MethodFactory` (#628)
+* [Marc Wrobel](https://github.com/marcwrobel) improved the documentation (#692)
 
 #### 2021
 

--- a/src/demo/java/org/junitpioneer/jupiter/DefaultLocaleTimezoneExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/DefaultLocaleTimezoneExtensionDemo.java
@@ -22,7 +22,7 @@ public class DefaultLocaleTimezoneExtensionDemo {
 	// tag::default_locale_language[]
 	@Test
 	@DefaultLocale("zh-Hant-TW")
-	void test_with_lanuage() {
+	void test_with_language() {
 		assertThat(Locale.getDefault()).isEqualTo(Locale.forLanguageTag("zh-Hant-TW"));
 	}
 	// end::default_locale_language[]
@@ -30,19 +30,19 @@ public class DefaultLocaleTimezoneExtensionDemo {
 	// tag::default_locale_language_alternatives[]
 	@Test
 	@DefaultLocale(language = "en")
-	void test_with_lanuage_only() {
+	void test_with_language_only() {
 		assertThat(Locale.getDefault()).isEqualTo(new Locale("en"));
 	}
 
 	@Test
 	@DefaultLocale(language = "en", country = "EN")
-	void test_with_lanuage_and_country() {
+	void test_with_language_and_country() {
 		assertThat(Locale.getDefault()).isEqualTo(new Locale("en", "EN"));
 	}
 
 	@Test
 	@DefaultLocale(language = "en", country = "EN", variant = "gb")
-	void test_with_lanuage_and_country_and_vairant() {
+	void test_with_language_and_country_and_variant() {
 		assertThat(Locale.getDefault()).isEqualTo(new Locale("en", "EN", "gb"));
 	}
 	// end::default_locale_language_alternatives[]

--- a/src/demo/java/org/junitpioneer/jupiter/params/RangeSourcesDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/params/RangeSourcesDemo.java
@@ -30,7 +30,7 @@ public class RangeSourcesDemo {
 	@DoubleRangeSource(from = -0.1, to = -10, step = -0.1)
 	void howColdIsIt(double d) {
 		System.out.println(d + " °C is cold");
-		System.out.println(d + " °F is REALY cold");
+		System.out.println(d + " °F is REALLY cold");
 		System.out.println(d + " K is too cold to be true");
 	}
 	// end::rangesources_double_with_step[]

--- a/src/main/java/org/junitpioneer/jupiter/CartesianProductTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/CartesianProductTestExtension.java
@@ -199,8 +199,8 @@ class CartesianProductTestExtension implements TestTemplateInvocationContextProv
 	private CartesianProductTest.Sets invokeSetsFactory(Method testMethod, Method factory) {
 		CartesianProductTest.Sets sets = (CartesianProductTest.Sets) invokeMethod(factory, null);
 		if (sets.getSets().size() > testMethod.getParameterCount()) {
-			// If sets == parameters but one of the parameters should be auto-injected by JUnit
-			// JUnit will throw a ParameterResolutionException for competing resolvers before we could get to this line
+			// If sets == parameters but one of the parameters should be auto-injected by JUnit.
+			// JUnit will throw a ParameterResolutionException for competing resolvers before we could get to this line.
 			throw new ParameterResolutionException(format(
 				"Method `%s` must register values for each parameter exactly once. Expected [%d] parameter sets, but got [%d].",
 				factory, testMethod.getParameterCount(), sets.getSets().size()));

--- a/src/main/java/org/junitpioneer/jupiter/ClearEnvironmentVariable.java
+++ b/src/main/java/org/junitpioneer/jupiter/ClearEnvironmentVariable.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * {@code @ClearEnvironmentVariable} is a JUnit Jupiter extension to clear the value
- * of a environment variable for a test execution.
+ * of an environment variable for a test execution.
  *
  * <p>The key of the environment variable to be cleared must be specified via {@link #key()}.
  * After the annotated element has been executed, the original value or the value of the

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
@@ -68,7 +68,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public @interface DefaultLocale {
 
 	/**
-	 * An language tag string as specified by IETF BCP 47. See
+	 * A language tag string as specified by IETF BCP 47. See
 	 * {@link java.util.Locale#forLanguageTag(String)} for more information
 	 * about valid language tag values.
 	 *

--- a/src/main/java/org/junitpioneer/jupiter/SetEnvironmentVariable.java
+++ b/src/main/java/org/junitpioneer/jupiter/SetEnvironmentVariable.java
@@ -20,8 +20,8 @@ import java.lang.annotation.Target;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
- * {@code @SetEnvironmentVariable} is a JUnit Jupiter extension to set the value of a
- * environment variable for a test execution.
+ * {@code @SetEnvironmentVariable} is a JUnit Jupiter extension to set the value of
+ * an environment variable for a test execution.
  *
  * <p>The key and value of the environment variable to be set must be specified via
  * {@link #key()} and {@link #value()}. After the annotated method has been executed,

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianFactoryArgumentsProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianFactoryArgumentsProvider.java
@@ -94,8 +94,8 @@ class CartesianFactoryArgumentsProvider
 		ArgumentSets argumentSets = (ArgumentSets) invokeMethod(factory, target);
 		long count = argumentSets.getArguments().size();
 		if (count > testMethod.getParameterCount()) {
-			// If arguments count == parameters but one of the parameters should be auto-injected by JUnit
-			// JUnit will throw a ParameterResolutionException for competing resolvers before we could get to this line
+			// If arguments count == parameters but one of the parameters should be auto-injected by JUnit.
+			// JUnit will throw a ParameterResolutionException for competing resolvers before we could get to this line.
 			throw new ParameterResolutionException(format(
 				"Method `%s` must register values for each parameter exactly once. Expected [%d] parameter sets, but got [%d].",
 				factory, testMethod.getParameterCount(), count));

--- a/src/main/java/org/junitpioneer/jupiter/params/DisableIfAllArguments.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/DisableIfAllArguments.java
@@ -45,7 +45,7 @@ public @interface DisableIfAllArguments {
 
 	/**
 	 * Disable test cases if all arguments (converted to String with {@link Object#toString()})
-	 * contain any of the the specified strings (according to {@link String#contains(CharSequence)}).
+	 * contain any of the specified strings (according to {@link String#contains(CharSequence)}).
 	 */
 	String[] contains() default {};
 

--- a/src/main/java/org/junitpioneer/jupiter/params/DisableIfAnyArgument.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/DisableIfAnyArgument.java
@@ -45,7 +45,7 @@ public @interface DisableIfAnyArgument {
 
 	/**
 	 * Disable test cases if any argument (converted to String with {@link Object#toString()})
-	 * contains any of the the specified strings (according to {@link String#contains(CharSequence)}).
+	 * contains any of the specified strings (according to {@link String#contains(CharSequence)}).
 	 */
 	String[] contains() default {};
 

--- a/src/main/java/org/junitpioneer/jupiter/params/DisableIfArgument.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/DisableIfArgument.java
@@ -63,7 +63,7 @@ public @interface DisableIfArgument {
 
 	/**
 	 * Disable test cases whose argument (converted to String with {@link Object#toString()})
-	 * contains any of the the specified strings (according to {@link String#contains(CharSequence)}).
+	 * contains any of the specified strings (according to {@link String#contains(CharSequence)}).
 	 */
 	String[] contains() default {};
 

--- a/src/test/java/org/junitpioneer/internal/PioneerPreconditionsTests.java
+++ b/src/test/java/org/junitpioneer/internal/PioneerPreconditionsTests.java
@@ -113,7 +113,7 @@ class PioneerPreconditionsTests {
 
 	@Nested
 	@DisplayName("not empty with message")
-	class NotEmptyWithMessgeTests {
+	class NotEmptyWithMessageTests {
 
 		@Test
 		@DisplayName("should throw violation exception if collection is null")

--- a/src/test/java/org/junitpioneer/jupiter/cartesian/CartesianTestFactoryTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/cartesian/CartesianTestFactoryTests.java
@@ -90,8 +90,8 @@ public class CartesianTestFactoryTests {
 		}
 
 		@Test
-		@DisplayName("when factory is non-static with lifecyle PER_CLASS")
-		void nonStaticWithLifecylePerClass() {
+		@DisplayName("when factory is non-static with lifecycle PER_CLASS")
+		void nonStaticWithLifecyclePerClass() {
 			ExecutionResults results = PioneerTestKit
 					.executeNestedTestMethodWithParameterTypes(List.of(CorrectFactoryTestCases.class),
 						CorrectFactoryTestCases.PerClassLifecycle.class, "nonStatic", String.class, String.class);
@@ -199,8 +199,8 @@ public class CartesianTestFactoryTests {
 		}
 
 		@Test
-		@DisplayName("finds very explicitly specified class and non-static method with lifecyle PER_CLASS")
-		void findNonStaticExactWithLifecylePerClass() {
+		@DisplayName("finds very explicitly specified class and non-static method with lifecycle PER_CLASS")
+		void findNonStaticExactWithLifecyclePerClass() {
 			ExecutionResults results = PioneerTestKit
 					.executeNestedTestMethodWithParameterTypes(List.of(WrongFactoryTestCases.class),
 						WrongFactoryTestCases.PerClassLifecycle.class, "findsNonStaticExact", String.class,


### PR DESCRIPTION
Fix small typos in :
- various documentations,
- test method and class names,
- test strings,
- javadoc and comments.

Proposed commit message:

```
Fix various typos (#692)

This PR fixes various typos in

* documentations,
* test method and class names,
* test strings,
* Javadoc and comments.

PR: #692
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [x] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [x] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [x] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [x] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [x] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [x] The `package-info.java` contains information about the new extension

Code
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [x] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [x] The list of contributions inside `README.md` mentions the new contribution (real name optional) 
