### PR TITLE
Update Java, plugins, and dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,11 +65,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          # we build the Javadoc with JDK 17 (for better results),
-          # so install that as well
-          java-version: |
-            17
-            11
+          java-version: 11
           distribution: temurin
           cache: 'gradle'
       - name: Cache SonarCloud results
@@ -199,7 +195,11 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          # we build the Javadoc with JDK 17 (for better results),
+          # so install that as well
+          java-version: |
+            17
+            11
           distribution: temurin
       - name: Perform release
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Main build
 
 env:
-  EXPERIMENTAL_JAVA: 20
+  EXPERIMENTAL_JAVA: 21
 
 on:
   # We want to trigger our builds all the time for the default branch
@@ -116,7 +116,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        java: [ 11, 17, 19 ]
+        java: [ 11, 17, 20 ]
         junit-version: [ '5.9.0' ]
         os: [ubuntu, macos, windows]
     name: with Java ${{ matrix.java }}, JUnit ${{ matrix.junit-version }} on ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,11 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: 11
+          # we build the Javadoc with JDK 17 (for better results),
+          # so install that as well
+          java-version: |
+            17
+            11
           distribution: temurin
           cache: 'gradle'
       - name: Cache SonarCloud results

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,7 +198,7 @@ jobs:
           # we build the Javadoc with JDK 17 (for better results),
           # so install that as well
           java-version: |
-            17
+            20
             11
           distribution: temurin
       - name: Perform release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11, 17, 20 ]
-        junit-version: [ '5.9.0' ]
+        junit-version: [ '5.9.2' ]
         os: [ubuntu, macos, windows]
     name: with Java ${{ matrix.java }}, JUnit ${{ matrix.junit-version }} on ${{ matrix.os }}
     steps:
@@ -145,7 +145,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        junit-version: [ '5.9.0' ]
+        junit-version: [ '5.9.2' ]
         os: [ubuntu, macos, windows]
     name: Experimental build with newest JDK early-access build and Gradle release candidate
     # Gradle doesn't work with JDK EA builds, so we launch it with a supported Java version,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -100,7 +100,7 @@ jacoco {
 	toolVersion = "0.8.9"
 }
 
-sonarqube {
+sonar {
 	// If you want to use this locally a sonarLogin has to be provided, either via Username and Password
 	// or via token, https://docs.sonarqube.org/latest/analysis/analysis-parameters/
 	properties {
@@ -200,7 +200,7 @@ tasks {
 		}
 	}
 	project(":demo") {
-		sonarqube {
+		sonar {
 			isSkipProject = true
 		}
 	}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ description = "JUnit 5 Extension Pack"
 
 val experimentalJavaVersion : String? by project
 val experimentalBuild: Boolean = experimentalJavaVersion?.isNotEmpty() ?: false
+val releaseBuild : Boolean = project.version != "unspecified"
 
 val targetJavaVersion = JavaVersion.VERSION_11
 
@@ -164,9 +165,7 @@ publishing {
 }
 
 signing {
-	setRequired({
-		project.version != "unspecified" && gradle.taskGraph.hasTask("publishToSonatype")
-	})
+	isRequired = releaseBuild
 	val signingKey: String? by project
 	val signingPassword: String? by project
 	useInMemoryPgpKeys(signingKey, signingPassword)
@@ -311,10 +310,12 @@ tasks {
 	}
 
 	javadoc {
-		javadocTool.set(project.javaToolchains.javadocToolFor {
-			// Create Javadoc with at least Java 17 to get the latest features, e.g. search bar
-			languageVersion.set(JavaLanguageVersion.of(maxOf(17, targetJavaVersion.majorVersion.toInt())))
-		})
+		if (releaseBuild) {
+			javadocTool.set(project.javaToolchains.javadocToolFor {
+				// Create Javadoc with at least Java 17 to get the latest features, e.g. search bar
+				languageVersion.set(JavaLanguageVersion.of(maxOf(17, targetJavaVersion.majorVersion.toInt())))
+			})
+		}
 
 		options {
 			// Cast to standard doclet options, see https://github.com/gradle/gradle/issues/7038#issuecomment-448294937

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -165,7 +165,7 @@ publishing {
 }
 
 signing {
-	isRequired = releaseBuild
+	isRequired = releaseBuild && gradle.taskGraph.hasTask("publishToSonatype")
 	val signingKey: String? by project
 	val signingPassword: String? by project
 	useInMemoryPgpKeys(signingKey, signingPassword)
@@ -312,7 +312,8 @@ tasks {
 	javadoc {
 		if (releaseBuild) {
 			javadocTool.set(project.javaToolchains.javadocToolFor {
-				// Create Javadoc with at least Java 17 to get the latest features, e.g. search bar
+				// create Javadoc with least Java version to get all features
+				// (e.g. search result page on 20)
 				languageVersion.set(JavaLanguageVersion.of(maxOf(20)))
 			})
 		}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -314,7 +314,7 @@ tasks {
 			javadocTool.set(project.javaToolchains.javadocToolFor {
 				// create Javadoc with least Java version to get all features
 				// (e.g. search result page on 20)
-				languageVersion.set(JavaLanguageVersion.of(maxOf(20)))
+				languageVersion.set(JavaLanguageVersion.of(20))
 			})
 		}
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,14 +4,14 @@ plugins {
 	checkstyle
 	`maven-publish`
 	signing
-	id("com.diffplug.spotless") version "6.4.2"
+	id("com.diffplug.spotless") version "6.18.0"
 	id("at.zierler.yamlvalidator") version "1.5.0"
-	id("org.sonarqube") version "3.3"
-	id("org.shipkit.shipkit-changelog") version "1.1.15"
-	id("org.shipkit.shipkit-github-release") version "1.1.15"
-	id("com.github.ben-manes.versions") version "0.42.0"
-	id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
-	id("org.gradlex.extra-java-module-info") version "1.0"
+	id("org.sonarqube") version "4.0.0.2929"
+	id("org.shipkit.shipkit-changelog") version "1.2.0"
+	id("org.shipkit.shipkit-github-release") version "1.2.0"
+	id("com.github.ben-manes.versions") version "0.46.0"
+	id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
+	id("org.gradlex.extra-java-module-info") version "1.3"
 }
 
 plugins.withType<JavaPlugin>().configureEach {
@@ -84,7 +84,7 @@ spotless {
 }
 
 checkstyle {
-	toolVersion = "10.2"
+	toolVersion = "10.9.3"
 	configDirectory.set(rootProject.file(".infra/checkstyle"))
 }
 
@@ -94,7 +94,7 @@ yamlValidator {
 }
 
 jacoco {
-	toolVersion = "0.8.8"
+	toolVersion = "0.8.9"
 }
 
 sonarqube {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,10 @@ repositories {
 }
 
 val junitVersion : String by project
-val jacksonVersion: String = "2.13.2.2"
+val jacksonVersion: String = "2.14.2"
+val assertjVersion: String = "3.24.2"
+val log4jVersion: String = "2.20.0"
+val jimfsVersion: String = "1.2"
 
 dependencies {
 	implementation(platform("org.junit:junit-bom:$junitVersion"))
@@ -61,13 +64,13 @@ dependencies {
 	testImplementation(group = "org.junit.jupiter", name = "junit-jupiter-engine")
 	testImplementation(group = "org.junit.platform", name = "junit-platform-testkit")
 
-	testImplementation(group = "org.assertj", name = "assertj-core", version = "3.22.0")
-	testImplementation(group = "org.mockito", name = "mockito-core", version = "4.4.0")
-	testImplementation(group = "com.google.jimfs", name = "jimfs", version = "1.2")
-	testImplementation(group = "nl.jqno.equalsverifier", name = "equalsverifier", version = "3.11.1")
+	testImplementation(group = "org.assertj", name = "assertj-core", version = assertjVersion)
+	testImplementation(group = "org.mockito", name = "mockito-core", version = "4.11.0")
+	testImplementation(group = "com.google.jimfs", name = "jimfs", version = jimfsVersion)
+	testImplementation(group = "nl.jqno.equalsverifier", name = "equalsverifier", version = "3.14.1")
 
-	testRuntimeOnly(group = "org.apache.logging.log4j", name = "log4j-core", version = "2.17.2")
-	testRuntimeOnly(group = "org.apache.logging.log4j", name = "log4j-jul", version = "2.17.2")
+	testRuntimeOnly(group = "org.apache.logging.log4j", name = "log4j-core", version = log4jVersion)
+	testRuntimeOnly(group = "org.apache.logging.log4j", name = "log4j-jul", version = log4jVersion)
 }
 
 spotless {
@@ -278,9 +281,9 @@ tasks {
 			val demoTests by registering(JvmTestSuite::class) {
 				dependencies {
 					implementation(project(project.path))
-					implementation("com.google.jimfs:jimfs:1.2")
+					implementation("com.google.jimfs:jimfs:$jimfsVersion")
 					implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
-					implementation("org.assertj:assertj-core:3.22.0")
+					implementation("org.assertj:assertj-core:$assertjVersion")
 				}
 
 				sources {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -313,7 +313,7 @@ tasks {
 		if (releaseBuild) {
 			javadocTool.set(project.javaToolchains.javadocToolFor {
 				// Create Javadoc with at least Java 17 to get the latest features, e.g. search bar
-				languageVersion.set(JavaLanguageVersion.of(maxOf(17, targetJavaVersion.majorVersion.toInt())))
+				languageVersion.set(JavaLanguageVersion.of(maxOf(20)))
 			})
 		}
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-junitVersion=5.9.0
+junitVersion=5.9.2
 
 # Ensure sufficient heap size, especially for Sonar.
 org.gradle.jvmargs=-Xmx8g

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/test/java/org/junitpioneer/internal/PioneerPreconditionsTests.java
+++ b/src/test/java/org/junitpioneer/internal/PioneerPreconditionsTests.java
@@ -128,8 +128,8 @@ class PioneerPreconditionsTests {
 		void emptyInput() {
 			assertThatThrownBy(
 				() -> PioneerPreconditions.notEmpty(Collections.emptySet(), "Collection must be provided"))
-						.isInstanceOf(PreconditionViolationException.class)
-						.hasMessage("Collection must be provided");
+					.isInstanceOf(PreconditionViolationException.class)
+					.hasMessage("Collection must be provided");
 		}
 
 		@Test

--- a/src/test/java/org/junitpioneer/internal/TestNameFormatterTests.java
+++ b/src/test/java/org/junitpioneer/internal/TestNameFormatterTests.java
@@ -88,10 +88,10 @@ public class TestNameFormatterTests {
 
 		assertThatThrownBy(
 			() -> formatter.format(0, Arrays.asList(Boolean.class, new int[] { 1, 2, 3 }, "enigma").toArray()))
-					.isInstanceOf(ExtensionConfigurationException.class)
-					.hasCauseExactlyInstanceOf(IllegalArgumentException.class)
-					.hasMessageContaining("The display name pattern defined for the "
-							+ TestNameFormatter.class.getName() + " is invalid.");
+				.isInstanceOf(ExtensionConfigurationException.class)
+				.hasCauseExactlyInstanceOf(IllegalArgumentException.class)
+				.hasMessageContaining(
+					"The display name pattern defined for the " + TestNameFormatter.class.getName() + " is invalid.");
 	}
 
 }

--- a/src/test/java/org/junitpioneer/jupiter/IssueTestCaseTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/IssueTestCaseTests.java
@@ -12,10 +12,10 @@ package org.junitpioneer.jupiter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-
 import org.junit.jupiter.api.Test;
 import org.junit.platform.engine.TestExecutionResult.Status;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 public final class IssueTestCaseTests {
 

--- a/src/test/java/org/junitpioneer/jupiter/IssueTestSuiteTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/IssueTestSuiteTests.java
@@ -10,10 +10,10 @@
 
 package org.junitpioneer.jupiter;
 
+import org.junit.jupiter.api.Test;
+
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
-
-import org.junit.jupiter.api.Test;
 
 class IssueTestSuiteTests {
 

--- a/src/test/java/org/junitpioneer/testkit/PioneerTestKitTests.java
+++ b/src/test/java/org/junitpioneer/testkit/PioneerTestKitTests.java
@@ -76,7 +76,7 @@ class PioneerTestKitTests {
 		void executeTestMethodWithParameterTypes_parameterArrayIsNull_NullPointerException() {
 			assertThatThrownBy(() -> PioneerTestKit
 					.executeTestMethodWithParameterTypes(DummyPropertyClass.class, "single", (Class<?>) null))
-							.isInstanceOf(NullPointerException.class);
+					.isInstanceOf(NullPointerException.class);
 		}
 
 		@Test
@@ -84,8 +84,8 @@ class PioneerTestKitTests {
 		void executeTestMethodWithParameterTypes_singleParameterIsNull_IllegalArgumentException() {
 			assertThatThrownBy(() -> PioneerTestKit
 					.executeTestMethodWithParameterTypes(DummyPropertyClass.class, "single", (Class<?>[]) null))
-							.isInstanceOf(IllegalArgumentException.class)
-							.hasMessage("methodParameterTypes must not be null");
+					.isInstanceOf(IllegalArgumentException.class)
+					.hasMessage("methodParameterTypes must not be null");
 		}
 
 	}


### PR DESCRIPTION
Closes #729, closes #726.

Proposed commit message:

```
Update Gradle, Java, plugins, and dependencies (#729, #726 / #727)

* Gradle: 7.6 ~> 8.1
* Java:
	* regular build: 19 ~> 20 
	* experimental build: 20 ~> 21
	* include 20 in release build to make Javadoc 20 available
	  (and remove the need for multiple Java versions from all
	  other builds to make them simpler and faster)
* all plugins
	* updating Jacoco to 0.8.9 removed an error on JDK 20
* all dependencies
	* stick to same minor JUnit version because that's our policy
	* stick to same major Mockito version because the build failed
	  with 5.2.0

Closes: #729, #726
PR: #727
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [x] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [x] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [x] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [x] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [x] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [x] The `package-info.java` contains information about the new extension

Code
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [x] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [x] The list of contributions inside `README.md` mentions the new contribution (real name optional) 
