### PR TITLE
Replace `extension` with `argument converter` in byte array converter docs

### DIFF
--- a/docs/byte-array-converter.adoc
+++ b/docs/byte-array-converter.adoc
@@ -1,5 +1,5 @@
 :page-title: Convert Number Argument to Byte Array
-:page-description: The JUnit 5 (Jupiter) extension `@NumberToByteArrayConversion` convert the number value of an argument to its byte array representation
+:page-description: The JUnit 5 (Jupiter) argument converter `@NumberToByteArrayConversion` converts the number value of an argument to its byte array representation
 :xp-demo-dir: ../src/demo/java
 :demo: {xp-demo-dir}/org/junitpioneer/jupiter/converter/ByteArrayConverterDemo.java
 
@@ -18,7 +18,7 @@ include::{demo}[tag=int_example]
 include::{demo}[tag=long_example]
 ----
 
-By default, the extension uses big endian order.
+By default, the argument converter uses big endian order.
 This can be configured in the annotation using `order`.
 
 [source,java,indent=0]
@@ -26,9 +26,9 @@ This can be configured in the annotation using `order`.
 include::{demo}[tag=little_endian_order]
 ----
 
-The extension will support `byte`, `short`, `int`, `long`, `double` and `float`.
+The argument converter will support `byte`, `short`, `int`, `long`, `double` and `float`.
 It does not support `String`.
 
 == Thread-Safety
 
-This extension is safe to use during https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution[parallel test execution].
+This argument converter is safe to use during https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution[parallel test execution].


### PR DESCRIPTION
As mentioned in https://github.com/junit-pioneer/junit-pioneer/pull/742#discussion_r1310493504, I propose to use `argument converter` instead of `extension` in the `@NumberToByteArrayConversion` docs as [`ArgumentConverter`](https://junit.org/junit5/docs/current/api/org.junit.jupiter.params/org/junit/jupiter/params/converter/ArgumentConverter.html) doesn't extend [`Extension`](https://junit.org/junit5/docs/current/api/org.junit.jupiter.api/org/junit/jupiter/api/extension/Extension.html).

Proposed commit message:

```
Use argument converter in `@NumberToByteArrayConversion` docs (#734 / #751)

Uses argument converter term in `@NumberToByteArrayConversion` docs.

See: #734
PR: #751
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [x] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [x] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [x] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [x] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [x] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [x] The `package-info.java` contains information about the new extension

Code
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [x] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Contributing
* [x] A prepared commit message exists
* [x] The list of contributions inside `README.md` mentions the new contribution (real name optional) 
