### PR TITLE
Migrate to setup-gradle@v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,7 +149,9 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3
       - name: Gradle build
-        run: ./gradlew --refresh-dependencies -PjunitVersion=${{ matrix.junit-version }} --stacktrace --scan clean build -x spotlessCheck
+        env:
+          ORG_GRADLE_PROJECT_junitVersion: ${{ matrix.junit-version }}
+        run: ./gradlew --refresh-dependencies --stacktrace --scan clean build -x spotlessCheck
 
   # We want to be up-to-date and know issues with future Java versions as soon as possible.
   # Furthermore, we also would love to see our build working with the latest Gradle version.
@@ -192,9 +194,15 @@ jobs:
       - name: Gradle version
         run: gradle --version
       - name: Gradle toolchains
-        run: gradle -Porg.gradle.java.installations.auto-download=false javaToolchains
+        env:
+          ORG_GRADLE_PROJECT_org.gradle.java.installations.auto-download: false
+        run: gradle javaToolchains
       - name: Gradle build
-        run: gradle --refresh-dependencies -PexperimentalJavaVersion=${{ env.EXPERIMENTAL_JAVA }} -PjunitVersion=${{ matrix.junit-version }} -Porg.gradle.java.installations.auto-download=false --stacktrace --scan clean build -x spotlessCheck
+        env:
+          ORG_GRADLE_PROJECT_experimentalJavaVersion: ${{ env.EXPERIMENTAL_JAVA }}
+          ORG_GRADLE_PROJECT_junitVersion: ${{ matrix.junit-version }}
+          ORG_GRADLE_PROJECT_org.gradle.java.installations.auto-download: false 
+        run: gradle --refresh-dependencies --stacktrace --scan clean build -x spotlessCheck
 
   # A release will be created if there is a `version` defined and `releasing` is set to `true`.
   # If not, this stage will be ignored.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,10 +64,10 @@ jobs:
           java-version: 11
           distribution: temurin
           cache: 'gradle'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
       - name: Gradle build
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: --refresh-dependencies --stacktrace --scan clean build -x spotlessCheck
+        run: ./gradlew --refresh-dependencies --stacktrace --scan clean build -x spotlessCheck
 
   # SonarCloud analysis
   sonar-cloud-analysis:
@@ -92,10 +92,10 @@ jobs:
         with:
           path: ~/.sonar/cache/
           key: ubuntu-sonar
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
       - name: Gradle build
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: --refresh-dependencies --stacktrace --scan clean build -x spotlessCheck
+        run: ./gradlew --refresh-dependencies --stacktrace --scan clean build -x spotlessCheck
       - name: SonarCloud analysis
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -117,10 +117,10 @@ jobs:
           java-version: 11
           distribution: temurin
           cache: 'gradle'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
       - name: Spotless check
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: --scan spotlessCheck
+        run: ./gradlew --scan spotlessCheck
 
   # Our full integration job, which will build for a matrix out of our
   # supported Java versions, operating systems and various JUnit versions.
@@ -146,10 +146,10 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: temurin
           cache: 'gradle'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
       - name: Gradle build
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: --refresh-dependencies -PjunitVersion=${{ matrix.junit-version }} --stacktrace --scan clean build -x spotlessCheck
+        run: ./gradlew --refresh-dependencies -PjunitVersion=${{ matrix.junit-version }} --stacktrace --scan clean build -x spotlessCheck
 
   # We want to be up-to-date and know issues with future Java versions as soon as possible.
   # Furthermore, we also would love to see our build working with the latest Gradle version.
@@ -184,16 +184,17 @@ jobs:
           java-version: 17
           distribution: temurin
           cache: 'gradle'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: release-candidate
+
+      - name: Gradle version
+        run: gradle --version
       - name: Gradle toolchains
-        uses: gradle/gradle-build-action@v2
-        with:
-          gradle-version: release-candidate
-          arguments: -Porg.gradle.java.installations.auto-download=false javaToolchains
+        run: gradle -Porg.gradle.java.installations.auto-download=false javaToolchains
       - name: Gradle build
-        uses: gradle/gradle-build-action@v2
-        with:
-          gradle-version: release-candidate
-          arguments: --refresh-dependencies -PexperimentalJavaVersion=${{ env.EXPERIMENTAL_JAVA }} -PjunitVersion=${{ matrix.junit-version }} -Porg.gradle.java.installations.auto-download=false --stacktrace --scan clean build -x spotlessCheck
+        run: gradle --refresh-dependencies -PexperimentalJavaVersion=${{ env.EXPERIMENTAL_JAVA }} -PjunitVersion=${{ matrix.junit-version }} -Porg.gradle.java.installations.auto-download=false --stacktrace --scan clean build -x spotlessCheck
 
   # A release will be created if there is a `version` defined and `releasing` is set to `true`.
   # If not, this stage will be ignored.
@@ -218,8 +219,9 @@ jobs:
             21
             11
           distribution: temurin
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v3
       - name: Perform release
-        uses: gradle/gradle-build-action@v2
         env:
           # used to trigger website build
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -231,8 +233,7 @@ jobs:
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.NEXUS_TOKEN_PASSWORD }}
           # defines released version according to GitHub Action input
           ORG_GRADLE_PROJECT_version: ${{ github.event.inputs.version }}
-        with:
-          arguments: publishToSonatype closeAndReleaseSonatypeStagingRepository githubRelease
+        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository githubRelease
 
   # After our release, we also need to trigger an update for our website build
   update-website:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,6 @@ jobs:
         with:
           java-version: 11
           distribution: temurin
-          cache: 'gradle'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3
       - name: Gradle build
@@ -86,7 +85,6 @@ jobs:
         with:
           java-version: 17
           distribution: temurin
-          cache: 'gradle'
       - name: Cache SonarCloud results
         uses: actions/cache@v3
         with:
@@ -116,7 +114,6 @@ jobs:
         with:
           java-version: 11
           distribution: temurin
-          cache: 'gradle'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3
       - name: Spotless check
@@ -145,7 +142,6 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin
-          cache: 'gradle'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3
       - name: Gradle build
@@ -185,7 +181,6 @@ jobs:
         with:
           java-version: 17
           distribution: temurin
-          cache: 'gradle'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3
         with:


### PR DESCRIPTION
Proposed commit message:

```
Migrate from gradle-build-action to setup-gradle GitHub Action.

A new way of consuming Gradle Actions is coming in v3.
There are no significant changes to the action logic,
the v3 version and the new action is a drop-in replacement.

Setting up AND running Gradle in the same step is deprecated,
so the steps are split into two: setup-gradle + `run:`.

Because `run:` uses different shells on different OSs,
the `-Pa=b` Gradle params are moved to `ORG_GRADLE_PROJECT_a: b`
environment variables, because that approach is fully cross platform.

Removed `cache: 'gradle'` from setup-java,
because setup-gradle is doing the same, and more.

PR: #803
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [x] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code (general)
* [x] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#assertions) (which are based on AssertJ)

Code (new package)
* [ ] The new package is exported in `module-info.java`
* [ ] The new package is also present in the tests
* [ ] The new package is opened for reflection to JUnit 5 in `module-info.java`
* [ ] The new package is listed in the contribution guide

Contributing
* [ ] A prepared commit message exists
* [ ] The list of contributions inside `README.adoc` mentions the new contribution (real name optional) 
