### PR TITLE
Fix StdIo and ReportEntry to target ANNOTATION_TYPE

### DIFF
--- a/src/main/java/org/junitpioneer/jupiter/ReportEntry.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReportEntry.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @since 0.5.6
  */
 @Repeatable(ReportEntry.ReportEntries.class)
-@Target(ElementType.METHOD)
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(ReportEntryExtension.class)
 public @interface ReportEntry {

--- a/src/main/java/org/junitpioneer/jupiter/StdIo.java
+++ b/src/main/java/org/junitpioneer/jupiter/StdIo.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * @since 0.7
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @WritesStdIo
 @ExtendWith(StdIoExtension.class)
 public @interface StdIo {

--- a/src/test/java/org/junitpioneer/jupiter/ReportEntryExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/ReportEntryExtensionTests.java
@@ -18,6 +18,10 @@ import static org.junitpioneer.jupiter.ReportEntry.PublishCondition.ON_SUCCESS;
 import static org.junitpioneer.testkit.PioneerTestKit.abort;
 import static org.junitpioneer.testkit.assertion.PioneerAssert.assertThat;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Disabled;
@@ -88,6 +92,17 @@ public class ReportEntryExtensionTests {
 				.hasNumberOfReportEntries(3)
 				.withValues("suddenly there came a tapping", "As if some one gently rapping",
 					"rapping at my chamber door");
+	}
+
+	@Test
+	@DisplayName("works as a meta-annotation")
+	void metaAnnotation() {
+		ExecutionResults results = PioneerTestKit
+				.executeTestMethod(ReportEntryTestCases.class, "with_composed_annotation");
+
+		assertThat(results)
+				.hasNumberOfReportEntries(1)
+				.withValues("“Though thy crest be shorn and shaven, thou,” I said, “art sure no craven,");
 	}
 
 	@Nested
@@ -600,10 +615,21 @@ public class ReportEntryExtensionTests {
 		void parameterized_with_nulls(String line, String value) {
 		}
 
+		@Test
+		@ComposedEntry
+		void with_composed_annotation() {
+		}
+
 		private static Stream<Arguments> withNulls() {
 			return Stream.of(Arguments.of("By the grave and stern decorum of the countenance it wore,", null));
 		}
 
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.METHOD)
+	@ReportEntry("“Though thy crest be shorn and shaven, thou,” I said, “art sure no craven,")
+	@interface ComposedEntry {
 	}
 
 }

--- a/src/test/java/org/junitpioneer/jupiter/StdIoExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/StdIoExtensionTests.java
@@ -22,6 +22,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -54,6 +58,17 @@ public class StdIoExtensionTests {
 		@StdIo
 		@DisplayName("catches the output on the standard out as lines")
 		void catchesOut(StdOut out) {
+			app.write();
+
+			assertThat(out.capturedLines())
+					.containsExactly("Lo! in the orient when the gracious light",
+						"Lifts up his burning head, each under eye");
+		}
+
+		@Test
+		@ComposedIo
+		@DisplayName("works if StdIo is a meta-annotation")
+		void catchesOutFromMeta(StdOut out) {
 			app.write();
 
 			assertThat(out.capturedLines())
@@ -350,6 +365,12 @@ public class StdIoExtensionTests {
 			System.out.println("Attending on his golden pilgrimage:");
 		}
 
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.METHOD)
+	@StdIo
+	@interface ComposedIo {
 	}
 
 }


### PR DESCRIPTION
Proposed commit message:

```
 Fix StdIo and ReportEntry not targeting ANNOTATION_TYPE (#696 / #698)

This commit fixes the annotations @ReportEntry and @StdIo missing
the ANNOTATION_TYPE or TYPE from their @Target. They can now be used
on composed annotations.

Closes: #696
PR: #698
```

Closes #696