### PR TITLE
Homogenize and improve Javadoc, particularly <p> tags:

### DIFF
--- a/src/main/java/org/junitpioneer/internal/PioneerAnnotationUtils.java
+++ b/src/main/java/org/junitpioneer/internal/PioneerAnnotationUtils.java
@@ -35,8 +35,8 @@ import org.junitpioneer.jupiter.cartesian.CartesianArgumentsSource;
 /**
  * Pioneer-internal utility class to handle annotations.
  * DO NOT USE THIS CLASS - IT MAY CHANGE SIGNIFICANTLY IN ANY MINOR UPDATE.
- * <p>
- * It uses the following terminology to describe annotations that are not
+ *
+ * <p>It uses the following terminology to describe annotations that are not
  * immediately present on an element:</p>
  *
  * <ul>
@@ -46,11 +46,10 @@ import org.junitpioneer.jupiter.cartesian.CartesianArgumentsSource;
  *     		{@link org.junit.jupiter.api.Nested @Nested}) is annotated</li>
  * </ul>
  *
- * <p>
- * All of the above mechanisms apply recursively, meaning that, e.g., for an annotation to be
+ * <p>All of the above mechanisms apply recursively, meaning that, e.g., for an annotation to be
  * <em>meta-present</em> it can present on an annotation that is present on another annotation
- * that is present on the element.
- * </p>
+ * that is present on the element.</p>
+ *
  */
 public class PioneerAnnotationUtils {
 

--- a/src/main/java/org/junitpioneer/jupiter/AbstractEntryBasedExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/AbstractEntryBasedExtension.java
@@ -305,9 +305,10 @@ abstract class AbstractEntryBasedExtension<K, V, C extends Annotation, S extends
 	}
 
 	/**
-	 * <p>Prepare the entry-based environment for entering a context that must be restorable.</p>
+	 * Prepare the entry-based environment for entering a context that must be restorable.
 	 *
-	 * <p>Implementations may choose one of two strategies:
+	 * <p>Implementations may choose one of two strategies:</p>
+	 *
 	 * <ul>
 	 * <li><em>Post swap</em>, where the original entry-based environment is left in place and a clone is returned.
 	 * In this case {@link #prepareToExitRestorableContext} will restore the clone.
@@ -315,7 +316,6 @@ abstract class AbstractEntryBasedExtension<K, V, C extends Annotation, S extends
 	 * original is returned.
 	 * In this case the {@link #prepareToExitRestorableContext} will restore the original environment.</li>
 	 * </ul>
-	 * </p>
 	 *
 	 * <p>The returned {@code Properties} must not be null and its key-value pairs must follow the rules for
 	 * entries of its type. E.g., environment variables contain only Strings while System {@code Properties}
@@ -326,7 +326,7 @@ abstract class AbstractEntryBasedExtension<K, V, C extends Annotation, S extends
 	protected abstract Properties prepareToEnterRestorableContext();
 
 	/**
-	 * <p>Prepare to exit a restorable context for the entry based environment.</p>
+	 * Prepare to exit a restorable context for the entry based environment.
 	 *
 	 * <p>The entry environment will be restored to the state passed in as {@code Properties}.
 	 * The {@code Properties} entries must follow the rules for entries of this environment,

--- a/src/main/java/org/junitpioneer/jupiter/ClearEnvironmentVariable.java
+++ b/src/main/java/org/junitpioneer/jupiter/ClearEnvironmentVariable.java
@@ -43,12 +43,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,
  * all tests annotated with {@link ClearEnvironmentVariable}, {@link SetEnvironmentVariable}, {@link ReadsEnvironmentVariable}, and {@link WritesEnvironmentVariable}
- * are executed sequentially to guarantee correctness under mutation of shared global state.
- * </p>
+ * are executed sequentially to guarantee correctness under mutation of shared global state.</p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/environment-variables/" target="_top">the documentation on <code>@ClearEnvironmentVariable and @SetEnvironmentVariable</code></a>.
- * </p>
+ * <a href="https://junit-pioneer.org/docs/environment-variables/" target="_top">the documentation on <code>@ClearEnvironmentVariable and @SetEnvironmentVariable</code></a>.</p>
  *
  * @since 0.6
  */

--- a/src/main/java/org/junitpioneer/jupiter/ClearSystemProperty.java
+++ b/src/main/java/org/junitpioneer/jupiter/ClearSystemProperty.java
@@ -35,12 +35,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,
  * all tests annotated with {@link ClearSystemProperty}, {@link SetSystemProperty}, {@link ReadsSystemProperty}, and {@link WritesSystemProperty}
- * are scheduled in a way that guarantees correctness under mutation of shared global state.
- * </p>
+ * are scheduled in a way that guarantees correctness under mutation of shared global state.</p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/system-properties/" target="_top">the documentation on <code>@ClearSystemProperty and @SetSystemProperty</code></a>.
- * </p>
+ * <a href="https://junit-pioneer.org/docs/system-properties/" target="_top">the documentation on <code>@ClearSystemProperty and @SetSystemProperty</code></a>.</p>
  *
  * @since 0.5
  */

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
@@ -56,12 +56,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,
  * all tests annotated with {@link DefaultLocale}, {@link ReadsDefaultLocale}, and {@link WritesDefaultLocale}
- * are scheduled in a way that guarantees correctness under mutation of shared global state.
- * </p>
+ * are scheduled in a way that guarantees correctness under mutation of shared global state.</p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/default-locale-timezone/" target="_top">the documentation on <code>@DefaultLocale and @DefaultTimeZone</code></a>.
- * </p>
+ * <a href="https://junit-pioneer.org/docs/default-locale-timezone/" target="_top">the documentation on <code>@DefaultLocale</code> and <code>@DefaultTimeZone</code></a>.</p>
  *
  * @since 0.2
  * @see java.util.Locale#getDefault()

--- a/src/main/java/org/junitpioneer/jupiter/DefaultTimeZone.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultTimeZone.java
@@ -38,12 +38,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,
  * all tests annotated with {@link DefaultTimeZone}, {@link ReadsDefaultTimeZone}, and {@link WritesDefaultTimeZone}
- * are scheduled in a way that guarantees correctness under mutation of shared global state.
- * </p>
+ * are scheduled in a way that guarantees correctness under mutation of shared global state.</p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/default-locale-timezone/" target="_top">the documentation on <code>@DefaultLocale and @DefaultTimeZone</code></a>.
- * </p>
+ * <a href="https://junit-pioneer.org/docs/default-locale-timezone/" target="_top">the documentation on <code>@DefaultLocale</code> and <code>@DefaultTimeZone</code></a>.</p>
  *
  * @since 0.2
  * @see java.util.TimeZone#getDefault()

--- a/src/main/java/org/junitpioneer/jupiter/DisableIfTestFails.java
+++ b/src/main/java/org/junitpioneer/jupiter/DisableIfTestFails.java
@@ -20,22 +20,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Disables all remaining tests in a container if one of them failed.
- * <p>
- * By default, all exceptions (including assertions, but exempting failed assumptions) will lead to
+ *
+ * <p>By default, all exceptions (including assertions, but exempting failed assumptions) will lead to
  * disabling the remaining tests. To configure this in more detail, see {@link #with()} and
- * {@link #onAssertion()}.
- * </p>
- * <p>
- * This annotation can be (meta-)present on classes that contain a nested class. In that case, a
- * failing test in the outer class will disable the nested class (if it runs later) and vice versa.
- * </p>
- * <p>
- * This annotation can be (meta-)present on a class and/or its super types (classes or interfaces).
+ * {@link #onAssertion()}.</p>
+ *
+ * <p>This annotation can be (meta-)present on classes that contain a nested class. In that case, a
+ * failing test in the outer class will disable the nested class (if it runs later) and vice versa.</p>
+ *
+ * <p>This annotation can be (meta-)present on a class and/or its super types (classes or interfaces).
  * In that case, the exception types given to {@link #with()} are merged and {@link #onAssertion()}
- * is or'ed.
- * </p>
- * <p>
- * But if a test fails in a specific class, only other tests in the corresponding container will
+ * is or'ed.</p>
+ *
+ * <p>But if a test fails in a specific class, only other tests in the corresponding container will
  * be disabled. That means if...</p>
  *
  * <ul>
@@ -55,21 +52,19 @@ public @interface DisableIfTestFails {
 
 	/**
 	 * Configure on which exceptions remaining tests are disabled (defaults to "any exception").
-	 * <p>
-	 * If {@code @DisableIfTestFails} is present multiple times (e.g. on multiple super types),
+	 *
+	 * <p>If {@code @DisableIfTestFails} is present multiple times (e.g. on multiple super types),
 	 * these exceptions are collected across all annotations, meaning if any of the mentioned
-	 * exceptions are thrown, the remaining tests are disabled.
-	 * </p>
+	 * exceptions are thrown, the remaining tests are disabled.</p>
 	 */
 	Class<? extends Throwable>[] with() default {};
 
 	/**
 	 * Set to {@code false} if failed assertions should not lead to disabling remaining tests.
-	 * <p>
-	 * If {@code @DisableIfTestFails} is present multiple times (e.g. on multiple super types),
+	 *
+	 * <p>If {@code @DisableIfTestFails} is present multiple times (e.g. on multiple super types),
 	 * this value is or'ed, meaning as soon as one annotation says to fail on assertion errors,
-	 * that's how the container will behave.
-	 * </p>
+	 * that's how the container will behave.</p>
 	 */
 	boolean onAssertion() default true;
 

--- a/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
@@ -77,8 +77,8 @@ class EnvironmentVariableExtension extends
 	}
 
 	/**
-	 * <p>This implementation uses the "Post swap" strategy, returning a clone of the environment variables
-	 * which will be restored in {@link AbstractEntryBasedExtension#prepareToExitRestorableContext}.</p>
+	 * This implementation uses the "Post swap" strategy, returning a clone of the environment variables
+	 * which will be restored in {@link AbstractEntryBasedExtension#prepareToExitRestorableContext}.
 	 *
 	 * <p>See {@link AbstractEntryBasedExtension#prepareToEnterRestorableContext} for more details.</p>
 	 *

--- a/src/main/java/org/junitpioneer/jupiter/ExpectedToFail.java
+++ b/src/main/java/org/junitpioneer/jupiter/ExpectedToFail.java
@@ -30,24 +30,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * <p>The big difference compared to JUnit's {@link org.junit.jupiter.api.Disabled @Disabled}
  * annotation is that the developer is informed as soon as a test is successful again.
  * This helps to avoid creating duplicate tests by accident and counteracts the accumulation
- * of disabled tests over time.
- * </p>
+ * of disabled tests over time.</p>
  *
  * <p>The annotation can only be used on methods and as meta-annotation on other annotation types.
  * Similar to {@code @Disabled}, it has to be used in addition to a "testable" annotation, such
- * as {@link org.junit.jupiter.api.Test @Test}. Otherwise the annotation has no effect.
- * </p>
+ * as {@link org.junit.jupiter.api.Test @Test}. Otherwise the annotation has no effect.</p>
  *
  * <p><b>Important:</b> This annotation is <b>not</b> intended as a way to mark test methods
  * which intentionally cause exceptions. Such test methods should use
  * {@link org.junit.jupiter.api.Assertions#assertThrows(Class, org.junit.jupiter.api.function.Executable) assertThrows}
  * or similar means to explicitly test for a specific exception class being thrown by a
- * specific action.
- * </p>
+ * specific action.</p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/expected-to-fail-tests/" target="_top">the documentation on <code>@ExpectedToFail</code></a>.
- * </p>
+ * <a href="https://junit-pioneer.org/docs/expected-to-fail-tests/" target="_top">the documentation on <code>@ExpectedToFail</code></a>.</p>
  *
  * @since 1.8.0
  * @see org.junit.jupiter.api.Disabled

--- a/src/main/java/org/junitpioneer/jupiter/ExpectedToFailExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/ExpectedToFailExtension.java
@@ -58,8 +58,7 @@ class ExpectedToFailExtension implements Extension, InvocationInterceptor {
 	 * of considering it an 'expected to fail' exception.
 	 *
 	 * <p>This method is used for exceptions that abort test execution and should
-	 * have higher precedence than aborted exceptions thrown by this extension.
-	 * </p>
+	 * have higher precedence than aborted exceptions thrown by this extension.</p>
 	 */
 	private static boolean shouldPreserveException(Throwable t) {
 		// Note: Ideally would use the same logic JUnit uses to determine if exception is aborting

--- a/src/main/java/org/junitpioneer/jupiter/Issue.java
+++ b/src/main/java/org/junitpioneer/jupiter/Issue.java
@@ -21,11 +21,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 /**
  * {@code @Issue} is a JUnit Jupiter extension to mark tests that
  * exist to cover an issue, like a requirement or a bugfix.
- * <p>
- * The annotated issue ID will be published as a report entry - where
+ *
+ * <p>The annotated issue ID will be published as a report entry - where
  * this information will be visible, depends on the tool used to
- * execute the tests.
- * </p>
+ * execute the tests.</p>
  *
  * <p>{@code @Issue} can be used on the method and class level.
  * Warning: If you place it on class level, make sure to not mix tests which belong to the issue and those which don't!</p>

--- a/src/main/java/org/junitpioneer/jupiter/IssueTestCase.java
+++ b/src/main/java/org/junitpioneer/jupiter/IssueTestCase.java
@@ -18,9 +18,8 @@ import org.junit.platform.engine.TestExecutionResult.Status;
 
 /**
  * Represents the execution result of test method, which is annotated with {@link Issue}.
- * <p>
- * Once Pioneer baselines against Java 17, this will be a record.
- * </p>
+ *
+ * <p>Once Pioneer baselines against Java 17, this will be a record.</p>
  *
  * @since 1.1
  * @see Issue

--- a/src/main/java/org/junitpioneer/jupiter/IssueTestSuite.java
+++ b/src/main/java/org/junitpioneer/jupiter/IssueTestSuite.java
@@ -15,9 +15,8 @@ import java.util.Objects;
 
 /**
  * Represents the execution result of test method, which is annotated with {@link org.junitpioneer.jupiter.Issue}.
- * <p>
- * Once Pioneer baselines against Java 17, this will be a record.
- * </p>
+ *
+ * <p>Once Pioneer baselines against Java 17, this will be a record.</p>
  *
  * @since 1.1
  * @see Issue

--- a/src/main/java/org/junitpioneer/jupiter/ReadsDefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReadsDefaultLocale.java
@@ -26,12 +26,10 @@ import org.junit.jupiter.api.parallel.Resources;
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,
  * all tests annotated with {@link DefaultLocale}, {@link ReadsDefaultLocale}, and {@link WritesDefaultLocale}
- * are scheduled in a way that guarantees correctness under mutation of shared global state.
- * </p>
+ * are scheduled in a way that guarantees correctness under mutation of shared global state.</p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/default-locale-timezone/" target="_top">the documentation on <code>@DefaultLocale</code> and <code>@DefaultTimeZone</code></a>.
- * </p>
+ * <a href="https://junit-pioneer.org/docs/default-locale-timezone/" target="_top">the documentation on <code>@DefaultLocale</code> and <code>@DefaultTimeZone</code></a>.</p>
  *
  * @since 0.9
  */

--- a/src/main/java/org/junitpioneer/jupiter/ReadsDefaultTimeZone.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReadsDefaultTimeZone.java
@@ -26,12 +26,10 @@ import org.junit.jupiter.api.parallel.Resources;
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,
  * all tests annotated with {@link DefaultTimeZone}, {@link ReadsDefaultTimeZone}, and {@link WritesDefaultTimeZone}
- * are scheduled in a way that guarantees correctness under mutation of shared global state.
- * </p>
+ * are scheduled in a way that guarantees correctness under mutation of shared global state.</p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/default-locale-timezone/" target="_top">the documentation on <code>@DefaultLocale</code> and <code>@DefaultTimeZone</code></a>.
- * </p>
+ * <a href="https://junit-pioneer.org/docs/default-locale-timezone/" target="_top">the documentation on <code>@DefaultLocale</code> and <code>@DefaultTimeZone</code></a>.</p>
  *
  * @since 0.9
  */

--- a/src/main/java/org/junitpioneer/jupiter/ReadsEnvironmentVariable.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReadsEnvironmentVariable.java
@@ -25,12 +25,10 @@ import org.junit.jupiter.api.parallel.ResourceLock;
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,
  * all tests annotated with {@link ClearEnvironmentVariable}, {@link SetEnvironmentVariable}, {@link ReadsEnvironmentVariable}, and {@link WritesEnvironmentVariable}
- * are scheduled in a way that guarantees correctness under mutation of shared global state.
- * </p>
+ * are scheduled in a way that guarantees correctness under mutation of shared global state.</p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/environment-variables/" target="_top">the documentation on <code>@ClearEnvironmentVariable</code> and <code>@SetEnvironmentVariable</code></a>.
- * </p>
+ * <a href="https://junit-pioneer.org/docs/environment-variables/" target="_top">the documentation on <code>@ClearEnvironmentVariable</code> and <code>@SetEnvironmentVariable</code></a>.</p>
  *
  * @since 0.9
  */

--- a/src/main/java/org/junitpioneer/jupiter/ReadsStdIo.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReadsStdIo.java
@@ -27,12 +27,10 @@ import org.junit.jupiter.api.parallel.Resources;
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,
  * all tests annotated with {@link StdIo}, {@link ReadsStdIo}, and {@link WritesStdIo}
- * are scheduled in a way that guarantees correctness under mutation of shared global state.
- * </p>
+ * are scheduled in a way that guarantees correctness under mutation of shared global state.</p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/standard-input-output/" target="_top">the documentation on Standard input/output</a>.
- * </p>
+ * <a href="https://junit-pioneer.org/docs/standard-input-output/" target="_top">the documentation on standard input/output</a>.</p>
  *
  * @since 0.9
  */

--- a/src/main/java/org/junitpioneer/jupiter/ReadsSystemProperty.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReadsSystemProperty.java
@@ -26,12 +26,10 @@ import org.junit.jupiter.api.parallel.Resources;
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,
  * all tests annotated with {@link ClearSystemProperty}, {@link SetSystemProperty}, {@link ReadsSystemProperty}, and {@link WritesSystemProperty}
- * are scheduled in a way that guarantees correctness under mutation of shared global state.
- * </p>
+ * are scheduled in a way that guarantees correctness under mutation of shared global state.</p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/system-properties/" target="_top">the documentation on <code>@ClearSystemProperty</code> and <code>@SetSystemProperty</code></a>.
- * </p>
+ * <a href="https://junit-pioneer.org/docs/system-properties/" target="_top">the documentation on <code>@ClearSystemProperty</code> and <code>@SetSystemProperty</code></a>.</p>
  *
  * @since 0.9
  */

--- a/src/main/java/org/junitpioneer/jupiter/ReportEntry.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReportEntry.java
@@ -19,22 +19,18 @@ import java.lang.annotation.Target;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
- * Publish the specified key-value pair to be consumed by an
- * {@code org.junit.platform.engine.EngineExecutionListener}
- * in order to supply additional information to the reporting
- * infrastructure. This is functionally identical to calling
+ * Publish the specified key-value pair to be consumed by an {@code org.junit.platform.engine.EngineExecutionListener}
+ * in order to supply additional information to the reporting infrastructure. This is functionally identical to calling
  * {@link org.junit.jupiter.api.extension.ExtensionContext#publishReportEntry(String, String) ExtensionContext::publishReportEntry}
  * from within the test method.
  *
  * <p>{@code ReportEntry} is repeatable and can be used on methods.</p>
  *
  * <p>This extension does not interact with
- * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>.
- * </p>
+ * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>.</p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/report-entries/" target="_top">the documentation on <code>Report entries</code></a>.
- * </p>
+ * <a href="https://junit-pioneer.org/docs/report-entries/" target="_top">the documentation on report entries</a>.</p>
  *
  * @since 0.5.6
  */

--- a/src/main/java/org/junitpioneer/jupiter/RestoreEnvironmentVariables.java
+++ b/src/main/java/org/junitpioneer/jupiter/RestoreEnvironmentVariables.java
@@ -27,8 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * or in {@code @BeforeAll} / {@code @BeforeEach} blocks.
  * To simply set or clear an environment variable, consider
  * {@link SetEnvironmentVariable @SetEnvironmentVariable} or
- * {@link ClearEnvironmentVariable @ClearEnvironmentVariable} instead.
- * </p>
+ * {@link ClearEnvironmentVariable @ClearEnvironmentVariable} instead.</p>
  *
  * <p>{@code RestoreEnvironmentVariables} can be used on the method and on the class level.
  * When placed on a test method, environment variables are stored before the method is run and restored
@@ -54,13 +53,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,
  * all tests annotated with {@link RestoreEnvironmentVariables}, {@link SetEnvironmentVariable},
  * {@link ReadsEnvironmentVariable}, and {@link WritesEnvironmentVariable}
- * are scheduled in a way that guarantees correctness under mutation of shared global state.
- * </p>
+ * are scheduled in a way that guarantees correctness under mutation of shared global state.</p>
  *
  * <p>For more details and examples, see
  * <a href="https://junit-pioneer.org/docs/environment-variables/" target="_top">the documentation on
- * <code>@ClearEnvironmentVariable, @SetEnvironmentVariable and @RestoreEnvironmentVariables</code></a>.
- * </p>
+ * <code>@ClearEnvironmentVariable</code>, <code>@SetEnvironmentVariable</code>, and <code>@RestoreEnvironmentVariables</code></a>.</p>
  *
  * @since 2.0.0
  */

--- a/src/main/java/org/junitpioneer/jupiter/RestoreSystemProperties.java
+++ b/src/main/java/org/junitpioneer/jupiter/RestoreSystemProperties.java
@@ -26,8 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * <p>Use this annotation when there is a need programmatically modify system properties in a test
  * method or in {@code @BeforeAll} / {@code @BeforeEach} blocks.
  * To simply set or clear a system property, consider {@link SetSystemProperty @SetSystemProperty} or
- * {@link ClearSystemProperty @ClearSystemProperty} instead.
- * </p>
+ * {@link ClearSystemProperty @ClearSystemProperty} instead.</p>
  *
  * <p>{@code RestoreSystemProperties} can be used on the method and on the class level.
  * When placed on a test method, a snapshot of system properties is stored prior to that test.
@@ -48,13 +47,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,
  * all tests annotated with {@link RestoreSystemProperties}, {@link SetSystemProperty},
  * {@link ReadsSystemProperty}, and {@link WritesSystemProperty}
- * are scheduled in a way that guarantees correctness under mutation of shared global state.
- * </p>
+ * are scheduled in a way that guarantees correctness under mutation of shared global state.</p>
  *
  * <p>For more details and examples, see
  * <a href="https://junit-pioneer.org/docs/system-properties/" target="_top">the documentation on
- * <code>@ClearSystemProperty, @SetSystemProperty and @RestoreSystemProperties</code></a>.
- * </p>
+ * <code>@ClearSystemProperty</code>, <code>@SetSystemProperty</code>, and <code>@RestoreSystemProperties</code></a>.</p>
  *
  * <p><em>Note:</em> System properties are normally just a hashmap of strings, however, it is
  * technically possible to store non-string values and create nested {@code Properties} with inherited /

--- a/src/main/java/org/junitpioneer/jupiter/SetEnvironmentVariable.java
+++ b/src/main/java/org/junitpioneer/jupiter/SetEnvironmentVariable.java
@@ -44,12 +44,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,
  * all tests annotated with {@link ClearEnvironmentVariable}, {@link SetEnvironmentVariable}, {@link ReadsEnvironmentVariable}, and {@link WritesEnvironmentVariable}
- * are scheduled in a way that guarantees correctness under mutation of shared global state.
- * </p>
+ * are scheduled in a way that guarantees correctness under mutation of shared global state.</p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/environment-variables/" target="_top">the documentation on <code>@ClearEnvironmentVariable and @SetEnvironmentVariable</code></a>.
- * </p>
+ * <a href="https://junit-pioneer.org/docs/environment-variables/" target="_top">the documentation on <code>@ClearEnvironmentVariable</code> and <code>@SetEnvironmentVariable</code></a>.</p>
  *
  * @since 0.6
  */

--- a/src/main/java/org/junitpioneer/jupiter/SetSystemProperty.java
+++ b/src/main/java/org/junitpioneer/jupiter/SetSystemProperty.java
@@ -37,12 +37,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,
  * all tests annotated with {@link ClearSystemProperty}, {@link SetSystemProperty}, {@link ReadsSystemProperty}, and {@link WritesSystemProperty}
- * are scheduled in a way that guarantees correctness under mutation of shared global state.
- * </p>
+ * are scheduled in a way that guarantees correctness under mutation of shared global state.</p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/system-properties/" target="_top">the documentation on <code>@ClearSystemProperty and @SetSystemProperty</code></a>.
- * </p>
+ * <a href="https://junit-pioneer.org/docs/system-properties/" target="_top">the documentation on <code>@ClearSystemProperty</code> and </code>@SetSystemProperty</code></a>.</p>
  *
  * @since 0.5
  */

--- a/src/main/java/org/junitpioneer/jupiter/SetSystemProperty.java
+++ b/src/main/java/org/junitpioneer/jupiter/SetSystemProperty.java
@@ -36,8 +36,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,
- * all tests annotated with {@link ClearSystemProperty}, {@link SetSystemProperty}, {@link ReadsSystemProperty}, and {@link WritesSystemProperty}
- * are scheduled in a way that guarantees correctness under mutation of shared global state.</p>
+ * all tests annotated with {@link ClearSystemProperty}, {@link SetSystemProperty}, {@link ReadsSystemProperty},
+ * and {@link WritesSystemProperty} are scheduled in a way that guarantees correctness under mutation of shared global
+ * state.</p>
  *
  * <p>For more details and examples, see
  * <a href="https://junit-pioneer.org/docs/system-properties/" target="_top">the documentation on <code>@ClearSystemProperty</code> and <code>@SetSystemProperty</code></a>.</p>

--- a/src/main/java/org/junitpioneer/jupiter/SetSystemProperty.java
+++ b/src/main/java/org/junitpioneer/jupiter/SetSystemProperty.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * are scheduled in a way that guarantees correctness under mutation of shared global state.</p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/system-properties/" target="_top">the documentation on <code>@ClearSystemProperty</code> and </code>@SetSystemProperty</code></a>.</p>
+ * <a href="https://junit-pioneer.org/docs/system-properties/" target="_top">the documentation on <code>@ClearSystemProperty</code> and <code>@SetSystemProperty</code></a>.</p>
  *
  * @since 0.5
  */

--- a/src/main/java/org/junitpioneer/jupiter/StdErr.java
+++ b/src/main/java/org/junitpioneer/jupiter/StdErr.java
@@ -11,9 +11,8 @@
 package org.junitpioneer.jupiter;
 
 /**
- * <p>For details and examples, see
- * <a href="https://junit-pioneer.org/docs/standard-input-output/" target="_top">the documentation on <code>Standard input/output</code></a>
- * </p>
+ * For details and examples, see
+ * <a href="https://junit-pioneer.org/docs/standard-input-output/" target="_top">the documentation on standard input/output</a>.
  *
  * @see StdIo
  */

--- a/src/main/java/org/junitpioneer/jupiter/StdIn.java
+++ b/src/main/java/org/junitpioneer/jupiter/StdIn.java
@@ -16,9 +16,8 @@ import java.io.StringReader;
 import java.io.StringWriter;
 
 /**
- * <p>For details and examples, see
- * <a href="https://junit-pioneer.org/docs/standard-input-output/" target="_top">the documentation on <code>Standard input/output</code></a>
- * </p>
+ * For details and examples, see
+ * <a href="https://junit-pioneer.org/docs/standard-input-output/" target="_top">the documentation on standard input/output</a>.
  *
  * @see StdIo
  */

--- a/src/main/java/org/junitpioneer/jupiter/StdIo.java
+++ b/src/main/java/org/junitpioneer/jupiter/StdIo.java
@@ -25,18 +25,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * <p>The annotated test method can have zero, one, or both parameters, but {@code StdIn} can only
  * be provided if {@link StdIo#value()} is used to specify input - otherwise an
  * {@link org.junit.jupiter.api.extension.ExtensionConfigurationException ExtensionConfigurationException}
- * will be thrown.
- * </p>
+ * will be thrown.</p>
  *
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,
  * all tests annotated with {@link StdIo}, {@link ReadsStdIo}, and {@link WritesStdIo}
- * are scheduled in a way that guarantees correctness under mutation of shared global state.
- * </p>
+ * are scheduled in a way that guarantees correctness under mutation of shared global state.</p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/standard-input-output/" target="_top">the documentation on <code>Standard input/output</code></a>.
- * </p>
+ * <a href="https://junit-pioneer.org/docs/standard-input-output/" target="_top">the documentation on standard input/output</a>.</p>
  *
  * @since 0.7
  */

--- a/src/main/java/org/junitpioneer/jupiter/StdOut.java
+++ b/src/main/java/org/junitpioneer/jupiter/StdOut.java
@@ -11,9 +11,8 @@
 package org.junitpioneer.jupiter;
 
 /**
- * <p>For details and examples, see
- * <a href="https://junit-pioneer.org/docs/standard-input-output/" target="_top">the documentation on <code>Standard input/output</code></a>
- * </p>
+ * For details and examples, see
+ * <a href="https://junit-pioneer.org/docs/standard-input-output/" target="_top">the documentation on standard input/output</a>.
  *
  * @see StdIo
  */

--- a/src/main/java/org/junitpioneer/jupiter/SystemPropertyExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/SystemPropertyExtension.java
@@ -47,16 +47,18 @@ class SystemPropertyExtension extends
 	}
 
 	/**
-	 * <p>This implementation uses the "Preemptive swap" strategy.</p>
+	 * This implementation uses the "Preemptive swap" strategy.
 	 *
 	 * <p>Since {@link Properties} allows a wrapped default instance and Object values,
-	 * cloning is difficult:
+	 * cloning is difficult:</p>
+	 *
 	 * <ul>
 	 * <li>It is difficult to tell which values are defaults and which are "top level",
 	 * thus a clone might contain the same effective values, but be flattened without defaults.</li>
 	 * <li>Object values in a wrapped default instance cannot be accessed without reflection.</li>
 	 * </ul>
-	 * The "Preemptive swap" strategy ensure that the original Properties are restored, however
+	 *
+	 * <p>The "Preemptive swap" strategy ensure that the original Properties are restored, however
 	 * complex they were. Any artifacts resulting from a flattened default structure are limited
 	 * to the context of the test.</p>
 	 *
@@ -80,7 +82,7 @@ class SystemPropertyExtension extends
 	}
 
 	/**
-	 * <p>A clone of the String values of the passed {@code Properties}, including defaults.</p>
+	 * A clone of the String values of the passed {@code Properties}, including defaults.
 	 *
 	 * <p>The clone will have the same effective values, but may not use the same nested
 	 * structure as the original. Object values, which are technically possible,

--- a/src/main/java/org/junitpioneer/jupiter/WritesDefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/WritesDefaultLocale.java
@@ -26,12 +26,10 @@ import org.junit.jupiter.api.parallel.Resources;
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,
  * all tests annotated with {@link DefaultLocale}, {@link ReadsDefaultLocale}, and {@link WritesDefaultLocale}
- * are scheduled in a way that guarantees correctness under mutation of shared global state.
- * </p>
+ * are scheduled in a way that guarantees correctness under mutation of shared global state.</p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/default-locale-timezone/" target="_top">the documentation on <code>@DefaultLocale</code> and <code>@DefaultTimeZone</code></a>.
- * </p>
+ * <a href="https://junit-pioneer.org/docs/default-locale-timezone/" target="_top">the documentation on <code>@DefaultLocale</code> and <code>@DefaultTimeZone</code></a>.</p>
  *
  * @since 0.9
  */

--- a/src/main/java/org/junitpioneer/jupiter/WritesDefaultTimeZone.java
+++ b/src/main/java/org/junitpioneer/jupiter/WritesDefaultTimeZone.java
@@ -26,12 +26,10 @@ import org.junit.jupiter.api.parallel.Resources;
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,
  * all tests annotated with {@link DefaultTimeZone}, {@link ReadsDefaultTimeZone}, and {@link WritesDefaultTimeZone}
- * are scheduled in a way that guarantees correctness under mutation of shared global state.
- * </p>
+ * are scheduled in a way that guarantees correctness under mutation of shared global state.</p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/default-locale-timezone/" target="_top">the documentation on <code>@DefaultLocale</code> and <code>@DefaultTimeZone</code></a>.
- * </p>
+ * <a href="https://junit-pioneer.org/docs/default-locale-timezone/" target="_top">the documentation on <code>@DefaultLocale</code> and <code>@DefaultTimeZone</code></a>.</p>
  *
  * @since 0.9
  */

--- a/src/main/java/org/junitpioneer/jupiter/WritesEnvironmentVariable.java
+++ b/src/main/java/org/junitpioneer/jupiter/WritesEnvironmentVariable.java
@@ -25,12 +25,10 @@ import org.junit.jupiter.api.parallel.ResourceLock;
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,
  * all tests annotated with {@link ClearEnvironmentVariable}, {@link SetEnvironmentVariable}, {@link ReadsEnvironmentVariable}, and {@link WritesEnvironmentVariable}
- * are scheduled in a way that guarantees correctness under mutation of shared global state.
- * </p>
+ * are scheduled in a way that guarantees correctness under mutation of shared global state.</p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/environment-variables/" target="_top">the documentation on <code>@ClearEnvironmentVariable</code> and <code>@SetEnvironmentVariable</code></a>.
- * </p>
+ * <a href="https://junit-pioneer.org/docs/environment-variables/" target="_top">the documentation on <code>@ClearEnvironmentVariable</code> and <code>@SetEnvironmentVariable</code></a>.</p>
  *
  * @since 0.9
  */

--- a/src/main/java/org/junitpioneer/jupiter/WritesStdIo.java
+++ b/src/main/java/org/junitpioneer/jupiter/WritesStdIo.java
@@ -27,12 +27,10 @@ import org.junit.jupiter.api.parallel.Resources;
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,
  * all tests annotated with {@link StdIo}, {@link WritesStdIo}, and {@link WritesStdIo}
- * are scheduled in a way that guarantees correctness under mutation of shared global state.
- * </p>
+ * are scheduled in a way that guarantees correctness under mutation of shared global state.</p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/standard-input-output/" target="_top">the documentation on Standard input/output</a>.
- * </p>
+ * <a href="https://junit-pioneer.org/docs/standard-input-output/" target="_top">the documentation on standard input/output</a>.</p>
  *
  * @since 0.9
  */

--- a/src/main/java/org/junitpioneer/jupiter/WritesSystemProperty.java
+++ b/src/main/java/org/junitpioneer/jupiter/WritesSystemProperty.java
@@ -26,12 +26,10 @@ import org.junit.jupiter.api.parallel.Resources;
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,
  * all tests annotated with {@link ClearSystemProperty}, {@link SetSystemProperty}, {@link ReadsSystemProperty}, and {@link WritesSystemProperty}
- * are scheduled in a way that guarantees correctness under mutation of shared global state.
- * </p>
+ * are scheduled in a way that guarantees correctness under mutation of shared global state.</p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/system-properties/" target="_top">the documentation on <code>@ClearSystemProperty</code> and <code>@SetSystemProperty</code></a>.
- * </p>
+ * <a href="https://junit-pioneer.org/docs/system-properties/" target="_top">the documentation on <code>@ClearSystemProperty</code> and <code>@SetSystemProperty</code></a>.</p>
  *
  * @since 0.9
  */

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/ArgumentSets.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/ArgumentSets.java
@@ -22,16 +22,10 @@ import java.util.stream.Stream;
  * Class for defining sets to a {@code CartesianTest} execution with arguments for each parameter
  * in the order in which they appear in the test method.
  *
- * <p>Use the static factory method
- * {@link ArgumentSets#argumentsForFirstParameter(Object[]) argumentsForFirstParameter}
- * to create an instance and call
- * {@link ArgumentSets#argumentsForNextParameter(Object[]) argumentsForNextParameter}
- * for each parameter after the first.
- * Alternatively, call the static factory method
- * {@link ArgumentSets#create() create}
- * to create an instance call {@code argumentsForNextParameter}
- * for each parameter.
- * </p>
+ * <p>Use the static factory method {@link ArgumentSets#argumentsForFirstParameter(Object[]) argumentsForFirstParameter}
+ * to create an instance and call {@link ArgumentSets#argumentsForNextParameter(Object[]) argumentsForNextParameter}
+ * for each parameter after the first. Alternatively, call the static factory method
+ * {@link ArgumentSets#create() create} to create an instance call {@code argumentsForNextParameter} for each parameter.</p>
  */
 public class ArgumentSets {
 
@@ -63,8 +57,8 @@ public class ArgumentSets {
 	 * {@link Object#equals(Object) equals}) for the first parameter of
 	 * a {@code CartesianTest} from the elements of the passed
 	 * {@link java.util.Collection Collection}.
-	 * <p>
-	 * The passed argument does not have to be an instance of {@link java.util.Set Set}.
+	 *
+	 * <p>The passed argument does not have to be an instance of {@link java.util.Set Set}.</p>
 	 *
 	 * @param arguments the objects that should be passed to the parameter
 	 * @return a new {@link ArgumentSets} object
@@ -108,8 +102,8 @@ public class ArgumentSets {
 	 * {@link Object#equals(Object) equals}) for the next parameter of
 	 * a {@code CartesianTest} from the elements of the passed
 	 * {@link Collection Collection}.
-	 * <p>
-	 * The passed argument does not have to be an instance of {@link java.util.Set Set}.
+	 *
+	 * <p>The passed argument does not have to be an instance of {@link java.util.Set Set}.</p>
 	 *
 	 * @param arguments the objects that should be passed to the parameter
 	 * @return this {@link ArgumentSets} object, for fluent set definitions

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianArgumentsSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianArgumentsSource.java
@@ -24,9 +24,9 @@ import java.lang.annotation.Target;
  *
  * <p>{@code @CartesianArgumentsSource} may also be used as a meta-annotation in order to
  * create a custom <em>composed annotation</em> that inherits the semantics
- * of {@code @CartesianArgumentsSource}.
- * </p>
- * This annotation is used to provide arguments for a {@link CartesianTest}.
+ * of {@code @CartesianArgumentsSource}.</p>
+ *
+ * <p>This annotation is used to provide arguments for a {@link CartesianTest}.</p>
  *
  * @see CartesianTest
  */

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianMethodArgumentsProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianMethodArgumentsProvider.java
@@ -14,10 +14,9 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Provides arguments for all parameters of a {@link CartesianTest} method.
- * <p>
- * For more information, see
- * <a href="https://junit-pioneer.org/docs/cartesian-product/" target="_top">the Cartesian product documentation</a>.
- * </p>
+ *
+ * <p>For more information, see
+ * <a href="https://junit-pioneer.org/docs/cartesian-product/" target="_top">the Cartesian product documentation</a>.</p>
  */
 public interface CartesianMethodArgumentsProvider extends CartesianArgumentsProvider {
 

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianParameterArgumentsProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianParameterArgumentsProvider.java
@@ -17,10 +17,9 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 
 /**
  * Provides arguments for a single parameter of a {@link CartesianTest} method.
- * <p>
- * For more information, see
- * <a href="https://junit-pioneer.org/docs/cartesian-product/" target="_top">the Cartesian product documentation</a>.
- * </p>
+ *
+ * <p>For more information, see
+ * <a href="https://junit-pioneer.org/docs/cartesian-product/" target="_top">the Cartesian product documentation</a>.</p>
  */
 public interface CartesianParameterArgumentsProvider<T> extends CartesianArgumentsProvider {
 

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianTest.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianTest.java
@@ -32,23 +32,19 @@ import org.junitpioneer.jupiter.cartesian.CartesianEnumArgumentsProvider.NullEnu
  * {@code @CartesianTest} is a JUnit Jupiter extension that marks
  * a test to be executed with all possible input combinations.
  *
- * <p>Methods annotated with this annotation should not be annotated with {@code Test}.
- * </p>
+ * <p>Methods annotated with this annotation should not be annotated with {@code Test}.</p>
  *
  * <p>This annotation is somewhat similar to {@code @ParameterizedTest}, as in it also takes
  * arguments and can run the same test multiple times. With {@code @CartesianTest} you
  * don't specify the test cases themselves, though. Instead you specify possible values for
  * each test method parameter (for example with @{@link CartesianTest.Values}) by annotating the parameters
- * themselves and the extension runs the method with each possible combination.
- * </p>
+ * themselves and the extension runs the method with each possible combination.</p>
  *
  * <p>You can specify a custom Display Name for the tests ran by {@code @CartesianTest}.
- * By default it's [{index}] {arguments}.
- * </p>
+ * By default it's [{index}] {arguments}.</p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/cartesian-product/" target="_top">the documentation on <code>@CartesianTest</code></a>.
- * </p>
+ * <a href="https://junit-pioneer.org/docs/cartesian-product/" target="_top">the documentation on <code>@CartesianTest</code></a>.</p>
  *
  * @since 1.5.0
  */
@@ -87,23 +83,22 @@ public @interface CartesianTest {
 	String ARGUMENTS_PLACEHOLDER = TestNameFormatter.ARGUMENTS_PLACEHOLDER;
 
 	/**
-	 * <p>The display name to be used for individual invocations of the
+	 * The display name to be used for individual invocations of the
 	 * parameterized test; never blank or consisting solely of whitespace.
-	 * </p>
 	 *
-	 * <p>Defaults to [{index}] {arguments}.
-	 * </p>
-	 * <p>
-	 * Supported placeholders:
-	 * <p>
-	 * - {@link org.junitpioneer.jupiter.cartesian.CartesianTest#DISPLAY_NAME_PLACEHOLDER}
-	 * - {@link org.junitpioneer.jupiter.cartesian.CartesianTest#INDEX_PLACEHOLDER}
-	 * - {@link org.junitpioneer.jupiter.cartesian.CartesianTest#ARGUMENTS_PLACEHOLDER}
-	 * - <code>{0}</code>, <code>{1}</code>, etc.: an individual argument (0-based)
+	 * <p>Defaults to [{index}] {arguments}.</p>
+	 *
+	 * <p>Supported placeholders:</p>
+	 *
+	 * <ul>
+	 * <li>{@link org.junitpioneer.jupiter.cartesian.CartesianTest#DISPLAY_NAME_PLACEHOLDER}</li>
+	 * <li>{@link org.junitpioneer.jupiter.cartesian.CartesianTest#INDEX_PLACEHOLDER}</li>
+	 * <li>{@link org.junitpioneer.jupiter.cartesian.CartesianTest#ARGUMENTS_PLACEHOLDER}</li>
+	 * <li><code>{0}</code>, <code>{1}</code>, etc.: an individual argument (0-based)</li>
+	 * </ul>
 	 *
 	 * <p>For the latter, you may use {@link java.text.MessageFormat} patterns
-	 * to customize formatting.
-	 * </p>
+	 * to customize formatting.</p>
 	 *
 	 * @since 1.5
 	 * @see java.text.MessageFormat

--- a/src/main/java/org/junitpioneer/jupiter/converter/package-info.java
+++ b/src/main/java/org/junitpioneer/jupiter/converter/package-info.java
@@ -1,7 +1,7 @@
 /**
  * This package contains argument converters.
  *
- * <p>See the following types for details.</p>
+ * <p>See the following types for details:</p>
  *
  * <ul>
  *     <li>{@link org.junitpioneer.jupiter.converter.NumberToByteArrayConversion}</li>

--- a/src/main/java/org/junitpioneer/jupiter/issue/IssueExtensionExecutionListener.java
+++ b/src/main/java/org/junitpioneer/jupiter/issue/IssueExtensionExecutionListener.java
@@ -31,8 +31,8 @@ import org.junitpioneer.jupiter.IssueTestCase;
 import org.junitpioneer.jupiter.IssueTestSuite;
 
 /**
- * <p>This listener collects the names and results of all tests, which are annotated with the {@link org.junitpioneer.jupiter.Issue @Issue} annotation.
- * After all tests are finished the results are provided to an {@link IssueProcessor} for further processing.</p>
+ * This listener collects the names and results of all tests, which are annotated with the {@link org.junitpioneer.jupiter.Issue @Issue} annotation.
+ * After all tests are finished the results are provided to an {@link IssueProcessor} for further processing.
  */
 public class IssueExtensionExecutionListener implements TestExecutionListener {
 

--- a/src/main/java/org/junitpioneer/jupiter/json/JsonClasspathSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/json/JsonClasspathSource.java
@@ -25,14 +25,12 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  * <p>This annotation can be used on a method parameter, to make it usable with
  * {@link org.junitpioneer.jupiter.cartesian.CartesianTest}.
  * If used with {@link org.junit.jupiter.params.ParameterizedTest},
- * the annotation has to be on the method itself as any other {@link ArgumentsSource}.
- * </p>
+ * the annotation has to be on the method itself as any other {@link ArgumentsSource}.</p>
  *
  * <p>Note that this extension requires a JSON parser to be available at run time,
  * which may include adding it to the module graph with {@code --add-modules}.
  * For details on that as well as how to use this extension, see
- * <a href="https://junit-pioneer.org/docs/json-argument-source" target="_top">the documentation on <code>JSON tests</code></a>
- * </p>
+ * <a href="https://junit-pioneer.org/docs/json-argument-source" target="_top">the documentation on the JSON argument source</a>.</p>
  *
  * @since 1.7.0
  *

--- a/src/main/java/org/junitpioneer/jupiter/json/JsonFileSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/json/JsonFileSource.java
@@ -25,14 +25,12 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  * <p>This annotation can be used on a method parameter, to make it usable with
  * {@link org.junitpioneer.jupiter.cartesian.CartesianTest}.
  * If used with {@link org.junit.jupiter.params.ParameterizedTest},
- * the annotation has to be on the method itself as any other {@link ArgumentsSource}.
- * </p>
+ * the annotation has to be on the method itself as any other {@link ArgumentsSource}.</p>
  *
  * <p>Note that this extension requires a JSON parser to be available at run time,
  * which may include adding it to the module graph with {@code --add-modules}.
  * For details on that as well as how to use this extension, see
- * <a href="https://junit-pioneer.org/docs/json-argument-source" target="_top">the documentation on <code>JSON tests</code></a>
- * </p>
+ * <a href="https://junit-pioneer.org/docs/json-argument-source" target="_top">the documentation on JSON tests</a>.</p>
  *
  * @since 1.7.0
  *

--- a/src/main/java/org/junitpioneer/jupiter/json/JsonSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/json/JsonSource.java
@@ -25,14 +25,12 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  * <p>This annotation can be used on a method parameter, to make it usable with
  * {@link org.junitpioneer.jupiter.cartesian.CartesianTest}.
  * If used with {@link org.junit.jupiter.params.ParameterizedTest},
- * the annotation has to be on the method itself as any other {@link ArgumentsSource}.
- * </p>
+ * the annotation has to be on the method itself as any other {@link ArgumentsSource}.</p>
  *
  * <p>Note that this extension requires a JSON parser to be available at run time,
  * which may include adding it to the module graph with {@code --add-modules}.
  * For details on that as well as how to use this extension, see
- * <a href="https://junit-pioneer.org/docs/json-argument-source" target="_top">the documentation on <code>JSON tests</code></a>
- * </p>
+ * <a href="https://junit-pioneer.org/docs/json-argument-source" target="_top">the documentation on the JSON argument source</a>.</p>
  *
  * @since 1.7.0
  *
@@ -51,9 +49,8 @@ public @interface JsonSource {
 
 	/**
 	 * The JSON values to use as the source of arguments; must not be empty.
-	 * <p>
-	 * Each value can represent a single object, or a collection of objects.
-	 * </p>
+	 *
+	 * <p>Each value can represent a single object, or a collection of objects.</p>
 	 */
 	String[] value();
 

--- a/src/main/java/org/junitpioneer/jupiter/json/Property.java
+++ b/src/main/java/org/junitpioneer/jupiter/json/Property.java
@@ -18,10 +18,9 @@ import java.lang.annotation.Target;
 
 /**
  * An annotation indicating the name of the JSON property that should be extracted into the method parameter.
- * <p>
- * If the test code is compiled with the {@code -parameters} flag, and the test method parameter's name
- * matches the JSON property's name, this annotation is not needed.
- * </p>
+ *
+ * <p>If the test code is compiled with the {@code -parameters} flag, and the test method parameter's name
+ * matches the JSON property's name, this annotation is not needed.</p>
  *
  * @since 1.7.0
  */

--- a/src/main/java/org/junitpioneer/jupiter/json/package-info.java
+++ b/src/main/java/org/junitpioneer/jupiter/json/package-info.java
@@ -4,10 +4,10 @@
  * <p>Note that these extensions require a JSON parser to be available at run time,
  * which may include adding it to the module graph with {@code --add-modules}.
  * For details on that, see
- * <a href="https://junit-pioneer.org/docs/json-argument-source" target="_top">the documentation on <code>JSON tests</code></a>
- * </p>
+ * <a href="https://junit-pioneer.org/docs/json-argument-source" target="_top">the documentation on the JSON argument source</a>.</p>
  *
  * <p>Check out the following types for details on providing values for parameterized tests:</p>
+ *
  * <ul>
  *     <li>{@link org.junitpioneer.jupiter.json.JsonSource}</li>
  *     <li>{@link org.junitpioneer.jupiter.json.JsonClasspathSource}</li>

--- a/src/main/java/org/junitpioneer/jupiter/package-info.java
+++ b/src/main/java/org/junitpioneer/jupiter/package-info.java
@@ -16,9 +16,9 @@
  *     <li>{@link org.junitpioneer.jupiter.Stopwatch}</li>
  * </ul>
  *
- * <p>
- * Also check the following packages:
- * </p>
+ *
+ * <p>Also check the following packages:</p>
+ *
  * <ul>
  *     <li>{@link org.junitpioneer.jupiter.cartesian cartesian}</li>
  *     <li>{@link org.junitpioneer.jupiter.issue issue}</li>

--- a/src/main/java/org/junitpioneer/jupiter/params/Aggregate.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/Aggregate.java
@@ -24,14 +24,12 @@ import org.junit.jupiter.params.aggregator.AggregateWith;
  * which is in turn supplied to the {@code @ParameterizedTest} method.</p>
  *
  * <p>For more details (including its limitations) and examples, see
- * <a href="https://junit-pioneer.org/docs/simple-arguments-aggregator/" target="_top">the documentation on
- * Simple Arguments Aggregator</a>
- * </p>
+ * <a href="https://junit-pioneer.org/docs/simple-arguments-aggregator/" target="_top">the documentation on the
+ * simple arguments aggregator</a>.</p>
  *
  * <p>This annotation is not compatible with {@link org.junitpioneer.jupiter.cartesian.CartesianTest} since
  * this expects a single parameter as opposed to {@link org.junitpioneer.jupiter.cartesian.CartesianTest}
- * requiring multiple parameters.
- * </p>
+ * requiring multiple parameters.</p>
  *
  * @since 2.1
  * @see org.junit.jupiter.params.aggregator.ArgumentsAggregator

--- a/src/main/java/org/junitpioneer/jupiter/params/ByteRangeSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/ByteRangeSource.java
@@ -25,24 +25,20 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  * <p>The supplied values will be provided as arguments to the annotated {@code @ParameterizedTest} method.</p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/range-sources/" target="_top">the documentation on <code>Range Sources</code></a>
- * </p>
+ * <a href="https://junit-pioneer.org/docs/range-sources/" target="_top">the documentation on range sources</a>.</p>
  *
  * <p>This annotation is {@link Repeatable}, to make it usable with {@link org.junitpioneer.jupiter.cartesian.CartesianTest}.
  * If used with {@link org.junit.jupiter.params.ParameterizedTest}, it can only be used once (because {@code ParameterizedTest}
  * can only take a single {@link ArgumentsSource}). Using it more than once will throw an {@link IllegalArgumentException}.
  * If used with {@link org.junitpioneer.jupiter.cartesian.CartesianTest}, it can be repeated to provide arguments to
- * more than one parameter.
- * </p>
+ * more than one parameter.</p>
  *
  * <p>This annotation can be used on a method parameter, to make it usable with
  * {@link org.junitpioneer.jupiter.cartesian.CartesianTest}. If used with {@link org.junit.jupiter.params.ParameterizedTest},
- * the annotation has to be on the method itself as any other {@link ArgumentsSource}.
+ * the annotation has to be on the method itself as any other {@link ArgumentsSource}.</p>
  *
- * <p>
- * For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/cartesian-product/" target="_top">the documentation on <code>Cartesian product tests</code></a>
- * </p>
+ * <p>For more details and examples, see
+ * <a href="https://junit-pioneer.org/docs/cartesian-product/" target="_top">the documentation on Cartesian product tests</a>.</p>
  *
  * @since 0.5
  * @see ArgumentsSource

--- a/src/main/java/org/junitpioneer/jupiter/params/DisableIfAllArguments.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/DisableIfAllArguments.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * {@link DisableIfAllArguments#matches() matches} is configured.</p>
  *
  * <p>For more information how the extension resolves the annotations, check
- * <a href="https://junit-pioneer.org/docs/disable-parameterized-tests/" target="_top">the documentation.</a></p>
+ * <a href="https://junit-pioneer.org/docs/disable-parameterized-tests/" target="_top">the documentation on disabling parameterized tests</a>.</p>
  *
  * @see DisableIfArgumentExtension
  * @since 1.5.0

--- a/src/main/java/org/junitpioneer/jupiter/params/DisableIfAnyArgument.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/DisableIfAnyArgument.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * {@link DisableIfAnyArgument#matches() matches} is configured.</p>
  *
  * <p>For more information how the extension resolves the annotations, check
- * <a href="https://junit-pioneer.org/docs/disable-parameterized-tests/" target="_top">the documentation.</a></p>
+ * <a href="https://junit-pioneer.org/docs/disable-parameterized-tests/" target="_top">the documentation on disabling parameterized tests</a>.</p>
  *
  * @see DisableIfArgumentExtension
  * @since 1.5.0

--- a/src/main/java/org/junitpioneer/jupiter/params/DisableIfArgument.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/DisableIfArgument.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * <p>This annotation is for disabling a test based on a single argument which can be designated with an
  * implicit index, an explicit index or by name (if parameter name information is present). For more
  * information how the extension resolves the annotations, check
- * <a href="https://junit-pioneer.org/docs/disable-parameterized-tests/" target="_top">the documentation.</a></p>
+ * <a href="https://junit-pioneer.org/docs/disable-parameterized-tests/" target="_top">the documentation on disabling parameterized tests</a>.</p>
  *
  * @see DisableIfArgumentExtension
  * @since 1.5.0

--- a/src/main/java/org/junitpioneer/jupiter/params/DisableIfDisplayName.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/DisableIfDisplayName.java
@@ -33,8 +33,7 @@ import org.junit.jupiter.params.ParameterizedTest;
  *
  * <p>If neither {@link DisableIfDisplayName#contains() contains} nor
  * {@link DisableIfDisplayName#matches() matches} is configured, or if both are present,
- * the extension will throw an exception.
- * </p>
+ * the extension will throw an exception.</p>
  *
  * @since 0.7
  * @see DisableIfNameExtension

--- a/src/main/java/org/junitpioneer/jupiter/params/DoubleRangeSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/DoubleRangeSource.java
@@ -25,8 +25,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  * <p>The supplied values will be provided as arguments to the annotated {@code @ParameterizedTest} method.</p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/range-sources/" target="_top">the documentation on <code>Range Sources</code></a>
- * </p>
+ * <a href="https://junit-pioneer.org/docs/range-sources/" target="_top">the documentation on range sources</a>.</p>
  *
  * <p>This annotation is {@link Repeatable}, to make it usable with {@link org.junitpioneer.jupiter.cartesian.CartesianTest}.
  * If used with {@link org.junit.jupiter.params.ParameterizedTest}, it can only be used once (because {@code ParameterizedTest}
@@ -36,13 +35,11 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  *
  * <p>This annotation can be used on a method parameter, to make it usable with
  * {@link org.junitpioneer.jupiter.cartesian.CartesianTest}. If used with {@link org.junit.jupiter.params.ParameterizedTest},
- * the annotation has to be on the method itself as any other {@link ArgumentsSource}.
- * </p>
+ * the annotation has to be on the method itself as any other {@link ArgumentsSource}.</p>
  *
- * <p>
- * For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/cartesian-product/" target="_top">the documentation on <code>Cartesian product tests</code></a>
- * </p>
+ *
+ * <p>For more details and examples, see
+ * <a href="https://junit-pioneer.org/docs/cartesian-product/" target="_top">the documentation on Cartesian product tests</a>.</p>
  *
  * @since 0.5
  * @see ArgumentsSource

--- a/src/main/java/org/junitpioneer/jupiter/params/FloatRangeSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/FloatRangeSource.java
@@ -25,8 +25,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  * <p>The supplied values will be provided as arguments to the annotated {@code @ParameterizedTest} method.</p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/range-sources/" target="_top">the documentation on <code>Range Sources</code></a>
- * </p>
+ * <a href="https://junit-pioneer.org/docs/range-sources/" target="_top">the documentation on range sources</a>.</p>
  *
  * <p>This annotation is {@link Repeatable}, to make it usable with {@link org.junitpioneer.jupiter.cartesian.CartesianTest}.
  * If used with {@link org.junit.jupiter.params.ParameterizedTest}, it can only be used once (because {@code ParameterizedTest}
@@ -36,13 +35,11 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  *
  * <p>This annotation can be used on a method parameter, to make it usable with
  * {@link org.junitpioneer.jupiter.cartesian.CartesianTest}. If used with {@link org.junit.jupiter.params.ParameterizedTest},
- * the annotation has to be on the method itself as any other {@link ArgumentsSource}.
- * </p>
+ * the annotation has to be on the method itself as any other {@link ArgumentsSource}.</p>
  *
- * <p>
- * For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/cartesian-product/" target="_top">the documentation on <code>Cartesian product tests</code></a>
- * </p>
+ *
+ * <p>For more details and examples, see
+ * <a href="https://junit-pioneer.org/docs/cartesian-product/" target="_top">the documentation on Cartesian product tests</a>.</p>
  *
  * @since 0.5
  * @see ArgumentsSource

--- a/src/main/java/org/junitpioneer/jupiter/params/IntRangeSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/IntRangeSource.java
@@ -25,8 +25,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  * <p>The supplied values will be provided as arguments to the annotated {@code @ParameterizedTest} method.</p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/range-sources/" target="_top">the documentation on <code>Range Sources</code></a>
- * </p>
+ * <a href="https://junit-pioneer.org/docs/range-sources/" target="_top">the documentation on range sources</a>.</p>
  *
  * <p>This annotation is {@link Repeatable}, to make it usable with {@link org.junitpioneer.jupiter.cartesian.CartesianTest}.
  * If used with {@link org.junit.jupiter.params.ParameterizedTest}, it can only be used once (because {@code ParameterizedTest}
@@ -38,10 +37,9 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  * {@link org.junitpioneer.jupiter.cartesian.CartesianTest}. If used with {@link org.junit.jupiter.params.ParameterizedTest},
  * the annotation has to be on the method itself as any other {@link ArgumentsSource}.
  *
- * <p>
- * For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/cartesian-product/" target="_top">the documentation on <code>Cartesian product tests</code></a>
- * </p>
+ *
+ * <p>For more details and examples, see
+ * <a href="https://junit-pioneer.org/docs/cartesian-product/" target="_top">the documentation on Cartesian product tests</a>.</p>
  *
  * @since 0.5
  * @see ArgumentsSource

--- a/src/main/java/org/junitpioneer/jupiter/params/LongRangeSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/LongRangeSource.java
@@ -25,8 +25,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  * <p>The supplied values will be provided as arguments to the annotated {@code @ParameterizedTest} method.</p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/range-sources/" target="_top">the documentation on <code>Range Sources</code></a>
- * </p>
+ * <a href="https://junit-pioneer.org/docs/range-sources/" target="_top">the documentation on range sources</a>.</p>
  *
  * <p>This annotation is {@link Repeatable}, to make it usable with {@link org.junitpioneer.jupiter.cartesian.CartesianTest}.
  * If used with {@link org.junit.jupiter.params.ParameterizedTest}, it can only be used once (because {@code ParameterizedTest}
@@ -38,10 +37,9 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  * {@link org.junitpioneer.jupiter.cartesian.CartesianTest}. If used with {@link org.junit.jupiter.params.ParameterizedTest},
  * the annotation has to be on the method itself as any other {@link ArgumentsSource}.
  *
- * <p>
- * For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/cartesian-product/" target="_top">the documentation on <code>Cartesian product tests</code></a>
- * </p>
+ *
+ * <p>For more details and examples, see
+ * <a href="https://junit-pioneer.org/docs/cartesian-product/" target="_top">the documentation on Cartesian product tests</a>.</p>
  *
  * @since 0.5
  * @see ArgumentsSource

--- a/src/main/java/org/junitpioneer/jupiter/params/RangeSourceArgumentsProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/RangeSourceArgumentsProvider.java
@@ -29,6 +29,7 @@ import org.junitpioneer.jupiter.cartesian.CartesianParameterArgumentsProvider;
 /**
  * Provides a range of {@link Number}s, as defined by an annotation which is its {@link ArgumentsSource}.
  * Such an annotation should have the following properties:
+ *
  * <ul>
  *     <li>{@code from} a primitive value for the "start" of the range.</li>
  *     <li>{@code to} a primitive value for the "end" of the range. {@code to} must have the same type as {@code from}.</li>

--- a/src/main/java/org/junitpioneer/jupiter/params/ShortRangeSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/ShortRangeSource.java
@@ -25,8 +25,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  * <p>The supplied values will be provided as arguments to the annotated {@code @ParameterizedTest} method.</p>
  *
  * <p>For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/range-sources/" target="_top">the documentation on <code>Range Sources</code></a>
- * </p>
+ * <a href="https://junit-pioneer.org/docs/range-sources/" target="_top">the documentation on range sources</a>.</p>
  *
  * <p>This annotation is {@link Repeatable}, to make it usable with {@link org.junitpioneer.jupiter.cartesian.CartesianTest}.
  * If used with {@link org.junit.jupiter.params.ParameterizedTest}, it can only be used once (because {@code ParameterizedTest}
@@ -38,10 +37,9 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  * {@link org.junitpioneer.jupiter.cartesian.CartesianTest}. If used with {@link org.junit.jupiter.params.ParameterizedTest},
  * the annotation has to be on the method itself as any other {@link ArgumentsSource}.
  *
- * <p>
- * For more details and examples, see
- * <a href="https://junit-pioneer.org/docs/cartesian-product/" target="_top">the documentation on <code>Cartesian product tests</code></a>
- * </p>
+ *
+ * <p>For more details and examples, see
+ * <a href="https://junit-pioneer.org/docs/cartesian-product/" target="_top">the documentation on Cartesian product tests</a>.</p>
  *
  * @since 0.5
  * @see ArgumentsSource

--- a/src/main/java/org/junitpioneer/jupiter/params/package-info.java
+++ b/src/main/java/org/junitpioneer/jupiter/params/package-info.java
@@ -1,7 +1,7 @@
 /**
  * Several extensions for working with {@code ParameterizedTest}s.
- * <p>Disable {@code @ParameterizedTest} executions based on conditions.</p>
- * <p>Check out the following types for details:</p>
+ *
+ * <p>Disable {@code @ParameterizedTest} executions based on conditions. Check out the following types for details:</p>
  * <ul>
  *     <li>{@link org.junitpioneer.jupiter.params.DisableIfDisplayName}</li>
  *     <li>{@link org.junitpioneer.jupiter.params.DisableIfAllArguments}</li>
@@ -9,8 +9,9 @@
  *     <li>{@link org.junitpioneer.jupiter.params.DisableIfArgument}</li>
  * </ul>
  *
- * <p>Argument providers for a range of numbers.</p>
- * <p>Check out the following types for details on providing values for parameterized tests:</p>
+ * <p>Argument providers for a range of numbers. Check out the following types for details on providing values for
+ * parameterized tests:</p>
+ *
  * <ul>
  *     <li>{@link org.junitpioneer.jupiter.params.ByteRangeSource}</li>
  *     <li>{@link org.junitpioneer.jupiter.params.ShortRangeSource}</li>
@@ -20,8 +21,8 @@
  *     <li>{@link org.junitpioneer.jupiter.params.DoubleRangeSource}</li>
  * </ul>
  *
- * <p>Argument aggregator for simple use cases.</p>
- * <p>Check out the following type for details:</p>
+ * <p>Argument aggregator for simple use cases. Check out the following type for details:</p>
+ *
  * <ul>
  *     <li>{@link org.junitpioneer.jupiter.params.Aggregate}</li>
  * </ul>

--- a/src/main/java/org/junitpioneer/jupiter/resource/Shared.java
+++ b/src/main/java/org/junitpioneer/jupiter/resource/Shared.java
@@ -78,12 +78,12 @@ public @interface Shared {
 	enum Scope {
 
 		/**
-		 * <p>At this scope, a shared resource will last as long as the entire test suite.</p>
+		 * At this scope, a shared resource will last as long as the entire test suite.
 		 */
 		GLOBAL,
 
 		/**
-		 * <p>At this scope, a shared resource will last as long as the test file it is defined in.</p>
+		 * At this scope, a shared resource will last as long as the test file it is defined in.
 		 */
 		SOURCE_FILE
 

--- a/src/main/java/org/junitpioneer/jupiter/resource/package-info.java
+++ b/src/main/java/org/junitpioneer/jupiter/resource/package-info.java
@@ -2,13 +2,15 @@
  * This package contains various classes pertaining to "resources": anything that needs to be injected into
  * tests and which may need to be started up or torn down. A common example is a temporary directory.
  *
- * <p>Check out the following types for details on the "temporary directory" extension:
+ * <p>Check out the following types for details on the "temporary directory" extension:</p>
+ *
  * <ul>
  *     <li>{@link org.junitpioneer.jupiter.resource.TemporaryDirectory}</li>
  *     <li>{@link org.junitpioneer.jupiter.resource.Dir}</li>
  * </ul>
  *
- * <p>Check out the following types for details on resources in general:
+ * <p>Check out the following types for details on resources in general:</p>
+ *
  * <ul>
  *     <li>{@link org.junitpioneer.jupiter.resource.Resource}</li>
  *     <li>{@link org.junitpioneer.jupiter.resource.ResourceFactory}</li>

--- a/src/main/java/org/junitpioneer/vintage/package-info.java
+++ b/src/main/java/org/junitpioneer/vintage/package-info.java
@@ -1,7 +1,8 @@
 /**
  * {@summary Contains extensions to JUnit Vintage, i.e. functionality that is concerned with older JUnit versions.}
  *
- * <p>Check out the following types for details:
+ * <p>Check out the following types for details:</p>
+ *
  * <ul>
  *     <li>{@link org.junitpioneer.vintage.Test}</li>
  * </ul>

--- a/src/test/java/org/junitpioneer/jupiter/RestoreEnvironmentVariablesTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/RestoreEnvironmentVariablesTests.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.parallel.Execution;
 
 /**
- * <p>Verify proper behavior when annotated on a top level class.</p>
+ * Verify proper behavior when annotated on a top level class.
  *
  * <p>{@link VerifyEnvVarsExtension} is registered as an extension <em>before</em> {@code RestoreSystemProperties}. It
  * stores the initial environment variables and verifies them at the end.
@@ -119,7 +119,7 @@ class RestoreEnvironmentVariablesTests {
 	}
 
 	/**
-	 * <p>Extension that checks the before and after state of environment variables.</p>
+	 * Extension that checks the before and after state of environment variables.
 	 *
 	 * <p>Must be registered before {@code RestoreEnvironmentVariables}.
 	 * To avoid replicating the system being tested w/ the test itself, this class

--- a/src/test/java/org/junitpioneer/jupiter/RestoreSystemPropertiesTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/RestoreSystemPropertiesTests.java
@@ -39,7 +39,7 @@ import org.junit.platform.commons.support.HierarchyTraversalMode;
 import org.junit.platform.commons.support.ReflectionSupport;
 
 /**
- * <p>Verify proper behavior when annotated on a top level class.</p>
+ * Verify proper behavior when annotated on a top level class.
  *
  * <p>{@link VerifySysPropsExtension} is registered as an extension <em>before</em> {@code RestoreSystemProperties}. It
  * stores the initial system properties and verifies them at the end.
@@ -161,8 +161,8 @@ class RestoreSystemPropertiesTests {
 
 	/**
 	 * Extension that checks the before and after state of SysProps.
-	 * <p>
-	 * Must be registered before RestoreSystemProperties.
+	 *
+	 * <p>Must be registered before RestoreSystemProperties.
 	 * To avoid replicating the system being tested w/ the test itself, this class
 	 * uses static state rather than the extension store. As a result, this test
 	 * class is marked as single threaded.
@@ -210,10 +210,10 @@ class RestoreSystemPropertiesTests {
 	}
 
 	/**
-	 * <p>This "deep" clone method uses reflection to do a clone that preserves the structure
+	 * This "deep" clone method uses reflection to do a clone that preserves the structure
 	 * (i.e. nested defaults) and potential non-string values of Properties.
 	 * This method is only used to ensure we have a 100% complete clone of original Sys Props for
-	 * comparison after restore.</p>
+	 * comparison after restore.
 	 *
 	 * <p>The actual SystemProperties extension does an 'effective' clone which is simpler and doesn't
 	 * require reflection.</p>

--- a/src/test/java/org/junitpioneer/testkit/ExecutionResults.java
+++ b/src/test/java/org/junitpioneer/testkit/ExecutionResults.java
@@ -24,8 +24,8 @@ import org.junit.platform.testkit.engine.Events;
 
 /**
  * Pioneers' class to handle JUnit Jupiter's {@link org.junit.platform.testkit.engine.EngineExecutionResults}.
- * <p>
- * Instantiate with the static factory methods in {@link PioneerTestKit}.
+ *
+ * <p>Instantiate with the static factory methods in {@link PioneerTestKit}.
  */
 public class ExecutionResults {
 

--- a/src/test/java/org/junitpioneer/testkit/assertion/AbstractPioneerAssert.java
+++ b/src/test/java/org/junitpioneer/testkit/assertion/AbstractPioneerAssert.java
@@ -16,11 +16,8 @@ import org.assertj.core.api.AbstractAssert;
  * A very basic extension of the AbstractAssert, used to add a quantity to assertions.
  * By storing this value in a field we don't have to refer back to it every time.
  *
- * Instead of
- * <p>assertThat(results).hasTests().thatStarted(3).thenFailed(3)</p>
- *
- * We can write
- * <p>assertThat(results).hasNumberOfTests(3).thatStarted().andAllOfThemFailed()</p>
+ * <p>Instead of <code>assertThat(results).hasTests().thatStarted(3).thenFailed(3)</code> we can write
+ * <code>assertThat(results).hasNumberOfTests(3).thatStarted().andAllOfThemFailed()</code>.</p>
  *
  * @param <SELF> the "self" type of this assertion class. Please read
  *          &quot;<a href="https://web.archive.org/web/20130721224442/http:/passion.forco.de/content/emulating-self-types-using-java-generics-simplify-fluent-api-implementation" target="_blank">

--- a/src/test/java/org/junitpioneer/testkit/assertion/PropertiesAssert.java
+++ b/src/test/java/org/junitpioneer/testkit/assertion/PropertiesAssert.java
@@ -31,13 +31,13 @@ public class PropertiesAssert extends AbstractAssert<PropertiesAssert, Propertie
 	/**
 	 * Assert Properties has the same effective values as the passed instance, but not
 	 * the same nested default structure.
-	 * <p>
-	 * Properties are considered <em>effectively equal</em> if they have the same property
+	 *
+	 * <p>Properties are considered <em>effectively equal</em> if they have the same property
 	 * names returned by {@code Properties.propertyNames()} and the same values returned by
 	 * {@code getProperty(name)}. Properties may come from the properties instance itself,
 	 * or from a nested default instance, indiscriminately.
-	 * <p>
-	 * Properties partially supports object values, but return null for {@code getProperty(name)}
+	 *
+	 * <p>Properties partially supports object values, but return null for {@code getProperty(name)}
 	 * when the value is a non-string. This assertion follows the same rules:  Any non-String
 	 * value is considered null for comparison purposes.
 	 *

--- a/src/test/java/org/junitpioneer/testkit/assertion/PropertiesAssertTests.java
+++ b/src/test/java/org/junitpioneer/testkit/assertion/PropertiesAssertTests.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 /**
- * <p>Verify proper behavior when annotated on a top level class.</p>
+ * Verify proper behavior when annotated on a top level class.
  *
  * <p>These tests include testing object values but not object keys. {@code Properties} sort-of supports
  * object values, but dies on common operations with object keys (e.g. {@code propertyNames()} fails), thus


### PR DESCRIPTION
Proposed commit message:

```
Homogenize and improve Javadoc, particularly `<p>` tags:

* leading paragraphs don't need `<p>`/`</p>` tags
* all subequent paragraphs need `<p>` *and* `</p>` tags
* `<p>` and `</p>` tags are on the same lines as the content
* paragraphs end with an end-of-sentence symbol
* a paragraph is always surrounded by empty lines (one before
 and one after)
* move `<ul>` blocks out of `<p>` blocks

Other changes:

* remove `<code>` tags when they don't contain code
* fix capitalization of feature names (they're no proper nouns)
* probably more that I forgot
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [x] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [x] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [x] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [x] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [x] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [x] The `package-info.java` contains information about the new extension

Code (general)
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [x] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#assertions) (which are based on AssertJ)

Code (new package)
* [x] The new package is exported in `module-info.java`
* [x] The new package is also present in the tests
* [x] The new package is opened for reflection to JUnit 5 in `module-info.java`
* [x] The new package is listed in the contribution guide

Contributing
* [x] A prepared commit message exists
* [x] The list of contributions inside `README.adoc` mentions the new contribution (real name optional) 
