### PR TITLE
Add new interfaces to extend DefaultLocale and DefaultTimeZone

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
       - name: Validate Gradle wrapper
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/actions/wrapper-validation@v4
 
   # Our basic build step as we want contributors to have a nice developer
   # experience with little build time and sufficient feedback. Therefore, we

--- a/docs/default-locale-timezone.adoc
+++ b/docs/default-locale-timezone.adoc
@@ -42,6 +42,15 @@ include::{demo}[tag=default_locale_class_level]
 
 NOTE: A class-level configuration means that the specified locale is set before and reset after each individual test in the annotated class.
 
+If your use case is not covered, you can implement the `LocaleProvider` interface.
+
+[source,java,indent=0]
+----
+include::{demo}[tag=default_locale_with_provider]
+----
+
+NOTE: The provider implementation must have a no-args (or the default) constructor.
+
 == `@DefaultTimeZone`
 
 The default `TimeZone` is specified according to the https://docs.oracle.com/javase/8/docs/api/java/util/TimeZone.html#getTimeZone-java.lang.String-[TimeZone.getTimeZone(String)] method.
@@ -59,6 +68,15 @@ include::{demo}[tag=default_timezone_class_level]
 ----
 
 NOTE: A class-level configuration means that the specified time zone is set before and reset after each individual test in the annotated class.
+
+If your use case is not covered, you can implement the `TimeZoneProvider` interface.
+
+[source,java,indent=0]
+----
+include::{demo}[tag=default_time_zone_with_provider]
+----
+
+NOTE: The provider implementation must have a no-args (or the default) constructor.
 
 == Thread-Safety
 

--- a/src/demo/java/org/junitpioneer/jupiter/DefaultLocaleTimezoneExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/DefaultLocaleTimezoneExtensionDemo.java
@@ -12,6 +12,7 @@ package org.junitpioneer.jupiter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.ZoneOffset;
 import java.util.Locale;
 import java.util.TimeZone;
 
@@ -68,6 +69,23 @@ public class DefaultLocaleTimezoneExtensionDemo {
 	}
 	// end::default_locale_class_level[]
 
+	// tag::default_locale_with_provider[]
+	@Test
+	@DefaultLocale(localeProvider = EnglishProvider.class)
+	void test_with_locale_provider() {
+		assertThat(Locale.getDefault()).isEqualTo(new Locale.Builder().setLanguage("en").build());
+	}
+
+	static class EnglishProvider implements LocaleProvider {
+
+		@Override
+		public Locale get() {
+			return Locale.ENGLISH;
+		}
+
+	}
+	// end::default_locale_with_provider[]
+
 	// tag::default_timezone_zone[]
 	@Test
 	@DefaultTimeZone("CET")
@@ -100,5 +118,22 @@ public class DefaultLocaleTimezoneExtensionDemo {
 
 	}
 	// end::default_timezone_class_level[]
+
+	// tag::default_time_zone_with_provider[]
+	@Test
+	@DefaultTimeZone(timeZoneProvider = UtcTimeZoneProvider.class)
+	void test_with_time_zone_provider() {
+		assertThat(TimeZone.getDefault()).isEqualTo(TimeZone.getTimeZone("UTC"));
+	}
+
+	static class UtcTimeZoneProvider implements TimeZoneProvider {
+
+		@Override
+		public TimeZone get() {
+			return TimeZone.getTimeZone(ZoneOffset.UTC);
+		}
+
+	}
+	// end::default_time_zone_with_provider[]
 
 }

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
@@ -102,7 +102,7 @@ public @interface DefaultLocale {
 	String variant() default "";
 
 	/**
-	 * A class implementing {@link LocaleProvider} to be used for custom{@code Locale} resolution.
+	 * A class implementing {@link LocaleProvider} to be used for custom {@code Locale} resolution.
 	 * This is mutually exclusive with other properties, if any other property is given a value it
 	 * will result in an {@link org.junit.jupiter.api.extension.ExtensionConfigurationException}.
 	 */

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
@@ -101,4 +101,11 @@ public @interface DefaultLocale {
 	 */
 	String variant() default "";
 
+	/**
+	 * A class implementing {@link LocaleProvider} to be used for custom{@code Locale} resolution.
+	 * This is mutually exclusive with other properties, if any other property is given a value it
+	 * will result in an {@link org.junit.jupiter.api.extension.ExtensionConfigurationException}.
+	 */
+	Class<? extends LocaleProvider> localeProvider() default LocaleProvider.NullLocaleProvider.class;
+
 }

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocaleExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocaleExtension.java
@@ -88,8 +88,7 @@ class DefaultLocaleExtension implements BeforeEachCallback, AfterEachCallback {
 	}
 
 	private static Locale getFromProvider(DefaultLocale annotation) {
-		if (!annotation.value().isEmpty() || !annotation.language().isEmpty() || !annotation.country().isEmpty()
-				|| !annotation.variant().isEmpty())
+		if (!annotation.country().isEmpty() || !annotation.variant().isEmpty())
 			throw new ExtensionConfigurationException(
 				"@DefaultLocale can only be used with a provider if value, language, country and variant are not set.");
 		var providerClass = annotation.localeProvider();

--- a/src/main/java/org/junitpioneer/jupiter/DefaultTimeZone.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultTimeZone.java
@@ -63,7 +63,7 @@ public @interface DefaultTimeZone {
 	String value() default "";
 
 	/**
-	 * A class implementing {@link TimeZoneProvider} to be used for custom{@code TimeZone} resolution.
+	 * A class implementing {@link TimeZoneProvider} to be used for custom {@code TimeZone} resolution.
 	 * This is mutually exclusive with other properties, if any other property is given a value it
 	 * will result in an {@link org.junit.jupiter.api.extension.ExtensionConfigurationException}.
 	 */

--- a/src/main/java/org/junitpioneer/jupiter/DefaultTimeZone.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultTimeZone.java
@@ -60,6 +60,13 @@ public @interface DefaultTimeZone {
 	 * "GMT-8:00". Note that the support of abbreviations is for JDK 1.1.x
 	 * compatibility only and full names should be used.
 	 */
-	String value();
+	String value() default "";
+
+	/**
+	 * A class implementing {@link TimeZoneProvider} to be used for custom{@code TimeZone} resolution.
+	 * This is mutually exclusive with other properties, if any other property is given a value it
+	 * will result in an {@link org.junit.jupiter.api.extension.ExtensionConfigurationException}.
+	 */
+	Class<? extends TimeZoneProvider> timeZoneProvider() default TimeZoneProvider.NullTimeZoneProvider.class;
 
 }

--- a/src/main/java/org/junitpioneer/jupiter/LocaleProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/LocaleProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016-2023 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junitpioneer.jupiter;
+
+import java.util.Locale;
+import java.util.function.Supplier;
+
+public interface LocaleProvider extends Supplier<Locale> {
+
+	abstract class NullLocaleProvider implements LocaleProvider {
+
+		NullLocaleProvider() {
+		}
+
+	}
+
+}

--- a/src/main/java/org/junitpioneer/jupiter/LocaleProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/LocaleProvider.java
@@ -15,11 +15,7 @@ import java.util.function.Supplier;
 
 public interface LocaleProvider extends Supplier<Locale> {
 
-	abstract class NullLocaleProvider implements LocaleProvider {
-
-		NullLocaleProvider() {
-		}
-
+	interface NullLocaleProvider extends LocaleProvider {
 	}
 
 }

--- a/src/main/java/org/junitpioneer/jupiter/TimeZoneProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/TimeZoneProvider.java
@@ -15,11 +15,7 @@ import java.util.function.Supplier;
 
 public interface TimeZoneProvider extends Supplier<TimeZone> {
 
-	abstract class NullTimeZoneProvider implements TimeZoneProvider {
-
-		NullTimeZoneProvider() {
-		}
-
+	interface NullTimeZoneProvider extends TimeZoneProvider {
 	}
 
 }

--- a/src/main/java/org/junitpioneer/jupiter/TimeZoneProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/TimeZoneProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016-2023 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junitpioneer.jupiter;
+
+import java.util.TimeZone;
+import java.util.function.Supplier;
+
+public interface TimeZoneProvider extends Supplier<TimeZone> {
+
+	abstract class NullTimeZoneProvider implements TimeZoneProvider {
+
+		NullTimeZoneProvider() {
+		}
+
+	}
+
+}

--- a/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
@@ -183,7 +183,7 @@ class DefaultLocaleTests {
 			}
 
 			@AfterAll
-			@ReadsDefaultTimeZone
+			@ReadsDefaultLocale
 			void resetAfterTestMethodExecution() {
 				assertThat(Locale.getDefault().getLanguage()).isEqualTo("custom");
 			}
@@ -191,7 +191,7 @@ class DefaultLocaleTests {
 		}
 
 		@AfterAll
-		@ReadsDefaultTimeZone
+		@ReadsDefaultLocale
 		void resetAfterTestMethodExecution() {
 			assertThat(Locale.getDefault().getLanguage()).isEqualTo("custom");
 		}
@@ -376,6 +376,7 @@ class DefaultLocaleTests {
 		}
 
 		@Test
+		@ReadsDefaultLocale
 		@DisplayName("throws a NullPointerException with custom message if provider returns null")
 		void providerReturnsNull() {
 			ExecutionResults results = executeTestMethod(BadProviderTestCases.class, "returnsNull");

--- a/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
@@ -390,14 +390,26 @@ class DefaultLocaleTests {
 		@Test
 		@ReadsDefaultLocale
 		@DisplayName("throws an ExtensionConfigurationException if any other option is present")
-		void mutuallyExclusive() {
-			ExecutionResults results = executeTestMethod(BadProviderTestCases.class, "mutuallyExclusive");
+		void mutuallyExclusiveWithValue() {
+			ExecutionResults results = executeTestMethod(BadProviderTestCases.class, "mutuallyExclusiveWithValue");
 
 			assertThat(results)
 					.hasSingleFailedTest()
 					.withExceptionInstanceOf(ExtensionConfigurationException.class)
 					.hasMessageContaining(
 						"can only be used with language tag if language, country, variant and provider are not set");
+		}
+
+		@Test
+		@ReadsDefaultLocale
+		@DisplayName("throws an ExtensionConfigurationException if any other option is present")
+		void mutuallyExclusiveWithLanguage() {
+			ExecutionResults results = executeTestMethod(BadProviderTestCases.class, "mutuallyExclusiveWithLanguage");
+
+			assertThat(results)
+					.hasSingleFailedTest()
+					.withExceptionInstanceOf(ExtensionConfigurationException.class)
+					.hasMessageContaining("can only be used with language tag if provider is not set");
 		}
 
 		@Test
@@ -418,7 +430,12 @@ class DefaultLocaleTests {
 
 		@Test
 		@DefaultLocale(value = "en", localeProvider = BasicLocaleProvider.class)
-		void mutuallyExclusive() {
+		void mutuallyExclusiveWithValue() {
+		}
+
+		@Test
+		@DefaultLocale(language = "en", localeProvider = BasicLocaleProvider.class)
+		void mutuallyExclusiveWithLanguage() {
 		}
 
 		@Test

--- a/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
@@ -388,6 +388,7 @@ class DefaultLocaleTests {
 		}
 
 		@Test
+		@ReadsDefaultLocale
 		@DisplayName("throws an ExtensionConfigurationException if any other option is present")
 		void mutuallyExclusive() {
 			ExecutionResults results = executeTestMethod(BadProviderTestCases.class, "mutuallyExclusive");
@@ -400,6 +401,7 @@ class DefaultLocaleTests {
 		}
 
 		@Test
+		@ReadsDefaultLocale
 		@DisplayName("throws an ExtensionConfigurationException if localeProvider can't be constructed")
 		void badConstructor() {
 			ExecutionResults results = executeTestMethod(BadProviderTestCases.class, "badConstructor");

--- a/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
@@ -421,7 +421,8 @@ class DefaultLocaleTests {
 			assertThat(results)
 					.hasSingleFailedTest()
 					.withExceptionInstanceOf(ExtensionConfigurationException.class)
-					.hasMessageContaining("can only be used with a provider if value, language, country and variant are not set.");
+					.hasMessageContaining(
+						"can only be used with a provider if value, language, country and variant are not set.");
 		}
 
 		@Test
@@ -433,7 +434,8 @@ class DefaultLocaleTests {
 			assertThat(results)
 					.hasSingleFailedTest()
 					.withExceptionInstanceOf(ExtensionConfigurationException.class)
-					.hasMessageContaining("can only be used with a provider if value, language, country and variant are not set.");
+					.hasMessageContaining(
+						"can only be used with a provider if value, language, country and variant are not set.");
 		}
 
 		@Test

--- a/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
@@ -414,6 +414,30 @@ class DefaultLocaleTests {
 
 		@Test
 		@ReadsDefaultLocale
+		@DisplayName("throws an ExtensionConfigurationException if any other option is present")
+		void mutuallyExclusiveWithCountry() {
+			ExecutionResults results = executeTestMethod(BadProviderTestCases.class, "mutuallyExclusiveWithCountry");
+
+			assertThat(results)
+					.hasSingleFailedTest()
+					.withExceptionInstanceOf(ExtensionConfigurationException.class)
+					.hasMessageContaining("can only be used with a provider if value, language, country and variant are not set.");
+		}
+
+		@Test
+		@ReadsDefaultLocale
+		@DisplayName("throws an ExtensionConfigurationException if any other option is present")
+		void mutuallyExclusiveWithVariant() {
+			ExecutionResults results = executeTestMethod(BadProviderTestCases.class, "mutuallyExclusiveWithVariant");
+
+			assertThat(results)
+					.hasSingleFailedTest()
+					.withExceptionInstanceOf(ExtensionConfigurationException.class)
+					.hasMessageContaining("can only be used with a provider if value, language, country and variant are not set.");
+		}
+
+		@Test
+		@ReadsDefaultLocale
 		@DisplayName("throws an ExtensionConfigurationException if localeProvider can't be constructed")
 		void badConstructor() {
 			ExecutionResults results = executeTestMethod(BadProviderTestCases.class, "badConstructor");
@@ -438,6 +462,18 @@ class DefaultLocaleTests {
 		@DefaultLocale(language = "en", localeProvider = BasicLocaleProvider.class)
 		void mutuallyExclusiveWithLanguage() {
 			// can't have both a language property and a provider
+		}
+
+		@Test
+		@DefaultLocale(country = "EN", localeProvider = BasicLocaleProvider.class)
+		void mutuallyExclusiveWithCountry() {
+			// can't have both a country property and a provider
+		}
+
+		@Test
+		@DefaultLocale(variant = "japanese", localeProvider = BasicLocaleProvider.class)
+		void mutuallyExclusiveWithVariant() {
+			// can't have both a variant property and a provider
 		}
 
 		@Test

--- a/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
@@ -431,21 +431,25 @@ class DefaultLocaleTests {
 		@Test
 		@DefaultLocale(value = "en", localeProvider = BasicLocaleProvider.class)
 		void mutuallyExclusiveWithValue() {
+			// can't have both a value and a provider
 		}
 
 		@Test
 		@DefaultLocale(language = "en", localeProvider = BasicLocaleProvider.class)
 		void mutuallyExclusiveWithLanguage() {
+			// can't have both a language property and a provider
 		}
 
 		@Test
 		@DefaultLocale(localeProvider = ReturnsNullLocaleProvider.class)
 		void returnsNull() {
+			// provider should not return 'null'
 		}
 
 		@Test
 		@DefaultLocale(localeProvider = BadConstructorLocaleProvider.class)
 		void badConstructor() {
+			// provider has to have a no-args constructor
 		}
 
 	}
@@ -470,12 +474,15 @@ class DefaultLocaleTests {
 
 	static class BadConstructorLocaleProvider implements LocaleProvider {
 
-		BadConstructorLocaleProvider(String unused) {
+		private final String language;
+
+		BadConstructorLocaleProvider(String language) {
+			this.language = language;
 		}
 
 		@Override
 		public Locale get() {
-			return Locale.GERMAN;
+			return Locale.forLanguageTag(language);
 		}
 
 	}

--- a/src/test/java/org/junitpioneer/jupiter/DefaultTimeZoneTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultTimeZoneTests.java
@@ -297,6 +297,7 @@ class DefaultTimeZoneTests {
 		}
 
 		@Test
+		@ReadsDefaultTimeZone
 		@DisplayName("throws ExtensionConfigurationException if properties are empty")
 		void throwsForEmptyOptions() {
 			ExecutionResults results = executeTestMethod(BadTimeZoneProviderCases.class, "empty");
@@ -308,6 +309,7 @@ class DefaultTimeZoneTests {
 		}
 
 		@Test
+		@ReadsDefaultTimeZone
 		@DisplayName("throws ExtensionConfigurationException if the provider does not have a suitable constructor")
 		void throwsForBadConstructor() {
 			ExecutionResults results = executeTestMethod(BadTimeZoneProviderCases.class, "noConstructor");

--- a/src/test/java/org/junitpioneer/jupiter/DefaultTimeZoneTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultTimeZoneTests.java
@@ -286,6 +286,7 @@ class DefaultTimeZoneTests {
 		}
 
 		@Test
+		@ReadsDefaultTimeZone
 		@DisplayName("throws ExtensionConfigurationException if the provider is not the only option")
 		void throwsForMutuallyExclusiveOptions() {
 			ExecutionResults results = executeTestMethod(BadTimeZoneProviderCases.class, "notExclusive");

--- a/src/test/java/org/junitpioneer/jupiter/DefaultTimeZoneTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultTimeZoneTests.java
@@ -289,7 +289,7 @@ class DefaultTimeZoneTests {
 		@ReadsDefaultTimeZone
 		@DisplayName("throws ExtensionConfigurationException if the provider is not the only option")
 		void throwsForMutuallyExclusiveOptions() {
-			ExecutionResults results = executeTestMethod(BadTimeZoneProviderCases.class, "notExclusive");
+			ExecutionResults results = executeTestMethod(BadTimeZoneProviderTestCases.class, "notExclusive");
 
 			assertThat(results)
 					.hasSingleFailedTest()
@@ -301,7 +301,7 @@ class DefaultTimeZoneTests {
 		@ReadsDefaultTimeZone
 		@DisplayName("throws ExtensionConfigurationException if properties are empty")
 		void throwsForEmptyOptions() {
-			ExecutionResults results = executeTestMethod(BadTimeZoneProviderCases.class, "empty");
+			ExecutionResults results = executeTestMethod(BadTimeZoneProviderTestCases.class, "empty");
 
 			assertThat(results)
 					.hasSingleFailedTest()
@@ -313,7 +313,7 @@ class DefaultTimeZoneTests {
 		@ReadsDefaultTimeZone
 		@DisplayName("throws ExtensionConfigurationException if the provider does not have a suitable constructor")
 		void throwsForBadConstructor() {
-			ExecutionResults results = executeTestMethod(BadTimeZoneProviderCases.class, "noConstructor");
+			ExecutionResults results = executeTestMethod(BadTimeZoneProviderTestCases.class, "noConstructor");
 
 			assertThat(results)
 					.hasSingleFailedTest()
@@ -323,21 +323,24 @@ class DefaultTimeZoneTests {
 
 	}
 
-	static class BadTimeZoneProviderCases {
+	static class BadTimeZoneProviderTestCases {
 
 		@Test
 		@DefaultTimeZone(value = "GMT", timeZoneProvider = BasicTimeZoneProvider.class)
 		void notExclusive() {
+			// can't have both a time zone value and a provider
 		}
 
 		@Test
 		@DefaultTimeZone
 		void empty() {
+			// must have a provider or a time zone
 		}
 
 		@Test
 		@DefaultTimeZone(timeZoneProvider = ComplicatedProvider.class)
 		void noConstructor() {
+			// provider has to have a no-args constructor
 		}
 
 	}
@@ -362,12 +365,15 @@ class DefaultTimeZoneTests {
 
 	static class ComplicatedProvider implements TimeZoneProvider {
 
-		private ComplicatedProvider(String value) {
+		private final String timeZoneString;
+
+		public ComplicatedProvider(String timeZoneString) {
+			this.timeZoneString = timeZoneString;
 		}
 
 		@Override
 		public TimeZone get() {
-			return TimeZone.getTimeZone("Europe/Prague");
+			return TimeZone.getTimeZone(timeZoneString);
 		}
 
 	}


### PR DESCRIPTION
Closes #660 

Proposed commit message:

```
Extension to DefaultLocale and DefaultTimeZone (#660 / #770)

Adds a way for users to pull in their own custom implementations when
using @DefaultLocale and @DefaultTimeZone.

Closes: #660
PR: #770
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [x] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [x] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [x] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [x] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [x] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [x] The `package-info.java` contains information about the new extension

Code (general)
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Code (new package)
* [ ] The new package is exported in `module-info.java`
* [ ] The new package is also present in the tests
* [ ] The new package is opened for reflection to JUnit 5 in `module-info.java`
* [ ] The new package is listed in the contribution guide

Contributing
* [ ] A prepared commit message exists
* [ ] The list of contributions inside `README.md` mentions the new contribution (real name optional) 
