### PR TITLE
Ascii docs convert

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,0 +1,171 @@
+= JUnit Pioneer
+:doctype: book
+
+= JUnit Pioneer
+
+<img src="docs/project-logo.jpg" align="right" width="150px"/>
+
+image::https://maven-badges.herokuapp.com/maven-central/org.junit-pioneer/junit-pioneer/badge.svg?style=flat[Latest Junit Pioneer on Maven Central, link="https://mvnrepository.com/artifact/org.junit-pioneer/junit-pioneer"]
+image::https://javadoc.io/badge2/org.junit-pioneer/junit-pioneer/javadoc.svg[Latest JUnit Pioneer Javadoc on javadoc.io, link="https://javadoc.io/doc/org.junit-pioneer/junit-pioneer"]
+image::https://github.com/junit-pioneer/junit-pioneer/actions/workflows/build.yml/badge.svg?branch=main[JUnit Pioneer build status, link="https://github.com/junit-pioneer/junit-pioneer/actions/workflows/build.yml?branch=main"]
+image::https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg[Contributor Covenant Code of Conduct, link="code_of_conduct.md"]
+
+A melting pot for all kinds of extensions to
+https://github.com/junit-team/junit5[JUnit 5], particular to its Jupiter API.
+
+Check out https://junit-pioneer.org/[junit-pioneer.org], particularly https://junit-pioneer.org/docs/[the documentation section].
+
+
+== A Pioneer's Mission
+
+JUnit Pioneer provides extensions for https://github.com/junit-team/junit5/[JUnit 5] and its Jupiter API.
+It does not limit itself to proven ideas with wide application but is purposely open to experimentation.
+It aims to spin off successful and cohesive portions into sibling projects or back into the JUnit 5 code base.
+
+To enable easy exchange of code with JUnit 5, JUnit Pioneer copies most of its infrastructure, from code style to build tool and configuration to continuous integration.
+
+
+== Getting on Board
+
+JUnit Pioneer is released on https://github.com/junit-pioneer/junit-pioneer/releases[GitHub] and https://search.maven.org/artifact/org.junit-pioneer/junit-pioneer[Maven Central]. Coordinates:
+
+* group ID: `org.junit-pioneer`
+* artifact ID: `junit-pioneer`
+* version: image::https://maven-badges.herokuapp.com/maven-central/org.junit-pioneer/junit-pioneer/badge.svg?style=flat[Latest Junit Pioneer on Maven Central, link="https://mvnrepository.com/artifact/org.junit-pioneer/junit-pioneer"]
+
+For Maven:
+
+```xml
+<dependency>
+	<groupId>org.junit-pioneer</groupId>
+	<artifactId>junit-pioneer</artifactId>
+	<version><!--...--></version>
+	<scope>test</scope>
+</dependency>
+```
+
+For Gradle:
+
+```groovy
+testCompile group: 'org.junit-pioneer', name: 'junit-pioneer', version: /*...*/
+```
+
+
+== Dependencies
+
+Starting with release 2.0, JUnit Pioneer is compiled against *Java 11* and comes as a module (i.e. with a `module-info.class`) named _org.junitpioneer_.
+That means it can be used on all Java versions 11 and higher on class path and module path.
+
+Pioneer does not only use JUnit 5's API, but also other artifacts from its ecosystem such as https://mvnrepository.com/artifact/org.junit.platform/junit-platform-commons[`junit-platform-commons`].
+To avoid dependency issues (e.g. in https://github.com/junit-pioneer/junit-pioneer/issues/343[junit-pioneer#343]), you should add the JUnit 5 BOM (https://mvnrepository.com/artifact/org.junit/junit-bom[`junit-bom`]) to your project instead of defining all dependency versions manually.
+
+To not add to user's https://nipafx.dev/jar-hell/[JAR hell], JUnit Pioneer is not taking on any runtime dependencies besides JUnit 5.
+Pioneer always depends on the lowest JUnit 5 version that supports its feature set, but that should not keep you from using 5's latest and greatest.
+
+Since 1.7.0 we also have an *optional* runtime dependency on https://github.com/FasterXML/jackson[Jackson], for our JSON-based extensions.
+You can read a bit more about our approach to dependencies in the [contribution guide](CONTRIBUTING.md#others).
+
+For our own infrastructure, we rely on the following compile and test dependencies:
+
+* AssertJ (assertions for our tests)
+* Mockito (mocking for our tests)
+* Log4J (to configure logging during test runs)
+* Jimfs (as an in-memory file system for our test)
+* Equalsverifier (for easier assertion of simple things)
+
+
+== Contributing
+
+We welcome contributions of all shapes and forms! 🌞
+
+* If you have an idea for an extension, https://github.com/junit-pioneer/junit-pioneer/issues/new[open an issue] and let's discuss.
+* If you want to help but don't know how, have a look at https://github.com/junit-pioneer/junit-pioneer/issues[the existing issues], particularly those marked https://github.com/junit-pioneer/junit-pioneer/labels/%F0%9F%93%A2%20up%20for%20grabs[_up for grabs_] or https://github.com/junit-pioneer/junit-pioneer/labels/good%20first%20issue[_good first issue_].
+* If you want to chat about JUnit Pioneer, https://discord.gg/rHfJeCF[join our discord] - we have a _#junit-pioneer_ channel. 😊
+
+Before contributing, please read the [contribution guide](CONTRIBUTING.md) as well as [the code of conduct](CODE_OF_CONDUCT.md).
+
+=== Maintainers
+
+JUnit Pioneer is maintained by a small team of people who work on it in their free time - see [`CONTRIBUTING.md`](CONTRIBUTING.md) for details on how they do that.
+In lexicographic order, these are:
+
+<dl>
+	<dt>Daniel Kraus aka <a href="https://github.com/beatngu13">beatngu13</a></dt>
+	<dd>Banking software by day, OSS by night.
+		Punk rock enthusiast and passionate hiker.
+		Into Java, software testing, and web services.
+		<a href="https://twitter.com/beatngu1101">Tweets</a> occasionally.</dd>
+	<dt>Matthias Bünger aka <a href="https://github.com/Bukama">Bukama</a></dt>
+	<dd>(Always tries to become a better) Java developer, loves testing and reads <a href="https://twitter.com/bukamabish">tweets</a>.
+		Became a maintainer in April 2020 after he "caused" (authored) too many <a href="https://github.com/junit-pioneer/junit-pioneer/issues">bishues</a>.</dd>
+	<dt>Mihály Verhás aka <a href="https://github.com/Michael1993">Michael1993</a></dt>
+	<dd>Not so witty, not so pretty, not really mean, not really cool bean.
+		A Hungarian Java developer who spends more time on Twitch than recommended by his doctors and used creative and diligent contributions to fool everyone into believing he is a decent enough guy to get promoted to maintainer (in November 2020).
+		</dd>
+	<dt>Nicolai Parlog aka <a href="https://github.com/nipafx">nipafx</a></dt>
+	<dd>Java enthusiast with a passion for learning and sharing, best known for his head decor.
+		He's a Java Developer Advocate at Oracle, organizer of <a href="https://accento.dev/">Accento</a>, occasional streamer, and more - check <a href="https://nipafx.dev">nipafx.dev</a> for the full list.
+		He co-founded JUnit Pioneer in November 2016 and has maintained it ever since (although often very negligently).</dd>
+	<dt>Simon Schrottner aka <a href="https://github.com/aepfli">aepfli</a></dt>
+	<dd>Bearded guy in Lederhosen, who loves to code, and loves to explore code quality, testing, and other tools that can improve the live of a software craftsman.
+		<a href="https://www.couchsurfing.com/people/simmens">Passionated couchsurfer</a> and <a href="https://www.facebook.com/togtrama">hobby event planner</a>.
+		Maintainer since April 2020.</dd>
+</dl>
+
+=== Contributors
+
+JUnit Pioneer, as small as it is, would be much smaller without kind souls contributing their time, energy, and skills.
+Thank you for your efforts! 🙏
+
+The least we can do is to thank them and list some of their accomplishments here (in lexicographic order).
+
+==== 2023
+* https://github.com/eeverman[Eric Everman] added `@RestoreSystemProperties` and `@RestoreEnvironmentVariables` annotations to the https://junit-pioneer.org/docs/system-properties/[System Properties] and https://junit-pioneer.org/docs/environment-variables/[Environment Variables] extensions (#574 / #700)
+
+==== 2022
+
+* https://github.com/filiphr[Filip Hrisafov] contributed the https://junit-pioneer.org/docs/json-argument-source/[JSON Argument Source] support (#101 / #492)
+* https://github.com/Marcono1234[Marcono1234] contributed the https://junit-pioneer.org/docs/expected-to-fail-tests/[`@ExpectedToFail` extension] (#551 / #676)
+* https://github.com/mathieufortin01[Mathieu Fortin] contributed the `suspendForMs` attribute in https://junit-pioneer.org/docs/retrying-test/[retrying tests] (#407 / #604)
+* https://github.com/p1729[Pankaj Kumar] contributed towards improving GitHub actions (#587 / #611)
+* https://github.com/robtimus[Rob Spoor] enabled non-static factory methods for `@CartesianTest.MethodFactory` (#628)
+* https://github.com/marcwrobel[Marc Wrobel] improved the documentation (#692)
+
+==== 2021
+
+* https://github.com/dump247[Cory Thomas] contributed the `minSuccess` attribute in https://junit-pioneer.org/docs/retrying-test/[retrying tests] (#408 / #430)
+* https://github.com/beatngu13[Daniel Kraus] fixed bugs in the environment variable and system property extensions (#432 / #433, #448 / #449, and more), revamped their annotation handling (#460 / #485), and improved the build process (#482 / #483) before becoming a maintainer
+* https://github.com/gdiegel[Gabriel Diegel] contributed the `@DisabledUntil` extension in https://junit-pioneer.org/docs/disabled-until/[Temporarily disable a test] (#366)
+* https://github.com/johnlehne[John Lehne] resolved an issue with the latest build status not showing correctly in README.md (#530)
+* https://github.com/jbduncan[Jonathan Bluett-Duncan] contributed a fix to `buildSrc/build.gradle` which was failing when a `.idea` directory did not contain a `vcs.xml` file (#532)
+* https://github.com/sleberknight[Scott Leberknight] resolved a javadoc issue (#547 / #548)
+* https://github.com/slawekjaranowski[Slawomir Jaranowski] Migrate to new Shipkit plugins (#410 / #419)
+* https://github.com/scordio[Stefano Cordio] contributed https://junit-pioneer.org/docs/cartesian-product/#cartesianenumsource[the Cartesian Enum source] (#379 / #409 and #414 / #453)
+
+==== 2020
+
+* https://github.com/mureinik[Allon Murienik] contributed https://junit-pioneer.org/docs/range-sources/[the range sources] (#44 / #123)
+* https://github.com/hovinen[Bradford Hovinen] improved the execution of the EnvironmentVariableUtils on different OS (#287 / #288)
+* https://github.com/beatngu13[Daniel Kraus] contributed https://junit-pioneer.org/docs/system-properties/[the system property extension] (#129 / #133) and further improved it, also worked on the environment variable extension (#180 / #248), the Cartesian product extension (#358 / #372), and helped with build infrastructure (e.g. #269)
+* https://github.com/dwalluck[David Walluck] introduced JUnit 5 BOM (#343 / #346)
+* https://github.com/NPException[Dirk Witzel] improved the documentation (#149 / #271)
+* https://github.com/simonenkoi[Ignat Simonenko] fixed a noteworthy bug in the default locale extension (#146 / #161)
+* https://github.com/Hancho2009[Mark Rösler] contributed the https://junit-pioneer.org/docs/environment-variables/[environment variable extension] (#167 / #174 and #241 / #242)
+* https://github.com/Bukama[Matthias Bünger] opened, vetted, and groomed countless issues and PRs and contributed multiple refactorings (e.g. #165 / #168) and fixes (e.g. #190 / #200) before getting promoted to maintainer
+* https://github.com/Michael1993[Mihály Verhás] contributed https://junit-pioneer.org/docs/standard-input-output/[the StdIO extension] (#34 / #227), https://junit-pioneer.org/docs/report-entries/[the ReportEntryExtension] (#134, #179 / #183, #216, #294), https://junit-pioneer.org/docs/cartesian-product/[the CartesianProductTestExtension] (#321, #362 / #68, #354), https://junit-pioneer.org/docs/disable-parameterized-tests/[the DisableIfParameterExtension] (#313, #368) added tests to other extensions (#164 / #272), the Pioneer assertions and contributed to multiple issues (e.g. #217 / #298) and PRs (e.g. #253, #307)
+* https://github.com/nishantvas[Nishant Vashisth] contributed an https://junit-pioneer.org/docs/disable-if-display-name/[extension to disable parameterized tests] by display name (#163 / #175)
+* https://github.com/aepfli[Simon Schrottner] contributed to multiple issues and PRs and almost single-handedly revamped the build and QA process (e.g. #192 / #185) before getting promoted to maintainer
+* https://github.com/sullis[Sullis] improved GitHub Actions with Gradle Wrapper Validation check (#302)
+
+==== 2019
+
+* https://github.com/panchenko[Alex Panchenko] fixed a noteworthy bug in the `TempDirectory` extension (#140)
+* https://github.com/sormuras[Christian Stein] helped get the project back on track (yes, again, I told you Nicolai was negligent)
+* https://github.com/beatngu13[Daniel Kraus] improved Shipkit integration (#148 / #151)
+* https://github.com/marcphilipp[Marc Philipp] helped get the project back on track and converted `build.gradle` to Kotlin (#145)
+
+==== 2018
+
+* https://github.com/britter[Benedikt Ritter] contributed https://junit-pioneer.org/docs/default-locale-timezone/[the default locale and time zone extensions] (#103 / #104)
+* https://github.com/sormuras[Christian Stein] introduced Shipkit-based continuous delivery (#87) and build scans (#124 / #132)
+* https://github.com/marcphilipp[Marc Philipp] helped get the project back on track and contributed https://junit-pioneer.org/docs/temp-directory/[the `TempDirectory` extension] (#39 / #69)

--- a/docs/docs-nav.yml
+++ b/docs/docs-nav.yml
@@ -37,5 +37,7 @@
         url: /docs/retrying-test/
       - title: "Standard Input and Output"
         url: /docs/standard-input-output/
+      - title: "Simple Arguments Aggregator"
+        url: /docs/simple-arguments-aggregator/
       - title: "Vintage @Test"
         url: /docs/vintage-test/

--- a/docs/simple-arguments-aggregator.adoc
+++ b/docs/simple-arguments-aggregator.adoc
@@ -1,0 +1,37 @@
+:page-title: Simple Arguments Aggregator
+:page-description: The JUnit 5 (Jupiter) extension `@Aggregate` aggregates supplied values into a single parameter for a `@ParameterizedTest`
+:xp-demo-dir: ../src/demo/java
+:demo: {xp-demo-dir}/org/junitpioneer/jupiter/params/SimpleAggregatorDemo.java
+
+Annotating a test parameter with `@Aggregate` aggregates all the supplied arguments into a single object.
+
+== Usage
+
+`@Aggregate` can be applied to a parameter in a `@ParameterizedTest`.
+
+[source,java,indent=0]
+====
+include::{demo}[tag=basic_example]
+====
+
+== Limitations
+
+The extension is meant to be used for simple use-cases, and has a couple limitations.
+
+ - The parameter object must have a `public` constructor.
+ - The arguments must be in the same order as the constructor parameters.
+ - The parameter object must be non-composite - it can not have another object(s) as fields.
+
+This last point has a few exceptions based on JUnit 5 support for https://junit.org/junit5/docs/current/user-guide/#writing-tests-parameterized-tests-argument-conversion-implicit[implicit type conversions].
+In the example above, if we have the following fields in the `Person` class:
+
+[source,java,indent=0]
+====
+include::{demo}[tag=person_class]
+====
+
+Then JUnit 5 will take care of the conversion from `String` to `Gender` and `LocalDate`.
+If you need to supply more complex objects to your tests, see if link:/docs/json-argument-source.adoc[JSON arguments sources] cover your use case.
+
+== Thread-Safety
+This extension is safe to use during https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution[parallel test execution].

--- a/src/demo/java/org/junitpioneer/jupiter/params/SimpleAggregatorDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/params/SimpleAggregatorDemo.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junitpioneer.jupiter.params;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class SimpleAggregatorDemo {
+
+	// tag::basic_example[]
+	@ParameterizedTest
+	@CsvSource({ "Jane, Doe, F, 1990-05-20", "John, Doe, M, 1990-10-22" })
+	void test(@Aggregate Person person) {
+	}
+	// end::basic_example[]
+
+	static class Person {
+
+		// tag::person_class[]
+		private final String firstName;
+		private final String lastName;
+		private final Gender gender;
+		private final LocalDate birthday;
+		// end::person_class[]
+
+		Person(String firstName, String lastName, Gender gender, LocalDate birthday) {
+			this.firstName = firstName;
+			this.lastName = lastName;
+			this.gender = gender;
+			this.birthday = birthday;
+		}
+
+	}
+
+	enum Gender {
+		F, M
+	}
+
+}

--- a/src/main/java/org/junitpioneer/jupiter/params/Aggregate.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/Aggregate.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junitpioneer.jupiter.params;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.params.aggregator.AggregateWith;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@AggregateWith(SimpleAggregator.class)
+public @interface Aggregate {
+}

--- a/src/main/java/org/junitpioneer/jupiter/params/Aggregate.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/Aggregate.java
@@ -17,6 +17,26 @@ import java.lang.annotation.Target;
 
 import org.junit.jupiter.params.aggregator.AggregateWith;
 
+/**
+ * {@code @Aggregate} is a parameter annotation, used for simple argument aggregation.
+ *
+ * <p>The supplied values are expected to be able to be aggregated into a single argument,
+ * which is in turn supplied to the {@code @ParameterizedTest} method.</p>
+ *
+ * <p>For more details and examples, see
+ * <a href="https://junit-pioneer.org/docs/simple-arguments-aggregator/" target="_top">the documentation on
+ * <code>Simple Arguments Aggregator</code></a>
+ * </p>
+ *
+ * <p>This annotation is not compatible with {@link org.junitpioneer.jupiter.cartesian.CartesianTest} as this expects
+ * a single parameter as opposed to {@link org.junitpioneer.jupiter.cartesian.CartesianTest} requiring
+ * multiple parameters.
+ * </p>
+ *
+ * @since 2.1
+ * @see org.junit.jupiter.params.aggregator.ArgumentsAggregator
+ * @see org.junitpioneer.jupiter.params.SimpleAggregator
+ */
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 @AggregateWith(SimpleAggregator.class)

--- a/src/main/java/org/junitpioneer/jupiter/params/SimpleAggregator.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/SimpleAggregator.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2016-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junitpioneer.jupiter.params;
+
+import static java.lang.String.format;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
+import org.junit.jupiter.params.aggregator.ArgumentsAggregationException;
+import org.junit.jupiter.params.aggregator.ArgumentsAggregator;
+import org.junitpioneer.internal.PioneerUtils;
+
+public class SimpleAggregator implements ArgumentsAggregator {
+
+	public SimpleAggregator() {
+		// recreate default constructor to prevent compiler warning
+	}
+
+	@Override
+	public Object aggregateArguments(ArgumentsAccessor accessor, ParameterContext context)
+			throws ArgumentsAggregationException {
+		Class<?> type = context.getParameter().getType();
+		Set<Constructor<?>> constructors = Stream
+				.concat(Arrays.stream(type.getDeclaredConstructors()), Arrays.stream(type.getConstructors()))
+				.filter(constructor -> constructor.getParameterCount() == accessor.size())
+				.collect(Collectors.toUnmodifiableSet());
+		if (constructors.isEmpty())
+			throw new ArgumentsAggregationException(
+				format("No matching constructor found, mismatching parameter sizes, expected %d.", accessor.size()));
+		return tryEachConstructor(constructors, accessor);
+	}
+
+	private Object tryEachConstructor(Set<Constructor<?>> constructors, ArgumentsAccessor accessor) {
+		Object value = null;
+		List<Constructor<?>> matchingConstructors = new ArrayList<>();
+		for (Constructor<?> constructor : constructors) {
+			try {
+				Object[] arguments = new Object[accessor.size()];
+				for (int i = 0; i < accessor.size(); i++) {
+					// wrapping primitive types to avoid casting problems - Java does auto unboxing later
+					arguments[i] = accessor.get(i, PioneerUtils.wrap(constructor.getParameterTypes()[i]));
+				}
+				value = constructor.newInstance(arguments);
+				matchingConstructors.add(constructor);
+			}
+			catch (Exception ignored) {
+				// continue, we throw if no matching constructor is found
+			}
+		}
+		if (value == null) {
+			throw new ArgumentsAggregationException(
+				"Could not aggregate arguments, no matching constructor was found.");
+		} else if (matchingConstructors.size() > 1) {
+			throw new ArgumentsAggregationException(format("Expected only one matching constructor but found %s: %s",
+				matchingConstructors.size(), matchingConstructors));
+		}
+		return value;
+	}
+
+}

--- a/src/main/java/org/junitpioneer/jupiter/params/SimpleAggregator.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/SimpleAggregator.java
@@ -11,13 +11,13 @@
 package org.junitpioneer.jupiter.params;
 
 import static java.lang.String.format;
+import static java.util.stream.Collectors.toUnmodifiableSet;
 
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.extension.ParameterContext;
@@ -39,7 +39,7 @@ public class SimpleAggregator implements ArgumentsAggregator {
 		Set<Constructor<?>> constructors = Stream
 				.concat(Arrays.stream(type.getDeclaredConstructors()), Arrays.stream(type.getConstructors()))
 				.filter(constructor -> constructor.getParameterCount() == accessor.size())
-				.collect(Collectors.toUnmodifiableSet());
+				.collect(toUnmodifiableSet());
 		if (constructors.isEmpty())
 			throw new ArgumentsAggregationException(
 				format("No matching constructor found, mismatching parameter sizes, expected %d.", accessor.size()));

--- a/src/main/java/org/junitpioneer/jupiter/params/SimpleAggregator.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/SimpleAggregator.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
@@ -26,7 +25,7 @@ import org.junit.jupiter.params.aggregator.ArgumentsAggregationException;
 import org.junit.jupiter.params.aggregator.ArgumentsAggregator;
 import org.junitpioneer.internal.PioneerUtils;
 
-public class SimpleAggregator implements ArgumentsAggregator {
+class SimpleAggregator implements ArgumentsAggregator {
 
 	public SimpleAggregator() {
 		// recreate default constructor to prevent compiler warning
@@ -36,8 +35,9 @@ public class SimpleAggregator implements ArgumentsAggregator {
 	public Object aggregateArguments(ArgumentsAccessor accessor, ParameterContext context)
 			throws ArgumentsAggregationException {
 		Class<?> type = context.getParameter().getType();
-		Set<Constructor<?>> constructors = Stream
-				.concat(Arrays.stream(type.getDeclaredConstructors()), Arrays.stream(type.getConstructors()))
+		Set<Constructor<?>> constructors = Arrays
+				.stream(type.getDeclaredConstructors())
+				// only if the constructor parameters and the supplied values are equal length
 				.filter(constructor -> constructor.getParameterCount() == accessor.size())
 				.collect(toUnmodifiableSet());
 		if (constructors.isEmpty())
@@ -67,7 +67,7 @@ public class SimpleAggregator implements ArgumentsAggregator {
 			throw new ArgumentsAggregationException(
 				"Could not aggregate arguments, no matching constructor was found.");
 		} else if (matchingConstructors.size() > 1) {
-			throw new ArgumentsAggregationException(format("Expected only one matching constructor but found %s: %s",
+			throw new ArgumentsAggregationException(format("Expected only one matching constructor but found %d: %s",
 				matchingConstructors.size(), matchingConstructors));
 		}
 		return value;

--- a/src/main/java/org/junitpioneer/jupiter/params/package-info.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/package-info.java
@@ -22,6 +22,12 @@
  *     <li>{@link org.junitpioneer.jupiter.params.DoubleRangeSource}</li>
  * </ul>
  *
+ * <p>
+ * Argument aggregator for simple use-cases.</p>
+ * <p>Check out the following type for details:</p>
+ * <ul>
+ *     <li>{@link org.junitpioneer.jupiter.params.Aggregate}</li>
+ * </ul>
  */
 
 package org.junitpioneer.jupiter.params;

--- a/src/test/java/org/junitpioneer/jupiter/params/SimpleAggregatorTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/params/SimpleAggregatorTests.java
@@ -13,6 +13,11 @@ package org.junitpioneer.jupiter.params;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junitpioneer.testkit.PioneerTestKit.executeTestMethodWithParameterTypes;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Month;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.aggregator.ArgumentsAggregationException;
@@ -20,11 +25,6 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.junitpioneer.testkit.ExecutionResults;
 import org.junitpioneer.testkit.assertion.PioneerAssert;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.Month;
 
 class SimpleAggregatorTests {
 
@@ -54,14 +54,14 @@ class SimpleAggregatorTests {
 	}
 
 	@ParameterizedTest
-	@CsvSource({"Speeding, 19:03:12", "Ran red light, 18:34:02", "Rolling stop, 07:12:12"})
+	@CsvSource({ "Speeding, 19:03:12", "Ran red light, 18:34:02", "Rolling stop, 07:12:12" })
 	void testLocalTime(@Aggregate Ticket ticket) {
 		assertThat(ticket.description).isNotBlank();
 		assertThat(ticket.time).isAfter(LocalTime.MIDNIGHT);
 	}
 
 	@ParameterizedTest
-	@CsvSource({"Fuzzy, 2010-10-10T12:20:09", "Unsure, 2022-12-11T07:12:15"})
+	@CsvSource({ "Fuzzy, 2010-10-10T12:20:09", "Unsure, 2022-12-11T07:12:15" })
 	void testLocalDateTime(@Aggregate Memory memory) {
 		assertThat(memory.description).isIn("Fuzzy", "Unsure");
 		assertThat(memory.occurred).isAfter(LocalDateTime.of(2010, Month.JANUARY, 1, 0, 0));
@@ -177,6 +177,7 @@ class SimpleAggregatorTests {
 	}
 
 	static class Human {
+
 		private final String name;
 		private final LocalDate birthday;
 
@@ -184,9 +185,11 @@ class SimpleAggregatorTests {
 			this.name = name;
 			this.birthday = birthday;
 		}
+
 	}
 
 	static class Ticket {
+
 		private final String description;
 		private final LocalTime time;
 
@@ -194,9 +197,11 @@ class SimpleAggregatorTests {
 			this.description = description;
 			this.time = time;
 		}
+
 	}
 
 	static class Memory {
+
 		private final String description;
 		private final LocalDateTime occurred;
 
@@ -204,5 +209,7 @@ class SimpleAggregatorTests {
 			this.description = description;
 			this.occurred = occurred;
 		}
+
 	}
+
 }

--- a/src/test/java/org/junitpioneer/jupiter/params/SimpleAggregatorTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/params/SimpleAggregatorTests.java
@@ -36,7 +36,7 @@ class SimpleAggregatorTests {
 	}
 
 	@ParameterizedTest
-	@ValueSource(ints = { 13, 17, 19})
+	@ValueSource(ints = { 13, 17, 19 })
 	void testBoxing(@Aggregate Boxed boxed) {
 		assertThat(boxed.value).isLessThan(20);
 	}
@@ -141,6 +141,7 @@ class SimpleAggregatorTests {
 	}
 
 	static class Boxed {
+
 		private final int value;
 
 		Boxed(int value) {

--- a/src/test/java/org/junitpioneer/jupiter/params/SimpleAggregatorTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/params/SimpleAggregatorTests.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2016-2022 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junitpioneer.jupiter.params;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junitpioneer.testkit.PioneerTestKit.executeTestMethodWithParameterTypes;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.aggregator.ArgumentsAggregationException;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junitpioneer.testkit.ExecutionResults;
+import org.junitpioneer.testkit.assertion.PioneerAssert;
+
+class SimpleAggregatorTests {
+
+	@ParameterizedTest
+	@CsvSource({ "23, M, Bob", "24, F, Jane" })
+	void testAggregator(@Aggregate Person person) {
+		if (person.gender == Gender.M) {
+			assertThat(person.age).isEqualTo(23);
+			assertThat(person.name).isEqualTo("Bob");
+		} else {
+			assertThat(person.age).isEqualTo(24);
+			assertThat(person.name).isEqualTo("Jane");
+		}
+	}
+
+	@ParameterizedTest
+	@ValueSource(ints = { 13, 17, 19})
+	void testBoxing(@Aggregate Boxed boxed) {
+		assertThat(boxed.value).isLessThan(20);
+	}
+
+	@Test
+	void noMatchingConstructorSize() {
+		ExecutionResults results = executeTestMethodWithParameterTypes(BadConfigurationTestCases.class,
+			"noMatchingConstructorSize", Person.class);
+
+		PioneerAssert
+				.assertThat(results)
+				.hasNumberOfFailedTests(2)
+				.andThenCheckExceptions(exceptions -> assertThat(exceptions)
+						.allSatisfy(exception -> assertThat(exception)
+								.hasCauseInstanceOf(ArgumentsAggregationException.class)
+								.hasMessageContaining(
+									"No matching constructor found, mismatching parameter sizes, expected")));
+	}
+
+	@Test
+	void noMatchingConstructor() {
+		ExecutionResults results = executeTestMethodWithParameterTypes(BadConfigurationTestCases.class,
+			"noMatchingConstructor", BadConfigurationTestCases.Verse.class);
+
+		PioneerAssert
+				.assertThat(results)
+				.hasNumberOfFailedTests(2)
+				.andThenCheckExceptions(exceptions -> assertThat(exceptions)
+						.allSatisfy(exception -> assertThat(exception)
+								.hasCauseInstanceOf(ArgumentsAggregationException.class)
+								.hasMessageContaining(
+									"Could not aggregate arguments, no matching constructor was found.")));
+	}
+
+	@Test
+	void tooManyMatchingConstructors() {
+		ExecutionResults results = executeTestMethodWithParameterTypes(BadConfigurationTestCases.class,
+			"tooManyMatchingConstructors", BadConfigurationTestCases.Verse.class);
+
+		PioneerAssert
+				.assertThat(results)
+				.hasNumberOfFailedTests(2)
+				.andThenCheckExceptions(exceptions -> assertThat(exceptions)
+						.allSatisfy(exception -> assertThat(exception)
+								.hasCauseInstanceOf(ArgumentsAggregationException.class)
+								.hasMessageContaining("Expected only one matching constructor")));
+	}
+
+	static class BadConfigurationTestCases {
+
+		@ParameterizedTest
+		@CsvSource({ "What is more gentle than a wind in summer?", "What is more soothing than the pretty hummer" })
+		void noMatchingConstructorSize(@Aggregate Person person) {
+		}
+
+		@ParameterizedTest
+		@CsvSource({ "That stays one moment in an open flower, And buzzes cheerily from bower to bower?",
+				"What is more tranquil than a musk-rose blowing, In a green island far from all men's knowing?" })
+		void noMatchingConstructor(@Aggregate Verse verse) {
+		}
+
+		@ParameterizedTest
+		@CsvSource({ "More healthful than the leafiness of dales?, 1", "More secret than a nest of nightingales?, 2" })
+		void tooManyMatchingConstructors(@Aggregate Verse verse) {
+		}
+
+		static class Verse {
+
+			private final String verse;
+			private final int line;
+
+			Verse(String verse, int line) {
+				this.verse = verse;
+				this.line = line;
+			}
+
+			Verse(String verse, Integer line) {
+				this.verse = verse;
+				this.line = line;
+			}
+
+		}
+
+	}
+
+	enum Gender {
+		M, F
+	}
+
+	static class Person {
+
+		private final int age;
+		private final Gender gender;
+		private final String name;
+
+		public Person(int age, Gender gender, String name) {
+			this.age = age;
+			this.gender = gender;
+			this.name = name;
+		}
+
+	}
+
+	static class Boxed {
+		private final int value;
+
+		Boxed(int value) {
+			this.value = value;
+		}
+
+	}
+
+}

--- a/src/test/java/org/junitpioneer/jupiter/params/SimpleAggregatorTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/params/SimpleAggregatorTests.java
@@ -21,6 +21,11 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.junitpioneer.testkit.ExecutionResults;
 import org.junitpioneer.testkit.assertion.PioneerAssert;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Month;
+
 class SimpleAggregatorTests {
 
 	@ParameterizedTest
@@ -39,6 +44,27 @@ class SimpleAggregatorTests {
 	@ValueSource(ints = { 13, 17, 19 })
 	void testBoxing(@Aggregate Boxed boxed) {
 		assertThat(boxed.value).isLessThan(20);
+	}
+
+	@ParameterizedTest
+	@CsvSource({ "John, 2023-07-16", "Bob, 1959-02-21", "Jane, 1977-05-03" })
+	void testLocalDate(@Aggregate Human human) {
+		assertThat(human.name).isNotBlank();
+		assertThat(human.birthday).isAfter(LocalDate.of(1900, 1, 1));
+	}
+
+	@ParameterizedTest
+	@CsvSource({"Speeding, 19:03:12", "Ran red light, 18:34:02", "Rolling stop, 07:12:12"})
+	void testLocalTime(@Aggregate Ticket ticket) {
+		assertThat(ticket.description).isNotBlank();
+		assertThat(ticket.time).isAfter(LocalTime.MIDNIGHT);
+	}
+
+	@ParameterizedTest
+	@CsvSource({"Fuzzy, 2010-10-10T12:20:09", "Unsure, 2022-12-11T07:12:15"})
+	void testLocalDateTime(@Aggregate Memory memory) {
+		assertThat(memory.description).isIn("Fuzzy", "Unsure");
+		assertThat(memory.occurred).isAfter(LocalDateTime.of(2010, Month.JANUARY, 1, 0, 0));
 	}
 
 	@Test
@@ -150,4 +176,33 @@ class SimpleAggregatorTests {
 
 	}
 
+	static class Human {
+		private final String name;
+		private final LocalDate birthday;
+
+		Human(String name, LocalDate birthday) {
+			this.name = name;
+			this.birthday = birthday;
+		}
+	}
+
+	static class Ticket {
+		private final String description;
+		private final LocalTime time;
+
+		Ticket(String description, LocalTime time) {
+			this.description = description;
+			this.time = time;
+		}
+	}
+
+	static class Memory {
+		private final String description;
+		private final LocalDateTime occurred;
+
+		Memory(String description, LocalDateTime occurred) {
+			this.description = description;
+			this.occurred = occurred;
+		}
+	}
 }


### PR DESCRIPTION
Convert README.md to README.adoc (#656)

This commit introduces the conversion of the README.md file to the
README.adoc format. The addition of the README.adoc file aims to replace
the existing README.md file with its equivalent in AsciiDoc format.

related to:#656

Please review this pull request.


---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [ ] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 
