### PR TITLE
Create separate Sonar step in build (update to Java 17)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,7 @@ jobs:
   # experience with little build time and sufficient feedback. Therefore, we
   # only build this on our default Java version but for all operating systems
   # we are supporting. This allows for a fast execution and fast feedback. The
-  # extended tests will run later under certain conditions. If the OS is
-  # Ubuntu, we also run the SonarCloud analysis.
+  # extended tests will run later under certain conditions.
   basic:
     runs-on: ${{ matrix.os }}-latest
     needs: validation
@@ -59,17 +58,36 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
-        with:
-          # Sonar needs the whole Git history for issue assignment
-          fetch-depth: 0
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
           java-version: 11
           distribution: temurin
           cache: 'gradle'
+      - name: Gradle build
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: --refresh-dependencies --stacktrace --scan clean build -x spotlessCheck
+
+  # SonarCloud analysis
+  sonar-cloud-analysis:
+    runs-on: ubuntu-latest
+    needs: validation
+    timeout-minutes: 15
+    name: SonarCloud analysis
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with:
+          # Sonar needs the whole Git history for issue assignment
+          fetch-depth: 0
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: temurin
+          cache: 'gradle'
       - name: Cache SonarCloud results
-        if: ${{ matrix.os == 'ubuntu' }}
         uses: actions/cache@v3
         with:
           path: ~/.sonar/cache/
@@ -79,7 +97,6 @@ jobs:
         with:
           arguments: --refresh-dependencies --stacktrace --scan clean build -x spotlessCheck
       - name: SonarCloud analysis
-        if: ${{ matrix.os == 'ubuntu' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: "61ab2579215aa8a0024a2f9368fc1298fdecfd18"


### PR DESCRIPTION
Closes #782 

Proposed commit message:

```
Make SonarCloud job use Java 17 (#782 / #784)

SonarCloud is moving away from supporting Java 11.
This PR separates the job from the main build into its own step
and configures it to use Java 17.

Closes: #782
PR: #784
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code (general)
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#assertions) (which are based on AssertJ)

Code (new package)
* [ ] The new package is exported in `module-info.java`
* [ ] The new package is also present in the tests
* [ ] The new package is opened for reflection to JUnit 5 in `module-info.java`
* [ ] The new package is listed in the contribution guide

Contributing
* [ ] A prepared commit message exists
* [ ] The list of contributions inside `README.adoc` mentions the new contribution (real name optional) 
