### PR TITLE
#735 Removed throwing new AssertionFailedError when test failed

### DIFF
--- a/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
 import org.junit.platform.commons.support.AnnotationSupport;
 import org.junitpioneer.internal.PioneerAnnotationUtils;
 import org.junitpioneer.internal.TestNameFormatter;
-import org.opentest4j.AssertionFailedError;
 import org.opentest4j.TestAbortedException;
 
 class RetryingTestExtension implements TestTemplateInvocationContextProvider, TestExecutionExceptionHandler {
@@ -155,9 +154,7 @@ class RetryingTestExtension implements TestTemplateInvocationContextProvider, Te
 						maxRetries, suspendForMs),
 					exception);
 			else
-				throw new AssertionFailedError(format(
-					"Test execution #%d (of up to %d with at least %d successes) failed ~> test fails - see cause for details",
-					retriesSoFar, maxRetries, minSuccess), exception);
+				throw exception;
 		}
 
 		private boolean expectedException(Throwable exception) {


### PR DESCRIPTION
Suggestion for: #735

My point is just throw an exception of what happend, because this annotation (in my opinion) is used to get rid of flaky tests (in api/e2e test especially). Or if it too flaky/broken, so we should fix it.

Thing what annoyed me in my practice, that when you try to make an allure report you'll have same fail issue (Which is not true) like "Test execution #3 (of up to 3 with at least 1 successes) failed ~ test fails - see cause for details"
And second is that you need to dive to previous exception/allure step to know what happened

So what do i mean. Here is how it works right now (without my PR)
<img src="https://github.com/junit-pioneer/junit-pioneer/assets/150076212/633a36a4-e0bf-426d-9d07-f393d4846b39" width="600">

Here how it'll work with mine PR
<img src="https://github.com/junit-pioneer/junit-pioneer/assets/150076212/6e032924-09d2-4c75-bb86-189ccc3ef746" width="600">

And that's how it'll work if we throw MultipleFailuresError instead AssertionFailedError. In my opinion it bloats fail message and when test failed you want to know cause. And if you want to know what retry it is you can just look at previous retry attempts
<img src="https://github.com/junit-pioneer/junit-pioneer/assets/150076212/b2c5fdba-beb6-4f2a-bc20-c8d6cdb8072e" width="600">

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code (general)
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#assertions) (which are based on AssertJ)

Code (new package)
* [ ] The new package is exported in `module-info.java`
* [ ] The new package is also present in the tests
* [ ] The new package is opened for reflection to JUnit 5 in `module-info.java`
* [ ] The new package is listed in the contribution guide

Contributing
* [ ] A prepared commit message exists
* [ ] The list of contributions inside `README.adoc` mentions the new contribution (real name optional) 
