### PR TITLE
Replace `@code` with `@link` in JavaDoc

### DIFF
--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *     </li>
  * </ul>
  *
- * <p>Please keep in mind the the {@code Locale.Builder} does a syntax check, if you use a variant!
+ * <p>Please keep in mind the the {@link java.util.Locale.Builder} does a syntax check, if you use a variant!
  * The given string must match the BCP 47 (or more detailed <a href="https://www.rfc-editor.org/rfc/rfc5646.html">RFC 5646</a>) syntax.</p>
  *
  * <p>If a language tag is set, none of the other fields must be set. Otherwise an
@@ -44,14 +44,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * be thrown. Specifying a {@link #country()} but no {@link #language()}, or a
  * {@link #variant()} but no {@link #country()} and {@link #language()} will
  * also cause an {@code ExtensionConfigurationException}. After the annotated
- * element has been executed, the default {@code Locale} will be restored to
+ * element has been executed, the default {@link java.util.Locale} will be restored to
  * its original value.</p>
  *
  * <p>{@code @DefaultLocale} can be used on the method and on the class level. It
  * is inherited from higher-level containers, but can only be used once per method
- * or class. If a class is annotated, the configured {@code Locale} will be the
- * default {@code Locale} for all tests inside that class. Any method level
- * configurations will override the class level default {@code Locale}.</p>
+ * or class. If a class is annotated, the configured {@link java.util.Locale} will be the
+ * default {@link java.util.Locale} for all tests inside that class. Any method level
+ * configurations will override the class level default {@link java.util.Locale}.</p>
  *
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,
@@ -97,7 +97,7 @@ public @interface DefaultLocale {
 
 	/**
 	 * An IETF BCP 47 language string that matches the <a href="https://www.rfc-editor.org/rfc/rfc5646.html">RFC 5646</a> syntax.
-	 * It's validated by the {@code Locale.Builder}, using {@code sun.util.locale.LanguageTag#isVariant}.
+	 * It's validated by the {@link java.util.Locale.Builder}, using {@link sun.util.locale.LanguageTag#isVariant}.
 	 */
 	String variant() default "";
 

--- a/src/main/java/org/junitpioneer/jupiter/ReadsStdIo.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReadsStdIo.java
@@ -21,8 +21,8 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.api.parallel.Resources;
 
 /**
- * Marks tests that read the static fields {@code System.in}, {@code System.out} or {@code System.err}
- * but don't call {@code System.setIn()}, {@code System.setOut()} or {@code System.setErr()}.
+ * Marks tests that read the static fields {@link System#in}, {@link System#out} or {@link System#err}
+ * but don't call {@link System#setIn()}, {@link System#setOut()} or {@link System#setErr()}.
  *
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,

--- a/src/main/java/org/junitpioneer/jupiter/ReportEntry.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReportEntry.java
@@ -19,7 +19,7 @@ import java.lang.annotation.Target;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
- * Publish the specified key-value pair to be consumed by an {@code org.junit.platform.engine.EngineExecutionListener}
+ * Publish the specified key-value pair to be consumed by an {@link org.junit.platform.engine.EngineExecutionListener}
  * in order to supply additional information to the reporting infrastructure. This is functionally identical to calling
  * {@link org.junit.jupiter.api.extension.ExtensionContext#publishReportEntry(String, String) ExtensionContext::publishReportEntry}
  * from within the test method.

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTest.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTest.java
@@ -46,12 +46,12 @@ import org.junitpioneer.internal.TestNameFormatter;
  *
  * <ul>
  *     <li>it can only be applied to methods</li>
- *     <li>methods annotated with this annotation <b>MUST NOT</b> be annotated with {@code @Test}
+ *     <li>methods annotated with this annotation <b>MUST NOT</b> be annotated with {@link org.junit.jupiter.api.Test @Test}
  *         to avoid multiple executions!</li>
  *     <li>it can't be used with other {@link TestTemplate}-based mechanisms
- *         like {@code org.junit.jupiter.api.RepeatedTest @RepeatedTest} or
- *         {@code org.junit.jupiter.params.ParameterizedTest @ParameterizedTest}</li>
- *     <li>it can't be used with {@code org.junit.jupiter.api.DynamicTest @DynamicTest}</li>
+ *         like {@link org.junit.jupiter.api.RepeatedTest @RepeatedTest} or
+ *         {@link org.junit.jupiter.params.ParameterizedTest @ParameterizedTest}</li>
+ *     <li>it can't be used with {@link org.junit.jupiter.api.DynamicTest @DynamicTest}</li>
  *     <li>all retries are run sequentially, even when used with
  *         <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution">parallel test execution</a></li>
  * </ul>

--- a/src/main/java/org/junitpioneer/jupiter/StdIn.java
+++ b/src/main/java/org/junitpioneer/jupiter/StdIn.java
@@ -60,14 +60,14 @@ public class StdIn extends InputStream {
 	}
 
 	/**
-	 * @return the string that was read from {@code System.in}; note that buffering readers may read all lines eagerly
+	 * @return the string that was read from {@link System#in}; note that buffering readers may read all lines eagerly
 	 */
 	public String capturedString() {
 		return writer.toString();
 	}
 
 	/**
-	 * @return the lines that were read from {@code System.in}; note that buffering readers may read all lines eagerly
+	 * @return the lines that were read from {@link System#in}; note that buffering readers may read all lines eagerly
 	 */
 	public String[] capturedLines() {
 		var lines = writer.toString().split(StdIoExtension.SEPARATOR, -1);

--- a/src/main/java/org/junitpioneer/jupiter/StdIo.java
+++ b/src/main/java/org/junitpioneer/jupiter/StdIo.java
@@ -18,9 +18,9 @@ import java.lang.annotation.Target;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
- * Allows specifying the input that's read from {@code System.in} as well as capturing
- * lines read from {@code System.in} (with parameter {@link StdIn}) or
- * written to {@code System.out} (with parameter {@link StdOut StdOut}).
+ * Allows specifying the input that's read from {@link System#in} as well as capturing
+ * lines read from {@link System#in} (with parameter {@link StdIn}) or
+ * written to {@link System#out} (with parameter {@link StdOut StdOut}).
  *
  * <p>The annotated test method can have zero, one, or both parameters, but {@code StdIn} can only
  * be provided if {@link StdIo#value()} is used to specify input - otherwise an

--- a/src/main/java/org/junitpioneer/jupiter/StdOutputStream.java
+++ b/src/main/java/org/junitpioneer/jupiter/StdOutputStream.java
@@ -34,7 +34,7 @@ abstract class StdOutputStream extends OutputStream {
 	}
 
 	/**
-	 * @return the string that was written to {@code System.out} or {@code System.err}
+	 * @return the string that was written to {@link System#out} or {@link System#err}
 	 */
 	public String capturedString() {
 		return writer.toString();
@@ -52,7 +52,7 @@ abstract class StdOutputStream extends OutputStream {
 	 * {@code println}. For more details and examples on this, see
 	 * <a href="https://junit-pioneer.org/docs/standard-input-output/" target="_top">the documentation on standard input/output</a>.</p>
 	 *
-	 * @return the lines that were written to {@code System.out} or {@code System.err}
+	 * @return the lines that were written to {@link System#out} or {@link System#err}
 	 */
 	public String[] capturedLines() {
 		var lines = writer.toString().split(StdIoExtension.SEPARATOR, -1);

--- a/src/main/java/org/junitpioneer/jupiter/WritesStdIo.java
+++ b/src/main/java/org/junitpioneer/jupiter/WritesStdIo.java
@@ -21,8 +21,8 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.api.parallel.Resources;
 
 /**
- * Marks tests that call {@code System.setIn()}, {@code System.setOut()} or {@code System.setErr()} to
- * set the static fields {@code System.in}/{@code System.out}/{@code System.err}.
+ * Marks tests that call {@link System#setIn()}, {@link System#setOut()} or {@link System#setErr()} to
+ * set the static fields {@link System#in}/{@link System#out}/{@link System#err}.
  *
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,

--- a/src/main/java/org/junitpioneer/jupiter/converter/NumberToByteArrayConversion.java
+++ b/src/main/java/org/junitpioneer/jupiter/converter/NumberToByteArrayConversion.java
@@ -43,14 +43,14 @@ public @interface NumberToByteArrayConversion {
 		/**
 		 * Constant denoting big-endian byte order.
 		 * In this order, the bytes of a multibyte value are ordered from most significant to least significant.
-		 * This is the logical equivalent of {@code java.nio.ByteOrder.BIG_ENDIAN}
+		 * This is the logical equivalent of {@link java.nio.ByteOrder.BIG_ENDIAN}
 		 */
 		BIG_ENDIAN,
 
 		/**
 		 * Constant denoting little-endian byte order.
 		 * In this order, the bytes of a multibyte value are ordered from least significant to most significant.
-		 * This is the logical equivalent of {@code java.nio.ByteOrder.LITTLE_ENDIAN}.
+		 * This is the logical equivalent of {@link java.nio.ByteOrder.LITTLE_ENDIAN}.
 		 */
 		LITTLE_ENDIAN
 

--- a/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
@@ -85,7 +85,7 @@ class DefaultLocaleTests {
 		 * This means "en-EN" is a valid languageTag, but not a valid IETF BCP 47 variant subtag.
 		 * <br>
 		 * This is very confusing as the <a href="https://www.oracle.com/java/technologies/javase/jdk11-suported-locales.html">official page for supported locales</a> shows that japanese locales return {@code *} or {@code JP} as a variant.
-		 * Even more confusing the enum values {@code Locale.JAPAN} and {@code Locale.JAPANESE} don't return a variant.
+		 * Even more confusing the enum values {@link Locale.JAPAN} and {@link Locale.JAPANESE} don't return a variant.
 		 *
 		 * @see <a href="https://www.rfc-editor.org/rfc/rfc5646.html">RFC 5646</a>
 		 */

--- a/src/test/java/org/junitpioneer/testkit/assertion/PropertiesAssert.java
+++ b/src/test/java/org/junitpioneer/testkit/assertion/PropertiesAssert.java
@@ -33,7 +33,7 @@ public class PropertiesAssert extends AbstractAssert<PropertiesAssert, Propertie
 	 * the same nested default structure.
 	 *
 	 * <p>Properties are considered <em>effectively equal</em> if they have the same property
-	 * names returned by {@code Properties.propertyNames()} and the same values returned by
+	 * names returned by {@link Properties#propertyNames()} and the same values returned by
 	 * {@code getProperty(name)}. Properties may come from the properties instance itself,
 	 * or from a nested default instance, indiscriminately.
 	 *


### PR DESCRIPTION
Proposed commit message:

```
Replace `@code` with `@link` in JavaDoc

In several places, JavaDoc uses `@code` the same as `@link`
but it works differently and should be replaced with the correct `@link`.
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [ ] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code (general)
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [x] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#assertions) (which are based on AssertJ)

Code (new package)
* [ ] The new package is exported in `module-info.java`
* [ ] The new package is also present in the tests
* [ ] The new package is opened for reflection to JUnit 5 in `module-info.java`
* [ ] The new package is listed in the contribution guide

Contributing
* [x] A prepared commit message exists
* [ ] The list of contributions inside `README.adoc` mentions the new contribution (real name optional) 
