### PR TITLE
 Refactored data clumps with the help of LLMs (research project)

### DIFF
--- a/src/test/java/org/junitpioneer/testkit/ExecutionResults.java
+++ b/src/test/java/org/junitpioneer/testkit/ExecutionResults.java
@@ -43,8 +43,8 @@ public class ExecutionResults {
 			return this;
 		}
 
-		Executor selectTestClass(Class<?> testClass) {
-			selectors.add(DiscoverySelectors.selectClass(testClass));
+		Executor selectTestClass(TestSelector testSelector) {
+			selectors.add(DiscoverySelectors.selectClass(testSelector.getTestClass()));
 			return new Executor();
 		}
 
@@ -56,32 +56,43 @@ public class ExecutionResults {
 			return new Executor();
 		}
 
-		Executor selectTestMethod(Class<?> testClass, String testMethodName) {
-			selectors.add(DiscoverySelectors.selectMethod(testClass, testMethodName));
+		Executor selectTestMethod(TestSelector testSelector) {
+			selectors
+					.add(
+						DiscoverySelectors.selectMethod(testSelector.getTestClass(), testSelector.getTestMethodName()));
 			return new Executor();
 		}
 
-		Executor selectTestMethodWithParameterTypes(Class<?> testClass, String testMethodName,
-				String methodParameterTypes) {
-			selectors.add(DiscoverySelectors.selectMethod(testClass, testMethodName, methodParameterTypes));
-			return new Executor();
-		}
-
-		Executor selectNestedTestClass(List<Class<?>> enclosingClasses, Class<?> testClass) {
-			selectors.add(DiscoverySelectors.selectNestedClass(enclosingClasses, testClass));
-			return new Executor();
-		}
-
-		Executor selectNestedTestMethod(List<Class<?>> enclosingClasses, Class<?> testClass, String testMethodName) {
-			selectors.add(DiscoverySelectors.selectNestedMethod(enclosingClasses, testClass, testMethodName));
-			return new Executor();
-		}
-
-		Executor selectNestedTestMethodWithParameterTypes(List<Class<?>> enclosingClasses, Class<?> testClass,
-				String testMethodName, String methodParameterTypes) {
+		Executor selectTestMethodWithParameterTypes(TestSelector testSelector) {
 			selectors
 					.add(DiscoverySelectors
-							.selectNestedMethod(enclosingClasses, testClass, testMethodName, methodParameterTypes));
+							.selectMethod(testSelector.getTestClass(), testSelector.getTestMethodName(),
+								testSelector.getMethodParameterTypes()));
+			return new Executor();
+		}
+
+		Executor selectNestedTestClass(NestedTestSelector nestedTestSelector) {
+			selectors
+					.add(DiscoverySelectors
+							.selectNestedClass(nestedTestSelector.getEnclosingClasses(),
+								nestedTestSelector.getTestClass()));
+			return new Executor();
+		}
+
+		Executor selectNestedTestMethod(NestedTestSelector nestedTestSelector) {
+			selectors
+					.add(DiscoverySelectors
+							.selectNestedMethod(nestedTestSelector.getEnclosingClasses(),
+								nestedTestSelector.getTestClass(), nestedTestSelector.getTestMethodName()));
+			return new Executor();
+		}
+
+		Executor selectNestedTestMethodWithParameterTypes(NestedTestSelector nestedTestSelector) {
+			selectors
+					.add(DiscoverySelectors
+							.selectNestedMethod(nestedTestSelector.getEnclosingClasses(),
+								nestedTestSelector.getTestClass(), nestedTestSelector.getTestMethodName(),
+								nestedTestSelector.getMethodParameterTypes()));
 			return new Executor();
 		}
 

--- a/src/test/java/org/junitpioneer/testkit/NestedTestSelector.java
+++ b/src/test/java/org/junitpioneer/testkit/NestedTestSelector.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junitpioneer.testkit;
+
+import java.util.List;
+
+public class NestedTestSelector extends TestSelector {
+
+	private final List<Class<?>> enclosingClasses;
+
+	public NestedTestSelector(List<Class<?>> enclosingClasses, Class<?> testClass, String testMethodName,
+			String methodParameterTypes) {
+		super(testClass, testMethodName, methodParameterTypes);
+		this.enclosingClasses = enclosingClasses;
+	}
+
+	public List<Class<?>> getEnclosingClasses() {
+		return enclosingClasses;
+	}
+
+}

--- a/src/test/java/org/junitpioneer/testkit/PioneerTestKit.java
+++ b/src/test/java/org/junitpioneer/testkit/PioneerTestKit.java
@@ -27,7 +27,7 @@ public class PioneerTestKit {
 	 * @return The execution results
 	 */
 	public static ExecutionResults executeTestClass(Class<?> testClass) {
-		return ExecutionResults.builder().selectTestClass(testClass).execute();
+		return ExecutionResults.builder().selectTestClass(new TestSelector(testClass, null, null)).execute();
 	}
 
 	/**
@@ -48,7 +48,7 @@ public class PioneerTestKit {
 	 * @return The execution results
 	 */
 	public static ExecutionResults executeTestMethod(Class<?> testClass, String testMethodName) {
-		return ExecutionResults.builder().selectTestMethod(testClass, testMethodName).execute();
+		return ExecutionResults.builder().selectTestMethod(new TestSelector(testClass, testMethodName, null)).execute();
 	}
 
 	/**
@@ -69,7 +69,7 @@ public class PioneerTestKit {
 
 		return ExecutionResults
 				.builder()
-				.selectTestMethodWithParameterTypes(testClass, testMethodName, allTypeNames)
+				.selectTestMethodWithParameterTypes(new TestSelector(testClass, testMethodName, allTypeNames))
 				.execute();
 	}
 
@@ -81,7 +81,10 @@ public class PioneerTestKit {
 	 * @return The execution results
 	 */
 	public static ExecutionResults executeNestedTestClass(List<Class<?>> enclosingClasses, Class<?> testClass) {
-		return ExecutionResults.builder().selectNestedTestClass(enclosingClasses, testClass).execute();
+		return ExecutionResults
+				.builder()
+				.selectNestedTestClass(new NestedTestSelector(enclosingClasses, testClass, null, null))
+				.execute();
 	}
 
 	/**
@@ -94,7 +97,10 @@ public class PioneerTestKit {
 	 */
 	public static ExecutionResults executeNestedTestMethod(List<Class<?>> enclosingClasses, Class<?> testClass,
 			String testMethodName) {
-		return ExecutionResults.builder().selectNestedTestMethod(enclosingClasses, testClass, testMethodName).execute();
+		return ExecutionResults
+				.builder()
+				.selectNestedTestMethod(new NestedTestSelector(enclosingClasses, testClass, testMethodName, null))
+				.execute();
 	}
 
 	/**
@@ -116,7 +122,8 @@ public class PioneerTestKit {
 
 		return ExecutionResults
 				.builder()
-				.selectNestedTestMethodWithParameterTypes(enclosingClasses, testClass, testMethodName, allTypeNames)
+				.selectNestedTestMethodWithParameterTypes(
+					new NestedTestSelector(enclosingClasses, testClass, testMethodName, allTypeNames))
 				.execute();
 	}
 
@@ -142,7 +149,7 @@ public class PioneerTestKit {
 		return ExecutionResults
 				.builder()
 				.addConfigurationParameters(configurationParameters)
-				.selectTestMethodWithParameterTypes(testClass, testMethodName, allTypeNames)
+				.selectTestMethodWithParameterTypes(new TestSelector(testClass, testMethodName, allTypeNames))
 				.execute();
 	}
 

--- a/src/test/java/org/junitpioneer/testkit/TestSelector.java
+++ b/src/test/java/org/junitpioneer/testkit/TestSelector.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016-2024 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junitpioneer.testkit;
+
+public class TestSelector {
+
+	private final Class<?> testClass;
+	private final String testMethodName;
+	private final String methodParameterTypes;
+
+	public TestSelector(Class<?> testClass, String testMethodName, String methodParameterTypes) {
+		this.testClass = testClass;
+		this.testMethodName = testMethodName;
+		this.methodParameterTypes = methodParameterTypes;
+	}
+
+	public Class<?> getTestClass() {
+		return testClass;
+	}
+
+	public String getTestMethodName() {
+		return testMethodName;
+	}
+
+	public String getMethodParameterTypes() {
+		return methodParameterTypes;
+	}
+
+}


### PR DESCRIPTION

Hello maintainers,

I am conducting a master thesis project focused on enhancing code quality through automated refactoring of data clumps, assisted by Large Language Models (LLMs).
Each proposed change in this pull request has been reviewed and tested by me to ensure compliance with your standards and contribution guidelines.

<details>
  <summary>Data clump definition</summary>
  
A data clump exists if
1. two methods (in the same or in different classes) have at least 3 common parameters and one of those methods does not override the other,  or 
2. At least three fields in a class are common with the parameters of a method (in the same or in a different class), or
3. Two different classes have at least three common fields
  
See also the following UML diagram as an example
![Example data clump](https://raw.githubusercontent.com/compf/data_clump_eval_assets/main/data_clump_explained.svg)
</details>


I believe these refactoring can contribute to the project by reducing complexity and enhancing readability of your source code.

Pursuant to the EU AI Act, I fully disclose the use of LLMs in generating these refactorings, emphasizing that all changes have undergone human review for quality assurance. 


Even if you decide not to integrate my changes to your codebase (which is perfectly fine), I ask you to fill out a feedback survey, which will be scientifically evaluated to determine the acceptance of AI-supported refactorings. You can find the feedback survey under https://campus.lamapoll.de/Data-clump-refactoring/en


Thank you for considering my contribution. I look forward to your feedback. If you have any other questions or comments, feel free to write a comment, or email me under tschoemaker@uni-osnabrueck.de .


Best regards,
Timo Schoemaker
Department of Computer Science
University of Osnabrück



**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code (general)
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#assertions) (which are based on AssertJ)

Code (new package)
* [ ] The new package is exported in `module-info.java`
* [ ] The new package is also present in the tests
* [ ] The new package is opened for reflection to JUnit 5 in `module-info.java`
* [ ] The new package is listed in the contribution guide

Contributing
* [ ] A prepared commit message exists
* [ ] The list of contributions inside `README.adoc` mentions the new contribution (real name optional) 
