### PR TITLE
Update plugins, deps, actions, and docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,7 @@ jobs:
     strategy:
       matrix:
         java: [ 11, 17, 20 ]
-        junit-version: [ '5.9.2' ]
+        junit-version: [ '5.9.2', '5.10.0' ]
         os: [ubuntu, macos, windows]
     name: with Java ${{ matrix.java }}, JUnit ${{ matrix.junit-version }} on ${{ matrix.os }}
     steps:
@@ -145,7 +145,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        junit-version: [ '5.9.2' ]
+        junit-version: [ '5.9.2', '5.10.0' ]
         os: [ubuntu, macos, windows]
     name: Experimental build with newest JDK early-access build and Gradle release candidate
     # Gradle doesn't work with JDK EA builds, so we launch it with a supported Java version,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
     name: Gradle wrapper validation
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
 
@@ -58,7 +58,7 @@ jobs:
     name: with Java 11 on ${{ matrix.os }}
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Sonar needs the whole Git history for issue assignment
           fetch-depth: 0
@@ -70,7 +70,7 @@ jobs:
           cache: 'gradle'
       - name: Cache SonarCloud results
         if: ${{ matrix.os == 'ubuntu' }}
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.sonar/cache/
           key: ubuntu-sonar
@@ -93,7 +93,7 @@ jobs:
     name: Code format check
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
@@ -122,7 +122,7 @@ jobs:
     name: with Java ${{ matrix.java }}, JUnit ${{ matrix.junit-version }} on ${{ matrix.os }}
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
@@ -152,7 +152,7 @@ jobs:
     # but set the Gradle toolchain to use the experimental version.
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up experimental Java
         uses: oracle-actions/setup-java@v1
         with:
@@ -188,7 +188,7 @@ jobs:
     name: Release Pioneer into the wild
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Shipkit needs the whole Git history for changelog generation
           fetch-depth: 0
@@ -225,7 +225,7 @@ jobs:
     name: Update website
     steps:
       - name: Trigger website build
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.GH_WRITE_TOKEN }}
           repository: junit-pioneer/junit-pioneer.github.io

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,8 +112,12 @@ Classes usually belong into one of these packages:
 
 * `org.junitpioneer.internal` - code intended to be shared across various extensions
 * `org.junitpioneer.jupiter` - extensions to JUnit Jupiter
-	* `....issue` - implementation details of issue extension
-	* `....params` - extensions for Jupiter's `@ParameterizedTest`
+	* `...cartesian` - implementation details of Cartesian product extension
+	* `...converter` - argument converters for Jupiter's `ArgumentConverter`
+	* `...issue` - implementation details of issue extension
+	* `...json` - JSON argument sources for Jupiter's `@ParameterizedTest`
+	* `...params` - extensions for Jupiter's `@ParameterizedTest`
+	* `...resource` - extensions for injecting resources
 * `org.junitpioneer.vintage` - extensions to older JUnit versions
 
 If none of them is a good fit, we'll find one together.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -535,7 +535,7 @@ Of course, we want to avoid our own dependency hell, so each dependency should s
 
 #### Updates
 
-To keep dependencies up to date, run `gradle dependencyUpdates`, which lists all dependencies for which a newer version exists.
+To keep dependencies up to date, run `./gradlew dependencyUpdates`, which lists all dependencies for which a newer version exists.
 Updates then need to be done manually.
 To keep the commit history clean, these should be done in bulk every few weeks.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,14 +4,14 @@ plugins {
 	checkstyle
 	`maven-publish`
 	signing
-	id("com.diffplug.spotless") version "6.18.0"
+	id("com.diffplug.spotless") version "6.21.0"
 	id("at.zierler.yamlvalidator") version "1.5.0"
-	id("org.sonarqube") version "4.0.0.2929"
+	id("org.sonarqube") version "4.3.1.3277"
 	id("org.shipkit.shipkit-changelog") version "1.2.0"
 	id("org.shipkit.shipkit-github-release") version "1.2.0"
-	id("com.github.ben-manes.versions") version "0.46.0"
+	id("com.github.ben-manes.versions") version "0.48.0"
 	id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
-	id("org.gradlex.extra-java-module-info") version "1.3"
+	id("org.gradlex.extra-java-module-info") version "1.4.2"
 }
 
 plugins.withType<JavaPlugin>().configureEach {
@@ -52,7 +52,7 @@ val junitVersion : String by project
 val jacksonVersion: String = "2.14.2"
 val assertjVersion: String = "3.24.2"
 val log4jVersion: String = "2.20.0"
-val jimfsVersion: String = "1.2"
+val jimfsVersion: String = "1.3.0"
 
 dependencies {
 	implementation(platform("org.junit:junit-bom:$junitVersion"))
@@ -66,9 +66,9 @@ dependencies {
 	testImplementation(group = "org.junit.platform", name = "junit-platform-testkit")
 
 	testImplementation(group = "org.assertj", name = "assertj-core", version = assertjVersion)
-	testImplementation(group = "org.mockito", name = "mockito-core", version = "4.11.0")
+	testImplementation(group = "org.mockito", name = "mockito-core", version = "5.5.0")
 	testImplementation(group = "com.google.jimfs", name = "jimfs", version = jimfsVersion)
-	testImplementation(group = "nl.jqno.equalsverifier", name = "equalsverifier", version = "3.14.1")
+	testImplementation(group = "nl.jqno.equalsverifier", name = "equalsverifier", version = "3.15.1")
 
 	testRuntimeOnly(group = "org.apache.logging.log4j", name = "log4j-core", version = log4jVersion)
 	testRuntimeOnly(group = "org.apache.logging.log4j", name = "log4j-jul", version = log4jVersion)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -216,7 +216,7 @@ tasks {
 
 		if (project.version != "unspecified") {
 			// Add version to Java modules
-			options.javaModuleVersion.set(project.version.toString());
+			options.javaModuleVersion.set(project.version.toString())
 		}
 	}
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -341,7 +341,7 @@ tasks {
 		enabled = !experimentalBuild
 		reports {
 			xml.required.set(true)
-			xml.outputLocation.set(file("${buildDir}/reports/jacoco/report.xml"))
+			xml.outputLocation.set(file("${layout.buildDirectory}/reports/jacoco/report.xml"))
 		}
 	}
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,7 +2,7 @@ rootProject.name = "junit-pioneer"
 include("demo")
 
 plugins {
-	id("com.gradle.enterprise") version "3.2"
+	id("com.gradle.enterprise") version "3.14.1"
 }
 
 gradleEnterprise { 

--- a/src/test/java/module-info.java
+++ b/src/test/java/module-info.java
@@ -55,6 +55,8 @@ module org.junitpioneer {
 	// via org.assertj.core
 	requires java.instrument;
 	requires jdk.unsupported;
+	// via org.mockito
+	requires jdk.attach;
 	// via nl.jqno.equalsverifier
 	requires java.sql;
 


### PR DESCRIPTION
Proposed commit message:

```
Update plugins, deps, actions, and docs (#761)

This PR updates various plugin, dependency, and GitHub Action
versions. In addition, the documentation is updated to include all
current packages.

PR: #761
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code (general)
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Code (new package)
* [ ] The new package is exported in `module-info.java`
* [ ] The new package is also present in the tests
* [ ] The new package is opened for reflection to JUnit 5 in `module-info.java`
* [ ] The new package is listed in the contribution guide

Contributing
* [x] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 
