### PR TITLE
Mention naming convention in CONTRIBUTING.adoc (#809 / #812)

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -75,6 +75,12 @@ Everything related to branches, commits, and more is described #fixing-bugs-deve
 
 Where to put types and how to name them.
 
+==== Naming Convention
+
+If not explicit mentioned differently, we follow the https://en.wikipedia.org/wiki/Camel_case[`camelCase`] convention for naming classes and methods.
+This means that everything is written without spaces, but every word starts with an upper letter, e.g. `DisableIfTestFailsExtension` (class name) or `handleTestExecutionException` (method name).
+
+
 ==== Package Structure
 
 Classes usually belong into one of these packages:

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -77,9 +77,7 @@ Where to put types and how to name them.
 
 ==== Naming Convention
 
-If not explicit mentioned differently, we follow the https://en.wikipedia.org/wiki/Camel_case[`camelCase`] convention for naming classes and methods.
-This means that everything is written without spaces, but every word starts with an upper letter, e.g. `DisableIfTestFailsExtension` (class name) or `handleTestExecutionException` (method name).
-
+If not explicit mentioned differently, we follow the https://www.oracle.com/java/technologies/javase/codeconventions-namingconventions.html[`Java naming conventions`].
 
 ==== Package Structure
 


### PR DESCRIPTION
The naming convention for classes and methods was not yet mentioned in our contributing guideline.

closes: #809
PR: #812