### PR TITLE
WIP Issue/574 sys props restore

### DIFF
--- a/src/main/java/org/junitpioneer/jupiter/AbstractEntryBasedExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/AbstractEntryBasedExtension.java
@@ -79,6 +79,12 @@ abstract class AbstractEntryBasedExtension<K, V, C extends Annotation, S extends
 			try {
 				entriesToClear = findEntriesToClear(element);
 				entriesToSet = findEntriesToSet(element);
+
+				//It seems like order is important here and shouldn't always be an error.
+				//If a prop is marked as cleared in a superclass and set on a method, this is OK, right?
+				//I think the intention here is for this to be OK (we are in a context loop), but I think
+				//the loop only applies to @Nested tests, not superclass/subclass relationships.
+				System.setProperties(null);
 				preventClearAndSetSameEntries(entriesToClear, entriesToSet.keySet());
 			}
 			catch (IllegalStateException ex) {

--- a/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
@@ -10,6 +10,8 @@
 
 package org.junitpioneer.jupiter;
 
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
@@ -66,6 +68,11 @@ class EnvironmentVariableExtension
 	@Override
 	protected void setEntry(String key, String value) {
 		EnvironmentVariableUtils.set(key, value);
+	}
+
+	@Override
+	protected Set<Map.Entry<Object, Object>> getAllEntries() {
+		return null;
 	}
 
 }

--- a/src/main/java/org/junitpioneer/jupiter/RestoreSystemProperties.java
+++ b/src/main/java/org/junitpioneer/jupiter/RestoreSystemProperties.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junitpioneer.jupiter;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.*;
+
+/**
+ * {@code @RestoreSystemProperties} is a JUnit Jupiter extension to restore the entire set of
+ * system properties to the original value, or the value of the higher-level container, after the
+ * annotated element has been executed.
+ *
+ * <p>Use this annotation when you need programmatically modify system properties in a test method
+ * or in {@code @BeforeAll} / {@code @BeforeEach} blocks.
+ * To simply set or clear a system property, consider {@link SetSystemProperty @SetSystemProperty} or
+ * {@link ClearSystemProperty @ClearSystemProperty} instead.
+ * </p>
+ *
+ * <p>{@code RestoreSystemProperties} can be used on the method and on the class level.
+ * When placed on a test method, system properties are stored before the method is run and restored
+ * after the method is complete.  Specifically, properties are stored after any {@code @BeforeAll}
+ * methods have run and before any {@code @BeforeEach} methods.</p>
+ *
+ * <p>When placed on a test class, system properties are stored before the test class runs and
+ * restored after the test class is complete, <em>in addition too</em> running before and after
+ * each test method just as if the annotation was on each method.  An advanced usage could include
+ * modifying some system properties in a {@code @BeforeAll} block to apply to all tests and
+ * additional property modifications within some tests themselves, all while safely restoring
+ * the state of the system properties after each test and after the entire test class.</p>
+ *
+ * <p>SetSystemProperty and ClearSystemProperty interaction....</p>
+ *
+ * <p>During
+ * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,
+ * all tests annotated with {@link RestoreSystemProperties}, {@link SetSystemProperty}, {@link ReadsSystemProperty}, and {@link WritesSystemProperty}
+ * are scheduled in a way that guarantees correctness under mutation of shared global state.
+ * </p>
+ *
+ * <p>For more details and examples, see
+ * <a href="https://junit-pioneer.org/docs/system-properties/" target="_top">the documentation on
+ * <code @ClearSystemProperty, @SetSystemProperty and @RestoreSystemProperties</code></a>.
+ * </p>
+ *
+ * <p>Note:  System properties are normally just strings, however, it is technically possible to bend the
+ * rules a bit to store other objects.  If this is your situation, be aware that this extension
+ * does a shallow copy of the system properties hashmap.</p>
+ *
+ * @since 0.5
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Inherited
+@WritesSystemProperty
+@ExtendWith(SystemPropertyExtension.class)
+public @interface RestoreSystemProperties {  }

--- a/src/main/java/org/junitpioneer/jupiter/SystemPropertyExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/SystemPropertyExtension.java
@@ -10,6 +10,9 @@
 
 package org.junitpioneer.jupiter;
 
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 import java.util.function.Function;
 
 class SystemPropertyExtension
@@ -43,6 +46,11 @@ class SystemPropertyExtension
 	@Override
 	protected void setEntry(String key, String value) {
 		System.setProperty(key, value);
+	}
+
+	@Override
+	protected Set<Entry<Object, Object>> getAllEntries() {
+		return System.getProperties().entrySet();
 	}
 
 }


### PR DESCRIPTION
WIP:  I intend to add documentation and much more testing (especially the interaction of set/clear/restore).
I put this PR in for initial feedback / sanity check.
All comments welcome - I already threw out one implementation that I decided was too ugly :-)

---

Add restore functionality to SystemProps & EnvironmentVars Extensions (#574 / ${pull-request})

To allow users to modify System.Properties and Env Vars directly in their test code outside of the existing
`set` and `clear` annotations, new `restore` annotations revert these resources to their pre-test state.
The new `restore` annotations can be used at the class or method level and the functionality was
added to the existing extension classes.  

Closes #574
PR: ${pull-request}

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [ ] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 
