### PR TITLE
Fix Simple Arguments Aggregator docs

### DIFF
--- a/docs/simple-arguments-aggregator.adoc
+++ b/docs/simple-arguments-aggregator.adoc
@@ -10,9 +10,9 @@ Annotating a test parameter with `@Aggregate` aggregates all the supplied argume
 `@Aggregate` can be applied to a parameter in a `@ParameterizedTest`.
 
 [source,java,indent=0]
-====
+----
 include::{demo}[tag=basic_example]
-====
+----
 
 == Limitations
 
@@ -26,9 +26,9 @@ This last point has a few exceptions based on JUnit 5 support for https://junit.
 In the example above, if we have the following fields in the `Person` class:
 
 [source,java,indent=0]
-====
+----
 include::{demo}[tag=person_class]
-====
+----
 
 Then JUnit 5 will take care of the conversion from `String` to `Gender` and `LocalDate`.
 If you need to supply more complex objects to your tests, see if link:/docs/json-argument-source.adoc[JSON arguments sources] cover your use case.


### PR DESCRIPTION
Proposed commit message:

```
Fix Simple Arguments Aggregator docs (#758)

Other documentation uses `----` instead of `====`. The latter
doesn't create `<code data-lang="java">` within `<pre>`.

PR: #758
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code (general)
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Code (new package)
* [ ] The new package is exported in `module-info.java`
* [ ] The new package is also present in the tests
* [ ] The new package is opened for reflection to JUnit 5 in `module-info.java`
* [ ] The new package is listed in the contribution guide

Contributing
* [x] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 
