### PR TITLE
Add back support for NULL values to Cartesian Argument Providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ The least we can do is to thank them and list some of their accomplishments here
 
 * [Eric Everman](https://github.com/eeverman) added `@RestoreSystemProperties` and `@RestoreEnvironmentVariables` annotations to the [System Properties](https://junit-pioneer.org/docs/system-properties/) and [Environment Variables](https://junit-pioneer.org/docs/environment-variables/) extensions (#574 / #700)
 * [Florian Westreicher](https://github.com/meredrica) contributed to the JSON argument source extension (#704 / #724)
+* [Pёtr Andreev](https://github.com/petrandreev) added back support for NULL values to `@CartesianTestExtension` (#764 / #765)
 
 #### 2022
 

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtension.java
@@ -11,7 +11,8 @@
 package org.junitpioneer.jupiter.cartesian;
 
 import static java.lang.String.format;
-import static java.util.stream.Collectors.toUnmodifiableList;
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toList;
 import static org.junit.platform.commons.support.AnnotationSupport.findAnnotation;
 import static org.junitpioneer.internal.PioneerUtils.cartesianProduct;
 
@@ -20,6 +21,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -164,7 +166,7 @@ class CartesianTestExtension implements TestTemplateInvocationContextProvider {
 				// We like to keep arguments in the order in which they were listed
 				// in the annotation. Could use a set with defined iteration, but
 				// this is more explicit.
-				.collect(toUnmodifiableList());
+				.collect(collectingAndThen(toList(), Collections::unmodifiableList));
 	}
 
 }

--- a/src/test/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtensionTests.java
@@ -471,6 +471,16 @@ public class CartesianTestExtensionTests {
 				assertThat(results).hasNumberOfDynamicallyRegisteredTests(2).hasNumberOfSucceededTests(2);
 			}
 
+			@Test
+			@DisplayName("when configured with NULL parameters")
+			void usesCustomCartesianArgumentsProviderWithNullArgumentOnParameters() {
+				ExecutionResults results = PioneerTestKit
+						.executeTestMethodWithParameterTypes(CustomCartesianArgumentsProviderTestCases.class,
+							"nullValuesCartesianArgumentProvider", String.class);
+
+				assertThat(results).hasNumberOfDynamicallyRegisteredTests(3).hasNumberOfSucceededTests(3);
+			}
+
 		}
 
 	}
@@ -1190,6 +1200,11 @@ public class CartesianTestExtensionTests {
 			assertThat(source).hasSize(2);
 		}
 
+		@CartesianTest
+		void nullValuesCartesianArgumentProvider(@NullValues String string) {
+
+		}
+
 	}
 
 	private enum TestEnum implements TestInterface {
@@ -1262,6 +1277,21 @@ public class CartesianTestExtensionTests {
 		@Override
 		public Stream<String> provideArguments(ExtensionContext context, Parameter parameter) {
 			return Stream.of("1", "2");
+		}
+
+	}
+
+	@Target(ElementType.PARAMETER)
+	@Retention(RetentionPolicy.RUNTIME)
+	@CartesianArgumentsSource(NullValuesProvider.class)
+	@interface NullValues {
+	}
+
+	static class NullValuesProvider implements CartesianParameterArgumentsProvider<String> {
+
+		@Override
+		public Stream<String> provideArguments(ExtensionContext context, Parameter parameter) {
+			return Stream.of(null, "1", null, "2");
 		}
 
 	}


### PR DESCRIPTION
During migration to JDK11 the support of NULL values provided by CartesianParameterArgumentsProvider has been silently dropped.

These changes
 - add back support for NULL values and ensure backward compatibility with v. 2.0.1
 - add regression tests for provided NULL values support

Fixes: #764

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code (general)
* [ ] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [x] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Code (new package)
* [ ] The new package is exported in `module-info.java`
* [ ] The new package is also present in the tests
* [ ] The new package is opened for reflection to JUnit 5 in `module-info.java`
* [ ] The new package is listed in the contribution guide

Contributing
* [ ] A prepared commit message exists
* [x] The list of contributions inside `README.md` mentions the new contribution (real name optional) 
