### PR TITLE
Add time data to issue report if test is annotated with @Stopwatch

### DIFF
--- a/docs/issue.adoc
+++ b/docs/issue.adoc
@@ -56,10 +56,15 @@ For further information about that, see https://docs.oracle.com/javase/8/docs/ap
 
 The exact API has two classes:
 
- - `IssueTestSuite`, which represents a single issue and all related tests.
- - `IssueTestCase`, which represents a single test.
+- `IssueTestSuite`, which represents a single issue and all related tests.
+- `IssueTestCase`, which represents a single test.
 
-`IssueTestCase` contains the result of the test, the unique identifier of the test and (optionally) the time it take to execute the test.
+`IssueTestCase` contains:
+
+- the result of the test
+- the unique identifier of the test
+- the time it took to execute the test (optionally)
+
 The time information is only available if the test is annotated with `@Stopwatch`.
 For more information, see the link:/docs/stopwatch.adoc[@Stopwatch documentation].
 

--- a/docs/issue.adoc
+++ b/docs/issue.adoc
@@ -54,6 +54,15 @@ The implementing class must be registered as a service.
 For further information about that, see https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html[the `ServiceLoader` documentation].
 ====
 
+The exact API has two classes:
+
+ - `IssueTestSuite`, which represents a single issue and all related tests.
+ - `IssueTestCase`, which represents a single test.
+
+`IssueTestCase` contains the result of the test, the unique identifier of the test and (optionally) the time it take to execute the test.
+The time information is only available if the test is annotated with `@Stopwatch`.
+For more information, see the link:/docs/stopwatch.adoc[@Stopwatch documentation].
+
 == Thread-Safety
 
 This extension is safe to use during https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution[parallel test execution].

--- a/src/main/java/org/junitpioneer/jupiter/IssueTestCase.java
+++ b/src/main/java/org/junitpioneer/jupiter/IssueTestCase.java
@@ -33,19 +33,35 @@ public final class IssueTestCase {
 
 	private final String testId;
 	private final Status result;
-	private final Long elapsedTime;
+	// no `OptionalLong` because its API doesn't have `map`
+	private final Optional<Long> elapsedTime;
 
 	/**
-	 * Constructor with all attributes.
-	 *
+	 * @param testId Unique name of the test method
+	 * @param result Result of the execution
+	 * @param elapsedTime The (optional) duration of test execution
+	 */
+	public IssueTestCase(String testId, Status result, Optional<Long> elapsedTime) {
+		this.testId = requireNonNull(testId);
+		this.result = requireNonNull(result, NO_RESULT_EXCEPTION_MESSAGE);
+		this.elapsedTime = elapsedTime;
+	}
+
+	/**
+	 * @param testId Unique name of the test method
+	 * @param result Result of the execution
+	 */
+	public IssueTestCase(String testId, Status result) {
+		this(testId, result, Optional.empty());
+	}
+
+	/**
 	 * @param testId Unique name of the test method
 	 * @param result Result of the execution
 	 * @param elapsedTime The duration of test execution
 	 */
-	public IssueTestCase(String testId, Status result, Long elapsedTime) {
-		this.testId = requireNonNull(testId);
-		this.result = requireNonNull(result, NO_RESULT_EXCEPTION_MESSAGE);
-		this.elapsedTime = elapsedTime;
+	public IssueTestCase(String testId, Status result, long elapsedTime) {
+		this(testId, result, Optional.of(elapsedTime));
 	}
 
 	/**
@@ -72,7 +88,7 @@ public final class IssueTestCase {
 	 * @return The elapsed time in ms.
 	 */
 	public Optional<Long> elapsedTime() {
-		return Optional.ofNullable(elapsedTime);
+		return elapsedTime;
 	}
 
 	@Override
@@ -93,8 +109,8 @@ public final class IssueTestCase {
 	@Override
 	public String toString() {
 		String value = "IssueTestCase{" + "uniqueName='" + testId + '\'' + ", result='" + result + '\'';
-		if (Objects.nonNull(elapsedTime)) {
-			value = value + ", elapsedTime='" + elapsedTime + " ms'";
+		if (elapsedTime.isPresent()) {
+			value = value + ", elapsedTime='" + elapsedTime.get() + " ms'";
 		}
 		return value + '}';
 	}

--- a/src/main/java/org/junitpioneer/jupiter/IssueTestCase.java
+++ b/src/main/java/org/junitpioneer/jupiter/IssueTestCase.java
@@ -13,6 +13,7 @@ package org.junitpioneer.jupiter;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import org.junit.platform.engine.TestExecutionResult.Status;
 
@@ -33,15 +34,18 @@ public final class IssueTestCase {
 	private final String testId;
 	private final Status result;
 
+	private final Long elapsedTime;
+
 	/**
 	 * Constructor with all attributes.
 	 *
 	 * @param testId Unique name of the test method
 	 * @param result Result of the execution
 	 */
-	public IssueTestCase(String testId, Status result) {
+	public IssueTestCase(String testId, Status result, Long elapsedTime) {
 		this.testId = requireNonNull(testId);
 		this.result = requireNonNull(result, NO_RESULT_EXCEPTION_MESSAGE);
+		this.elapsedTime = elapsedTime;
 	}
 
 	/**
@@ -61,6 +65,15 @@ public final class IssueTestCase {
 		return result;
 	}
 
+	/**
+	 * Returns the elapsed time since the start of test methods' execution in milliseconds.
+	 *
+	 * @return The elapsed time in ms.
+	 */
+	public Optional<Long> elapsedTime() {
+		return Optional.ofNullable(elapsedTime);
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o)
@@ -68,16 +81,20 @@ public final class IssueTestCase {
 		if (!(o instanceof IssueTestCase))
 			return false;
 		IssueTestCase that = (IssueTestCase) o;
-		return testId.equals(that.testId) && result == that.result;
+		return testId.equals(that.testId) && result == that.result && Objects.equals(elapsedTime, that.elapsedTime);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(testId, result);
+		return Objects.hash(testId, result, elapsedTime);
 	}
 
 	@Override
 	public String toString() {
+		if (Objects.nonNull(elapsedTime)) {
+			return "IssueTestCase{" + "uniqueName='" + testId + '\'' + ", result='" + result + '\'' + ", elapsedTime='"
+					+ elapsedTime + " ms'}";
+		}
 		return "IssueTestCase{" + "uniqueName='" + testId + '\'' + ", result='" + result + '\'' + '}';
 	}
 

--- a/src/main/java/org/junitpioneer/jupiter/IssueTestCase.java
+++ b/src/main/java/org/junitpioneer/jupiter/IssueTestCase.java
@@ -33,7 +33,6 @@ public final class IssueTestCase {
 
 	private final String testId;
 	private final Status result;
-
 	private final Long elapsedTime;
 
 	/**
@@ -41,6 +40,7 @@ public final class IssueTestCase {
 	 *
 	 * @param testId Unique name of the test method
 	 * @param result Result of the execution
+	 * @param elapsedTime The duration of test execution
 	 */
 	public IssueTestCase(String testId, Status result, Long elapsedTime) {
 		this.testId = requireNonNull(testId);
@@ -50,6 +50,7 @@ public final class IssueTestCase {
 
 	/**
 	 * Returns the unique name of the test method.
+	 *
 	 * @return Unique name of the test method
 	 */
 	public String testId() {
@@ -91,11 +92,11 @@ public final class IssueTestCase {
 
 	@Override
 	public String toString() {
+		String value = "IssueTestCase{" + "uniqueName='" + testId + '\'' + ", result='" + result + '\'';
 		if (Objects.nonNull(elapsedTime)) {
-			return "IssueTestCase{" + "uniqueName='" + testId + '\'' + ", result='" + result + '\'' + ", elapsedTime='"
-					+ elapsedTime + " ms'}";
+			value = value + ", elapsedTime='" + elapsedTime + " ms'";
 		}
-		return "IssueTestCase{" + "uniqueName='" + testId + '\'' + ", result='" + result + '\'' + '}';
+		return value + '}';
 	}
 
 }

--- a/src/main/java/org/junitpioneer/jupiter/IssueTestCase.java
+++ b/src/main/java/org/junitpioneer/jupiter/IssueTestCase.java
@@ -97,7 +97,7 @@ public final class IssueTestCase {
 			return true;
 		if (!(o instanceof IssueTestCase))
 			return false;
-		IssueTestCase that = (IssueTestCase) o;
+		var that = (IssueTestCase) o;
 		return testId.equals(that.testId) && result == that.result && Objects.equals(elapsedTime, that.elapsedTime);
 	}
 
@@ -108,9 +108,9 @@ public final class IssueTestCase {
 
 	@Override
 	public String toString() {
-		String value = "IssueTestCase{" + "uniqueName='" + testId + '\'' + ", result='" + result + '\'';
+		var value = "IssueTestCase{" + "uniqueName='" + testId + '\'' + ", result='" + result + '\'';
 		if (elapsedTime.isPresent()) {
-			value = value + ", elapsedTime='" + elapsedTime.get() + " ms'";
+			value += ", elapsedTime='" + elapsedTime.get() + " ms'";
 		}
 		return value + '}';
 	}

--- a/src/main/java/org/junitpioneer/jupiter/StopwatchExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/StopwatchExtension.java
@@ -18,9 +18,7 @@ import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
 import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
-import org.junit.platform.commons.support.AnnotationSupport;
 import org.junitpioneer.internal.PioneerAnnotationUtils;
-import org.junitpioneer.jupiter.issue.IssueExtensionExecutionListener;
 
 /**
  * The StopwatchExtension implements callback methods for the {@code @Stopwatch} annotation.

--- a/src/main/java/org/junitpioneer/jupiter/StopwatchExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/StopwatchExtension.java
@@ -10,12 +10,17 @@
 
 package org.junitpioneer.jupiter;
 
+import static org.junitpioneer.jupiter.issue.IssueExtensionExecutionListener.TIME_REPORT_KEY;
+
 import java.time.Clock;
 
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
 import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.platform.commons.support.AnnotationSupport;
+import org.junitpioneer.internal.PioneerAnnotationUtils;
+import org.junitpioneer.jupiter.issue.IssueExtensionExecutionListener;
 
 /**
  * The StopwatchExtension implements callback methods for the {@code @Stopwatch} annotation.
@@ -33,7 +38,16 @@ class StopwatchExtension implements BeforeTestExecutionCallback, AfterTestExecut
 
 	@Override
 	public void afterTestExecution(ExtensionContext context) {
-		calculateAndReportElapsedTime(context);
+		long elapsedTime = calculateElapsedTime(context);
+		reportElapsedTime(context, elapsedTime);
+	}
+
+	private static void reportElapsedTime(ExtensionContext context, long elapsedTime) {
+		String message = String.format("Execution of '%s' took [%d] ms.", context.getDisplayName(), elapsedTime);
+		context.publishReportEntry(STORE_KEY, message);
+		if (PioneerAnnotationUtils.isAnnotationPresent(context, Issue.class)) {
+			context.publishReportEntry(TIME_REPORT_KEY, String.valueOf(elapsedTime));
+		}
 	}
 
 	private void storeNowAsLaunchTime(ExtensionContext context) {
@@ -44,12 +58,9 @@ class StopwatchExtension implements BeforeTestExecutionCallback, AfterTestExecut
 		return context.getStore(NAMESPACE).get(context.getUniqueId(), long.class);
 	}
 
-	private void calculateAndReportElapsedTime(ExtensionContext context) {
+	private long calculateElapsedTime(ExtensionContext context) {
 		long launchTime = loadLaunchTime(context);
-		long elapsedTime = clock.instant().toEpochMilli() - launchTime;
-
-		String message = String.format("Execution of '%s' took [%d] ms.", context.getDisplayName(), elapsedTime);
-		context.publishReportEntry(STORE_KEY, message);
+		return clock.instant().toEpochMilli() - launchTime;
 	}
 
 }

--- a/src/main/java/org/junitpioneer/jupiter/issue/IssueExtensionExecutionListener.java
+++ b/src/main/java/org/junitpioneer/jupiter/issue/IssueExtensionExecutionListener.java
@@ -15,7 +15,6 @@ import static java.util.stream.Collectors.toUnmodifiableList;
 import static org.junit.platform.engine.TestExecutionResult.Status;
 
 import java.util.List;
-import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -60,7 +59,8 @@ public class IssueExtensionExecutionListener implements TestExecutionListener {
 		var messages = entry.getKeyValuePairs();
 		var testId = testIdentifier.getUniqueId();
 		// because test IDs are unique, we can be sure that the report entries belong to the same test
-		var testCaseBuilder = testCases.getOrDefault(testId, new IssueTestCaseBuilder(testId));
+		testCases.putIfAbsent(testId, new IssueTestCaseBuilder(testId));
+		var testCaseBuilder = testCases.get(testId);
 
 		if (messages.containsKey(REPORT_ENTRY_KEY)) {
 			var issueId = messages.get(REPORT_ENTRY_KEY);

--- a/src/main/java/org/junitpioneer/jupiter/issue/IssueExtensionExecutionListener.java
+++ b/src/main/java/org/junitpioneer/jupiter/issue/IssueExtensionExecutionListener.java
@@ -59,8 +59,7 @@ public class IssueExtensionExecutionListener implements TestExecutionListener {
 		var messages = entry.getKeyValuePairs();
 		var testId = testIdentifier.getUniqueId();
 		// because test IDs are unique, we can be sure that the report entries belong to the same test
-		testCases.putIfAbsent(testId, new IssueTestCaseBuilder(testId));
-		var testCaseBuilder = testCases.get(testId);
+		var testCaseBuilder = testCases.computeIfAbsent(testId, IssueTestCaseBuilder::new);
 
 		if (messages.containsKey(REPORT_ENTRY_KEY)) {
 			var issueId = messages.get(REPORT_ENTRY_KEY);

--- a/src/main/java/org/junitpioneer/jupiter/issue/IssueExtensionExecutionListener.java
+++ b/src/main/java/org/junitpioneer/jupiter/issue/IssueExtensionExecutionListener.java
@@ -37,7 +37,6 @@ import org.junitpioneer.jupiter.IssueTestSuite;
 public class IssueExtensionExecutionListener implements TestExecutionListener {
 
 	public static final String REPORT_ENTRY_KEY = "IssueExtension";
-
 	public static final String TIME_REPORT_KEY = "IssueExtensionTimeReport";
 
 	/**
@@ -58,21 +57,18 @@ public class IssueExtensionExecutionListener implements TestExecutionListener {
 		if (!active)
 			return;
 
-		String testId = testIdentifier.getUniqueId();
-		Map<String, String> messages = entry.getKeyValuePairs();
+		var messages = entry.getKeyValuePairs();
+		var testId = testIdentifier.getUniqueId();
+		// because test IDs are unique, we can be sure that the report entries belong to the same test
+		var testCaseBuilder = testCases.getOrDefault(testId, new IssueTestCaseBuilder(testId));
 
 		if (messages.containsKey(REPORT_ENTRY_KEY)) {
-			String issueId = messages.get(REPORT_ENTRY_KEY);
-			// because test IDs are unique, we can be sure that the report entries belong to the same test
-			// but because we can't be sure which extension gets invoked first (stopwatch or issue)
-			// we have to make sure not to erase previously recorded information
-			testCases.computeIfPresent(testId, (__, builder) -> builder.setIssueId(issueId));
-			testCases.putIfAbsent(testId, new IssueTestCaseBuilder(testId).setIssueId(issueId));
+			var issueId = messages.get(REPORT_ENTRY_KEY);
+			testCaseBuilder.setIssueId(issueId);
 		}
 		if (messages.containsKey(TIME_REPORT_KEY)) {
-			long elapsedTime = Long.parseLong(messages.get(TIME_REPORT_KEY));
-			testCases.computeIfPresent(testId, (__, builder) -> builder.setElapsedTime(elapsedTime));
-			testCases.putIfAbsent(testId, new IssueTestCaseBuilder(testId).setElapsedTime(elapsedTime));
+			var elapsedTime = Long.parseLong(messages.get(TIME_REPORT_KEY));
+			testCaseBuilder.setElapsedTime(elapsedTime);
 		}
 	}
 

--- a/src/main/java/org/junitpioneer/jupiter/issue/IssueTestCaseBuilder.java
+++ b/src/main/java/org/junitpioneer/jupiter/issue/IssueTestCaseBuilder.java
@@ -13,12 +13,15 @@ package org.junitpioneer.jupiter.issue;
 import org.junit.platform.engine.TestExecutionResult.Status;
 import org.junitpioneer.jupiter.IssueTestCase;
 
+import java.util.Optional;
+
 class IssueTestCaseBuilder {
 
 	private final String testId;
+
+	// all of these can be null
 	private String issueId;
 	private Status result;
-
 	private Long elapsedTime;
 
 	public IssueTestCaseBuilder(String testId) {
@@ -45,7 +48,7 @@ class IssueTestCaseBuilder {
 	}
 
 	public IssueTestCase build() {
-		return new IssueTestCase(testId, result, elapsedTime);
+		return new IssueTestCase(testId, result, Optional.ofNullable(elapsedTime));
 	}
 
 }

--- a/src/main/java/org/junitpioneer/jupiter/issue/IssueTestCaseBuilder.java
+++ b/src/main/java/org/junitpioneer/jupiter/issue/IssueTestCaseBuilder.java
@@ -19,12 +19,19 @@ class IssueTestCaseBuilder {
 	private String issueId;
 	private Status result;
 
+	private Long elapsedTime;
+
 	public IssueTestCaseBuilder(String testId) {
 		this.testId = testId;
 	}
 
 	public IssueTestCaseBuilder setResult(Status result) {
 		this.result = result;
+		return this;
+	}
+
+	public IssueTestCaseBuilder setElapsedTime(long elapsedTime) {
+		this.elapsedTime = elapsedTime;
 		return this;
 	}
 
@@ -38,7 +45,7 @@ class IssueTestCaseBuilder {
 	}
 
 	public IssueTestCase build() {
-		return new IssueTestCase(testId, result);
+		return new IssueTestCase(testId, result, elapsedTime);
 	}
 
 }

--- a/src/main/java/org/junitpioneer/jupiter/issue/IssueTestCaseBuilder.java
+++ b/src/main/java/org/junitpioneer/jupiter/issue/IssueTestCaseBuilder.java
@@ -10,10 +10,10 @@
 
 package org.junitpioneer.jupiter.issue;
 
+import java.util.Optional;
+
 import org.junit.platform.engine.TestExecutionResult.Status;
 import org.junitpioneer.jupiter.IssueTestCase;
-
-import java.util.Optional;
 
 class IssueTestCaseBuilder {
 

--- a/src/test/java/org/junitpioneer/jupiter/IssueTestCaseTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/IssueTestCaseTests.java
@@ -22,7 +22,17 @@ public final class IssueTestCaseTests {
 	@Test
 	void testToString() {
 		String expected = "IssueTestCase{uniqueName='myName', result='SUCCESSFUL'}";
-		IssueTestCase sut = new IssueTestCase("myName", Status.SUCCESSFUL);
+		IssueTestCase sut = new IssueTestCase("myName", Status.SUCCESSFUL, null);
+
+		String result = sut.toString();
+
+		assertThat(result).isEqualTo(expected);
+	}
+
+	@Test
+	void testToStringWithTime() {
+		String expected = "IssueTestCase{uniqueName='myName', result='SUCCESSFUL', elapsedTime='0 ms'}";
+		IssueTestCase sut = new IssueTestCase("myName", Status.SUCCESSFUL, 0L);
 
 		String result = sut.toString();
 
@@ -31,7 +41,7 @@ public final class IssueTestCaseTests {
 
 	@Test
 	public void equalsContract() {
-		EqualsVerifier.forClass(IssueTestCase.class).withNonnullFields("testId", "result").verify();
+		EqualsVerifier.forClass(IssueTestCase.class).withNonnullFields("testId", "result", "elapsedTime").verify();
 	}
 
 }

--- a/src/test/java/org/junitpioneer/jupiter/IssueTestCaseTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/IssueTestCaseTests.java
@@ -22,7 +22,7 @@ public final class IssueTestCaseTests {
 	@Test
 	void testToString() {
 		String expected = "IssueTestCase{uniqueName='myName', result='SUCCESSFUL'}";
-		IssueTestCase sut = new IssueTestCase("myName", Status.SUCCESSFUL, null);
+		IssueTestCase sut = new IssueTestCase("myName", Status.SUCCESSFUL);
 
 		String result = sut.toString();
 

--- a/src/test/java/org/junitpioneer/jupiter/issue/IssueExtensionExecutionListenerTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/issue/IssueExtensionExecutionListenerTests.java
@@ -94,7 +94,7 @@ public class IssueExtensionExecutionListenerTests {
 			() -> assertThat(issueTestSuite.tests().size()).isEqualTo(1));
 
 		assertThat(issueTestSuite.tests())
-				.containsExactly(new IssueTestCase("[test:aborted-test]", Status.ABORTED, null));
+				.containsExactly(new IssueTestCase("[test:aborted-test]", Status.ABORTED));
 	}
 
 	@Test
@@ -121,8 +121,8 @@ public class IssueExtensionExecutionListenerTests {
 			() -> assertThat(issueTestSuite.tests().size()).isEqualTo(2));
 
 		assertThat(issueTestSuite.tests())
-				.containsExactlyInAnyOrder(new IssueTestCase("[test:successful-test]", Status.SUCCESSFUL, null),
-					new IssueTestCase("[test:aborted-test]", Status.ABORTED, null));
+				.containsExactlyInAnyOrder(new IssueTestCase("[test:successful-test]", Status.SUCCESSFUL),
+					new IssueTestCase("[test:aborted-test]", Status.ABORTED));
 	}
 
 }

--- a/src/test/java/org/junitpioneer/jupiter/issue/IssueExtensionExecutionListenerTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/issue/IssueExtensionExecutionListenerTests.java
@@ -13,6 +13,7 @@ package org.junitpioneer.jupiter.issue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junitpioneer.jupiter.issue.IssueExtensionExecutionListener.REPORT_ENTRY_KEY;
+import static org.junitpioneer.jupiter.issue.IssueExtensionExecutionListener.TIME_REPORT_KEY;
 import static org.junitpioneer.jupiter.issue.TestPlanHelper.createTestIdentifier;
 import static org.mockito.Mockito.mock;
 
@@ -51,10 +52,12 @@ public class IssueExtensionExecutionListenerTests {
 	@Test
 	void issueTestCasesCreated() {
 		ReportEntry issueEntry = ReportEntry.from(REPORT_ENTRY_KEY, "#123");
+		ReportEntry timeEntry = ReportEntry.from(TIME_REPORT_KEY, "6");
 		TestIdentifier successfulTest = createTestIdentifier("successful-test");
 
 		executionListener.testPlanExecutionStarted(testPlan);
 		executionListener.reportingEntryPublished(successfulTest, issueEntry);
+		executionListener.reportingEntryPublished(successfulTest, timeEntry);
 		executionListener.executionStarted(successfulTest);
 		executionListener.executionFinished(successfulTest, TestExecutionResult.successful());
 		executionListener.testPlanExecutionFinished(testPlan);
@@ -68,7 +71,7 @@ public class IssueExtensionExecutionListenerTests {
 			() -> assertThat(issueTestSuite.tests().size()).isEqualTo(1));
 
 		assertThat(issueTestSuite.tests())
-				.containsExactly(new IssueTestCase("[test:successful-test]", Status.SUCCESSFUL));
+				.containsExactly(new IssueTestCase("[test:successful-test]", Status.SUCCESSFUL, 6L));
 	}
 
 	@Test
@@ -90,7 +93,8 @@ public class IssueExtensionExecutionListenerTests {
 		assertAll(() -> assertThat(issueTestSuite.issueId()).isEqualTo("#123"),
 			() -> assertThat(issueTestSuite.tests().size()).isEqualTo(1));
 
-		assertThat(issueTestSuite.tests()).containsExactly(new IssueTestCase("[test:aborted-test]", Status.ABORTED));
+		assertThat(issueTestSuite.tests())
+				.containsExactly(new IssueTestCase("[test:aborted-test]", Status.ABORTED, null));
 	}
 
 	@Test
@@ -117,8 +121,8 @@ public class IssueExtensionExecutionListenerTests {
 			() -> assertThat(issueTestSuite.tests().size()).isEqualTo(2));
 
 		assertThat(issueTestSuite.tests())
-				.containsExactlyInAnyOrder(new IssueTestCase("[test:successful-test]", Status.SUCCESSFUL),
-					new IssueTestCase("[test:aborted-test]", Status.ABORTED));
+				.containsExactlyInAnyOrder(new IssueTestCase("[test:successful-test]", Status.SUCCESSFUL, null),
+					new IssueTestCase("[test:aborted-test]", Status.ABORTED, null));
 	}
 
 }

--- a/src/test/java/org/junitpioneer/jupiter/issue/IssueExtensionExecutionListenerTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/issue/IssueExtensionExecutionListenerTests.java
@@ -93,8 +93,7 @@ public class IssueExtensionExecutionListenerTests {
 		assertAll(() -> assertThat(issueTestSuite.issueId()).isEqualTo("#123"),
 			() -> assertThat(issueTestSuite.tests().size()).isEqualTo(1));
 
-		assertThat(issueTestSuite.tests())
-				.containsExactly(new IssueTestCase("[test:aborted-test]", Status.ABORTED));
+		assertThat(issueTestSuite.tests()).containsExactly(new IssueTestCase("[test:aborted-test]", Status.ABORTED));
 	}
 
 	@Test

--- a/src/test/java/org/junitpioneer/jupiter/issue/IssueExtensionIntegrationTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/issue/IssueExtensionIntegrationTests.java
@@ -10,11 +10,11 @@
 
 package org.junitpioneer.jupiter.issue;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.junitpioneer.testkit.PioneerTestKit.abort;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/org/junitpioneer/jupiter/issue/IssueExtensionIntegrationTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/issue/IssueExtensionIntegrationTests.java
@@ -10,11 +10,11 @@
 
 package org.junitpioneer.jupiter.issue;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.*;
 import static org.junitpioneer.testkit.PioneerTestKit.abort;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -27,6 +27,8 @@ import org.junit.platform.launcher.core.LauncherFactory;
 import org.junitpioneer.jupiter.Issue;
 import org.junitpioneer.jupiter.IssueTestCase;
 import org.junitpioneer.jupiter.IssueTestSuite;
+import org.junitpioneer.jupiter.Stopwatch;
+import org.opentest4j.AssertionFailedError;
 
 /**
  * Mary Elizabeth Fyre: Do Not Stand at My Grave and Weep is in the public domain.
@@ -44,10 +46,17 @@ public class IssueExtensionIntegrationTests {
 
 		List<IssueTestSuite> issueTestSuites = StoringIssueProcessor.ISSUE_TEST_SUITES;
 
-		assertThat(issueTestSuites).hasSize(3);
+		assertThat(issueTestSuites).hasSize(4);
 		assertThat(issueTestSuites)
 				.extracting(IssueTestSuite::issueId)
-				.containsExactlyInAnyOrder("Poem #1", "Poem #2", "Poem #3");
+				.containsExactlyInAnyOrder("Poem #1", "Poem #2", "Poem #3", "Poem #5");
+		IssueTestSuite firstSuite = issueTestSuites
+				.stream()
+				.filter(issueTestSuite -> issueTestSuite.issueId().equals("Poem #1"))
+				.findFirst()
+				.orElseThrow(AssertionFailedError::new);
+
+		assertThat(firstSuite.tests()).hasSize(2);
 		assertThat(issueTestSuites)
 				.allSatisfy(issueTestSuite -> assertThat(issueTestSuite.tests())
 						.allSatisfy(IssueExtensionIntegrationTests::assertStatus));
@@ -60,39 +69,51 @@ public class IssueExtensionIntegrationTests {
 			assertThat(testCase.result()).isEqualTo(Status.ABORTED);
 		if (testCase.testId().contains("failing"))
 			assertThat(testCase.result()).isEqualTo(Status.FAILED);
+		if (testCase.testId().contains("Stopwatch")) {
+			assertThat(testCase.elapsedTime()).isNotEmpty();
+		} else {
+			assertThat(testCase.elapsedTime()).isEmpty();
+		}
 	}
 
 	static class IssueIntegrationTestCases {
 
 		@Test
 		@Issue("Poem #1")
-		@DisplayName("Do not stand at my grave and weep. I am not there. I do not sleep.")
+		@DisplayName("Do not stand at my grave and weep.")
 		void successfulTest() {
 		}
 
 		@Test
+		@Stopwatch
 		@Issue("Poem #1")
+		@DisplayName("I am not there. I do not sleep.")
+		void successfulWithStopwatch() {
+		}
+
+		@Test
+		@Issue("Poem #2")
 		@DisplayName("I am a thousand winds that blow. I am the diamond glints on snow.")
 		void failingTest() {
 			fail("supposed to fail");
 		}
 
 		@Test
-		@Issue("Poem #2")
+		@Issue("Poem #3")
 		@DisplayName("I am the sunlight on ripened grain. I am the gentle autumn rain.")
 		void abortedTest() {
 			abort();
 		}
 
 		@Test
-		@Issue("Poem #2")
+		@Issue("Poem #4")
 		@Disabled("skipped")
 		@DisplayName("When you awaken in the morning's hush, I am the swift uplifting rush")
 		void skippedTest() {
 		}
 
 		@Test
-		@Issue("Poem #3")
+		@Issue("Poem #5")
 		@DisplayName("Of quiet birds in circled flight. I am the soft stars that shine at night.")
 		void publishingTest(TestReporter reporter) {
 			reporter.publishEntry("Issue", "reporting test");


### PR DESCRIPTION
Closes #689 

Proposed commit message:

```
Create interaction between @Stopwatch and @Issue (#689 / #743)

If a test is annotated with both @Issue and @Stopwatch, the test's
run time is included in the `IssueTestCase`.

Closes: #689
PR: #743
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [ ] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 
