### PR TITLE
Move to  only $YEAR

### DIFF
--- a/.infra/spotless/eclipse-public-license-2.0.java
+++ b/.infra/spotless/eclipse-public-license-2.0.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-$YEAR the original author or authors.
+ * Copyright $YEAR the original author or authors.
  *
  * All rights reserved. This program and the accompanying materials are
  * made available under the terms of the Eclipse Public License v2.0 which


### PR DESCRIPTION
Proposed commit message:

```
Move to $YEAR in license (#801 / #813)

We decided to no longer update the copyright
notice in our license/files but instead use the
solution adapted by the Eclipse project as well,
which is only using the creation year.

Closes: #801
PR: #813
```

Contributing
* [X] A prepared commit message exists
