### PR TITLE
Fix typo to let the warning render correctly on environment variables docs

### DIFF
--- a/docs/environment-variables.adoc
+++ b/docs/environment-variables.adoc
@@ -8,7 +8,7 @@ Both annotations work on the test method and class level, are repeatable, combin
 After the annotated method has been executed, the variables mentioned in the annotation will be restored to their original value or the value of the higher-level container, or will be cleared if they didn't have one before.
 Other environment variables that are changed during the test, are *not* restored.
 
-[WARNING]J
+[WARNING]
 ====
 Java considers environment variables to be immutable, so this extension uses reflection to change them.
 This requires that the `SecurityManager` allows modifications and can potentially break on different operating systems and Java versions.


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/2906988/214843993-a97bd6f4-8c26-4141-8ee7-3ace978266f3.png)

After (similar to):

![image](https://user-images.githubusercontent.com/2906988/214844023-9397d2af-20c5-43c6-9b43-4683f4895070.png)
