### PR TITLE
Add missing / to end version tag in Maven instruction

### DIFF
--- a/docs/project-page.adoc
+++ b/docs/project-page.adoc
@@ -24,7 +24,7 @@ Maven:
 <dependency>
 	<groupId>org.junit-pioneer</groupId>
 	<artifactId>junit-pioneer</artifactId>
-	<version><!-- ... --><version>
+	<version><!-- ... --></version>
 	<scope>test</scope>
 </dependency>
 ----


### PR DESCRIPTION
Quick fix to add a missing / to properly end the version tag in the project-page.adoc.