### PR TITLE
Add Nested annotation in Demo where it's missing

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -125,6 +125,7 @@ The least we can do is to thank them and list some of their accomplishments here
 * https://github.com/eeverman[Eric Everman] added `@RestoreSystemProperties` and `@RestoreEnvironmentVariables` annotations to the https://junit-pioneer.org/docs/system-properties/[System Properties] and https://junit-pioneer.org/docs/environment-variables/[Environment Variables] extensions (#574 / #700)
 * https://github.com/meredrica[Florian Westreicher] contributed to the JSON argument source extension (#704 / #724)
 * https://github.com/petrandreev[Pёtr Andreev] added back support for NULL values to `@CartesianTestExtension` (#764 / #765)
+* https://github.com/IlyasYOY[Ilya Ilyinykh] found unused demo tests (#777)
 
 ==== 2022
 

--- a/README.adoc
+++ b/README.adoc
@@ -124,8 +124,8 @@ The least we can do is to thank them and list some of their accomplishments here
 ==== 2023
 * https://github.com/eeverman[Eric Everman] added `@RestoreSystemProperties` and `@RestoreEnvironmentVariables` annotations to the https://junit-pioneer.org/docs/system-properties/[System Properties] and https://junit-pioneer.org/docs/environment-variables/[Environment Variables] extensions (#574 / #700)
 * https://github.com/meredrica[Florian Westreicher] contributed to the JSON argument source extension (#704 / #724)
+* https://github.com/IlyasYOY[Ilya Ilyinykh] found unused demo tests (#791)
 * https://github.com/petrandreev[Pёtr Andreev] added back support for NULL values to `@CartesianTestExtension` (#764 / #765)
-* https://github.com/IlyasYOY[Ilya Ilyinykh] found unused demo tests (#777)
 
 ==== 2022
 

--- a/src/demo/java/org/junitpioneer/jupiter/DefaultLocaleTimezoneExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/DefaultLocaleTimezoneExtensionDemo.java
@@ -15,6 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Locale;
 import java.util.TimeZone;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class DefaultLocaleTimezoneExtensionDemo {
@@ -48,6 +49,7 @@ public class DefaultLocaleTimezoneExtensionDemo {
 	}
 	// end::default_locale_language_alternatives[]
 
+	@Nested
 	// tag::default_locale_class_level[]
 	@DefaultLocale(language = "fr")
 	class MyLocaleTests {
@@ -80,6 +82,7 @@ public class DefaultLocaleTimezoneExtensionDemo {
 	}
 	// end::default_timezone_zone[]
 
+	@Nested
 	// tag::default_timezone_class_level[]
 	@DefaultTimeZone("CET")
 	class MyTimeZoneTests {

--- a/src/demo/java/org/junitpioneer/jupiter/DisableIfTestFailsExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/DisableIfTestFailsExtensionDemo.java
@@ -51,7 +51,7 @@ public class DisableIfTestFailsExtensionDemo {
 	// tag::disable_if_test_not_on_assertions[]
 	@DisableIfTestFails(onAssertion = false)
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-	static class ThreeTestsWithSecondFailingWithUnconfiguredAssertionTestCase {
+	class ThreeTestsWithSecondFailingWithUnconfiguredAssertionTestCase {
 
 		@Test
 		@Order(1)
@@ -76,7 +76,7 @@ public class DisableIfTestFailsExtensionDemo {
 	// tag::disable_if_test_with_given_exception[]
 	@DisableIfTestFails(with = IOException.class)
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-	static class ThreeTestsWithSecondThrowingConfiguredExceptionTestCase {
+	class ThreeTestsWithSecondThrowingConfiguredExceptionTestCase {
 
 		@Test
 		@Order(1)

--- a/src/demo/java/org/junitpioneer/jupiter/DisableIfTestFailsExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/DisableIfTestFailsExtensionDemo.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 
 public class DisableIfTestFailsExtensionDemo {
 
+	// these tests fail intentionally ~> no @Nested
 	// tag::disable_if_test_fails[]
 	@DisableIfTestFails
 	// this annotation ensures that tests are run in the order of
@@ -48,6 +49,7 @@ public class DisableIfTestFailsExtensionDemo {
 	}
 	// end::disable_if_test_fails[]
 
+	// these tests fail intentionally ~> no @Nested
 	// tag::disable_if_test_not_on_assertions[]
 	@DisableIfTestFails(onAssertion = false)
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -73,6 +75,7 @@ public class DisableIfTestFailsExtensionDemo {
 	}
 	// end::disable_if_test_not_on_assertions[]
 
+	// these tests fail intentionally ~> no @Nested
 	// tag::disable_if_test_with_given_exception[]
 	@DisableIfTestFails(with = IOException.class)
 	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)

--- a/src/demo/java/org/junitpioneer/jupiter/DisableUntilExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/DisableUntilExtensionDemo.java
@@ -10,6 +10,7 @@
 
 package org.junitpioneer.jupiter;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class DisableUntilExtensionDemo {
@@ -30,6 +31,7 @@ public class DisableUntilExtensionDemo {
 	}
 	// end::disable_until_with_reason[]
 
+	@Nested
 	// tag::disable_until_at_class_level[]
 	@DisabledUntil(date = "2022-01-01")
 	class TestClass {

--- a/src/demo/java/org/junitpioneer/jupiter/EnvironmentVariablesExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/EnvironmentVariablesExtensionDemo.java
@@ -57,6 +57,7 @@ public class EnvironmentVariablesExtensionDemo {
 	}
 	// end::environment_using_set_and_clear[]
 
+	@Nested
 	// tag::environment_using_at_class_level[]
 	@ClearEnvironmentVariable(key = "some variable")
 	class MyEnvironmentVariableTest {

--- a/src/demo/java/org/junitpioneer/jupiter/StdInOutExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/StdInOutExtensionDemo.java
@@ -16,6 +16,7 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class StdInOutExtensionDemo {
@@ -86,6 +87,7 @@ public class StdInOutExtensionDemo {
 	}
 	// end::stdio_edge_cases_ExampleConsoleReader[]
 
+	@Nested
 	// tag::stdio_edge_cases_ConsoleReaderTest[]
 	class ConsoleReaderTest {
 

--- a/src/demo/java/org/junitpioneer/jupiter/StopwatchExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/StopwatchExtensionDemo.java
@@ -10,6 +10,7 @@
 
 package org.junitpioneer.jupiter;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class StopwatchExtensionDemo {
@@ -22,6 +23,7 @@ public class StopwatchExtensionDemo {
 	}
 	// end::method[]
 
+	@Nested
 	// tag::class[]
 	@Stopwatch
 	class TestCases {

--- a/src/demo/java/org/junitpioneer/jupiter/SystemPropertyExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/SystemPropertyExtensionDemo.java
@@ -54,6 +54,7 @@ public class SystemPropertyExtensionDemo {
 	}
 	// end::systemproperty_using_set_and_clear[]
 
+	@Nested
 	// tag::systemproperty_using_at_class_level[]
 	@ClearSystemProperty(key = "some property")
 	class MySystemPropertyTest {

--- a/src/demo/java/org/junitpioneer/jupiter/json/JsonArgumentSourceExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/json/JsonArgumentSourceExtensionDemo.java
@@ -131,7 +131,7 @@ class JsonArgumentSourceExtensionDemo {
 
 	}
 
-	static class Misc {
+	class Misc {
 
 		// tag::use_object_mapper_example[]
 		@ParameterizedTest

--- a/src/demo/java/org/junitpioneer/jupiter/json/JsonArgumentSourceExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/json/JsonArgumentSourceExtensionDemo.java
@@ -131,7 +131,8 @@ class JsonArgumentSourceExtensionDemo {
 
 	}
 
-	class Misc {
+	// these tests fail intentionally ~> no @Nested
+	class Failing {
 
 		// tag::use_object_mapper_example[]
 		@ParameterizedTest

--- a/src/demo/java/org/junitpioneer/jupiter/params/DisableParameterizedExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/params/DisableParameterizedExtensionDemo.java
@@ -78,55 +78,55 @@ public class DisableParameterizedExtensionDemo {
 	}
 	// end::disable_parameterized_different_rules_for_different_parameters_matches[]
 
+	// tag::disable_parameterized_contains_in_all_tokens[]
+	@DisableIfAllArguments(contains = "the")
+	@ParameterizedTest
+	@CsvSource(value = { "If the swift moment I entreat:;Tarry a while! You are so fair!",
+			"Then forge the shackles to my feet,;Then I will gladly perish there!",
+			"Then let them toll the passing-bell,;Then of your servitude be free,",
+			"The clock may stop, its hands fall still,;And time be over then for me!" }, delimiter = ';')
+	void disableAllContains(String line, String line2) {
+		// ...
+	}
+	// end::disable_parameterized_contains_in_all_tokens[]
+
+	// tag::disable_parameterized_contains_in_any_token[]
+	@DisableIfAnyArgument(contains = "Then")
+	@ParameterizedTest
+	@CsvSource(value = { "If the swift moment I entreat:;Tarry a while! You are so fair!",
+			"Then forge the shackles to my feet,;Then I will gladly perish there!",
+			"Then let them toll the passing-bell,;Then of your servitude be free,",
+			"The clock may stop, its hands fall still,;And time be over then for me!" }, delimiter = ';')
+	void disableAnyContains(String line, String line2) {
+		// ...
+	}
+	// end::disable_parameterized_contains_in_any_token[]
+
+	// tag::disable_parameterized_contains_multiple_arguments[]
+	@DisableIfAnyArgument(contains = { "Then", "then" })
+	@ParameterizedTest
+	@CsvSource(value = { "If the swift moment I entreat:;Tarry a while! You are so fair!",
+			"Then forge the shackles to my feet,;Then I will gladly perish there!",
+			"Then let them toll the passing-bell,;Then of your servitude be free,",
+			"The clock may stop, its hands fall still,;And time be over then for me!" }, delimiter = ';')
+	void disableAnyContainsMultipleArguments(String line, String line2) {
+		// [...]
+	}
+	// end::disable_parameterized_contains_multiple_arguments[]
+
+	// tag::disable_parameterized_matches_all_arguments[]
+	@DisableIfAllArguments(matches = ".*\\s[a-z]{3}\\s.*")
+	@ParameterizedTest
+	@CsvSource(value = { "If the swift moment I entreat:;Tarry a while! You are so fair!",
+			"Then forge the shackles to my feet,;Then I will gladly perish there!",
+			"Then let them toll the passing-bell,;Then of your servitude be free,",
+			"The clock may stop, its hands fall still,;And time be over then for me!" }, delimiter = ';')
+	void interceptMatchesAny(String line, String line2) {
+		// [...]
+	}
+	// end::disable_parameterized_matches_all_arguments[]
+
 	class TheseTestsWillFailIntentionally {
-
-		// tag::disable_parameterized_contains_in_all_tokens[]
-		@DisableIfAllArguments(contains = "the")
-		@ParameterizedTest
-		@CsvSource(value = { "If the swift moment I entreat:;Tarry a while! You are so fair!",
-				"Then forge the shackles to my feet,;Then I will gladly perish there!",
-				"Then let them toll the passing-bell,;Then of your servitude be free,",
-				"The clock may stop, its hands fall still,;And time be over then for me!" }, delimiter = ';')
-		void disableAllContains(String line, String line2) {
-			// ...
-		}
-		// end::disable_parameterized_contains_in_all_tokens[]
-
-		// tag::disable_parameterized_contains_in_any_token[]
-		@DisableIfAnyArgument(contains = "Then")
-		@ParameterizedTest
-		@CsvSource(value = { "If the swift moment I entreat:;Tarry a while! You are so fair!",
-				"Then forge the shackles to my feet,;Then I will gladly perish there!",
-				"Then let them toll the passing-bell,;Then of your servitude be free,",
-				"The clock may stop, its hands fall still,;And time be over then for me!" }, delimiter = ';')
-		void disableAnyContains(String line, String line2) {
-			// ...
-		}
-		// end::disable_parameterized_contains_in_any_token[]
-
-		// tag::disable_parameterized_contains_multiple_arguments[]
-		@DisableIfAnyArgument(contains = { "Then", "then" })
-		@ParameterizedTest
-		@CsvSource(value = { "If the swift moment I entreat:;Tarry a while! You are so fair!",
-				"Then forge the shackles to my feet,;Then I will gladly perish there!",
-				"Then let them toll the passing-bell,;Then of your servitude be free,",
-				"The clock may stop, its hands fall still,;And time be over then for me!" }, delimiter = ';')
-		void disableAnyContainsMultipleArguments(String line, String line2) {
-			// [...]
-		}
-		// end::disable_parameterized_contains_multiple_arguments[]
-
-		// tag::disable_parameterized_matches_all_arguments[]
-		@DisableIfAllArguments(matches = ".*\\s[a-z]{3}\\s.*")
-		@ParameterizedTest
-		@CsvSource(value = { "If the swift moment I entreat:;Tarry a while! You are so fair!",
-				"Then forge the shackles to my feet,;Then I will gladly perish there!",
-				"Then let them toll the passing-bell,;Then of your servitude be free,",
-				"The clock may stop, its hands fall still,;And time be over then for me!" }, delimiter = ';')
-		void interceptMatchesAny(String line, String line2) {
-			// [...]
-		}
-		// end::disable_parameterized_matches_all_arguments[]
 
 		// tag::disable_parameterized_named_parameter_contains[]
 		@DisableIfArgument(name = "line2", contains = "swift")

--- a/src/demo/java/org/junitpioneer/jupiter/params/DisableParameterizedExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/params/DisableParameterizedExtensionDemo.java
@@ -126,6 +126,7 @@ public class DisableParameterizedExtensionDemo {
 	}
 	// end::disable_parameterized_matches_all_arguments[]
 
+	// these tests fail intentionally ~> no @Nested
 	class TheseTestsWillFailIntentionally {
 
 		// tag::disable_parameterized_named_parameter_contains[]

--- a/src/demo/java/org/junitpioneer/jupiter/resource/ResourceExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/resource/ResourceExtensionDemo.java
@@ -16,7 +16,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class ResourceExtensionDemo {

--- a/src/demo/java/org/junitpioneer/jupiter/resource/ResourceExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/resource/ResourceExtensionDemo.java
@@ -10,6 +10,9 @@
 
 package org.junitpioneer.jupiter.resource;
 
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
@@ -19,22 +22,26 @@ import java.nio.file.Paths;
 public class ResourceExtensionDemo {
 
 	// tag::create_new_resources_demo[]
+	@Test
 	void test1(@New(TemporaryDirectory.class) Path tempDir) {
 		// Test code goes here, e.g.,
 		assertTrue(Files.exists(tempDir));
 	}
 
+	@Test
 	void test2(@New(TemporaryDirectory.class) Path tempDir) {
 		// This temporary directory is different to the first one.
 	}
 	// end::create_new_resources_demo[]
 
 	// tag::create_new_dir_demo[]
+	@Test
 	void dirTest1(@Dir Path tempDir) {
 		// Test code goes here, e.g.,
 		assertTrue(Files.exists(tempDir));
 	}
 
+	@Test
 	void dirTest2(@Dir Path tempDir) {
 		// This temporary directory is different to the first one.
 	}
@@ -42,18 +49,20 @@ public class ResourceExtensionDemo {
 
 	// @formatter:off
 	// tag::create_new_resource_with_arg_demo[]
+	@Test
 	void testWithArg(
 			@New(value = TemporaryDirectory.class, arguments = "customPrefix")
 			Path tempDir) {
 		// Test code goes here, e.g.,
 		Path rootTempDir = Paths.get(System.getProperty("java.io.tmpdir"));
-		assertTrue(rootTempDir.relativize(tempDir).startsWith("customPrefix"));
+		assertTrue(rootTempDir.relativize(tempDir).toString().startsWith("customPrefix"));
 	}
 	// end::create_new_resource_with_arg_demo[]
 	// @formatter:on
 
 	// @formatter:off
 	// tag::create_shared_resource_demo[]
+	@Test
 	void sharedResourceTest1(
 			@Shared(factory = TemporaryDirectory.class, name = "sharedTempDir")
 			Path sharedTempDir) {
@@ -61,6 +70,7 @@ public class ResourceExtensionDemo {
 		assertTrue(Files.exists(sharedTempDir));
 	}
 
+	@Test
 	void sharedResourceTest2(
 			@Shared(factory = TemporaryDirectory.class, name = "sharedTempDir")
 			Path sharedTempDir) {
@@ -73,18 +83,21 @@ public class ResourceExtensionDemo {
 
 	// @formatter:off
 	// tag::create_multiple_shared_resources_demo[]
+	@Test
 	void firstSharedResource1(
 			@Shared(factory = TemporaryDirectory.class, name = "first")
 			Path first) {
 		// Test code working with first shared resource...
 	}
 
+	@Test
 	void firstSharedResource2(
 			@Shared(factory = TemporaryDirectory.class, name = "first")
 			Path first) {
 		// Test code working with first shared resource...
 	}
 
+	@Test
 	void secondSharedResource(
 			@Shared(factory = TemporaryDirectory.class, name = "second")
 			Path second) {
@@ -99,6 +112,7 @@ public class ResourceExtensionDemo {
 // tag::create_global_shared_resource_demo_first[]
 class FirstTest {
 
+	@Test
 	void test(
 			@Shared(
 					factory = TemporaryDirectory.class,
@@ -116,6 +130,7 @@ class FirstTest {
 // tag::create_global_shared_resource_demo_second[]
 class SecondTest {
 
+	@Test
 	void test(
 			@Shared(
 					factory = TemporaryDirectory.class,

--- a/src/demo/java/org/junitpioneer/jupiter/resource/ResourceExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/resource/ResourceExtensionDemo.java
@@ -10,14 +10,14 @@
 
 package org.junitpioneer.jupiter.resource;
 
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 public class ResourceExtensionDemo {
 


### PR DESCRIPTION
Copy of #777 (so credit goes to @IlyasYOY) in a branch we can push to.

Proposed commit message:

```
Run more demos as part of the build (#791)

Some demo methods and classes weren't correctly annotated with `@Test`
or `@Nested` respectively and were thus not executed as part of the
build even though they should've been. For tests/classes that were not
supposed to be executed, that was not always obvious.

This change fixes that.

PR: #791
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [-] There is documentation (Javadoc and site documentation; added or updated)
* [x] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [-] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [-] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [-] Only one sentence per line (especially in `.adoc` files)
* [-] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [-] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [-] The `package-info.java` contains information about the new extension

Code (general)
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [x] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.md#assertions) (which are based on AssertJ)

Code (new package)
* [-] The new package is exported in `module-info.java`
* [-] The new package is also present in the tests
* [-] The new package is opened for reflection to JUnit 5 in `module-info.java`
* [-] The new package is listed in the contribution guide

Contributing
* [x] A prepared commit message exists
* [-] The list of contributions inside `README.md` mentions the new contribution (real name optional) 
