### PR TITLE
Switch JUnit to 5.10

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-junitVersion=5.9.2
+junitVersion=5.10.1
 
 # Ensure sufficient heap size, especially for Sonar.
 org.gradle.jvmargs=-Xmx8g


### PR DESCRIPTION
I would be good to switch and release the new version to do not (transitively) generate: 
> ClassNotFoundException: org.junit.platform.engine.support.store.NamespacedHierarchicalStore$CloseAction

in some corner cases.

For example. Using 5.10 in the project with Allure 2.25.0 can generate the following dependencies:
```
[INFO] +- io.qameta.allure:allure-junit5:jar:2.25.0:test
[INFO] |  +- io.qameta.allure:allure-junit-platform:jar:2.25.0:test
[INFO] |  |  \- io.qameta.allure:allure-test-filter:jar:2.25.0:test
[INFO] |  \- org.junit.platform:junit-platform-launcher:jar:1.9.2:test
[INFO] |     \- org.junit.platform:junit-platform-engine:jar:1.9.2:test
...
[INFO] +- org.junit.jupiter:junit-jupiter-api:jar:5.10.1:compile
[INFO] |  +- org.opentest4j:opentest4j:jar:1.3.0:compile
[INFO] |  +- org.junit.platform:junit-platform-commons:jar:1.10.1:compile
[INFO] |  \- org.apiguardian:apiguardian-api:jar:1.1.2:compile
```

It is possible to override them (e.g. by using JUnit BOM in the end project, which is good also for the other reasons), but Allure should provide consistent dependencies [with](https://github.com/allure-framework/allure2/blob/db4a2cc791835ca71d1a8f9583afa0924a5de296/build.gradle.kts#L90):
```
mavenBom("org.junit:junit-bom:5.10.1")
...
dependency("org.junit-pioneer:junit-pioneer:2.2.0")
```

It could be probably "fixed" on the Allure side, but junit-pioneer providing 5.10/1.10 by default would be helpful anyway.

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code (general)
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#assertions) (which are based on AssertJ)

Code (new package)
* [ ] The new package is exported in `module-info.java`
* [ ] The new package is also present in the tests
* [ ] The new package is opened for reflection to JUnit 5 in `module-info.java`
* [ ] The new package is listed in the contribution guide

Contributing
* [ ] A prepared commit message exists
* [ ] The list of contributions inside `README.adoc` mentions the new contribution (real name optional) 
