### PR TITLE
Update JUnit and Java

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
         # Pioneer, latest LTS, latest stable
         java: [ 11, 21, 23 ]
         # Pioneer, latest stable
-        junit-version: [ '5.9.2', '5.10.0' ]
+        junit-version: [ '5.10.1', '5.11.2' ]
         os: [ubuntu, macos, windows]
     name: with Java ${{ matrix.java }}, JUnit ${{ matrix.junit-version }} on ${{ matrix.os }}
     steps:
@@ -164,7 +164,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        junit-version: [ '5.9.2', '5.10.0' ]
+        junit-version: [ '5.10.1', '5.11.2' ]
         os: [ubuntu, macos, windows]
     name: Experimental build with newest JDK early-access build and Gradle release candidate
     # Gradle doesn't work with JDK EA builds, so we launch it with a supported Java version,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,8 +134,8 @@ jobs:
       matrix:
         # Pioneer, latest LTS, latest stable
         java: [ 11, 21, 23 ]
-        # Pioneer, latest stable
-        junit-version: [ '5.10.1', '5.11.2' ]
+        # Pioneer = latest stable
+        junit-version: [ '5.11.2' ]
         os: [ubuntu, macos, windows]
     name: with Java ${{ matrix.java }}, JUnit ${{ matrix.junit-version }} on ${{ matrix.os }}
     steps:
@@ -164,7 +164,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        junit-version: [ '5.10.1', '5.11.2' ]
+        junit-version: [ '5.11.2' ]
         os: [ubuntu, macos, windows]
     name: Experimental build with newest JDK early-access build and Gradle release candidate
     # Gradle doesn't work with JDK EA builds, so we launch it with a supported Java version,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,8 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
+          # Sonar needs Java 17
+          # See https://docs.sonarsource.com/sonarcloud/appendices/scanner-environment/
           java-version: 17
           distribution: temurin
       - name: Cache SonarCloud results
@@ -130,7 +132,9 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        java: [ 11, 17, 21 ]
+        # Pioneer, latest LTS, latest stable
+        java: [ 11, 21, 23 ]
+        # Pioneer, latest stable
         junit-version: [ '5.9.2', '5.10.0' ]
         os: [ubuntu, macos, windows]
     name: with Java ${{ matrix.java }}, JUnit ${{ matrix.junit-version }} on ${{ matrix.os }}
@@ -179,7 +183,7 @@ jobs:
       - name: Set up supported Java
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 23
           distribution: temurin
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v3
@@ -216,10 +220,10 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
-          # we build the Javadoc with JDK 17 (for better results),
+          # we build the Javadoc with JDK 23 (for better results),
           # so install that as well
           java-version: |
-            21
+            23
             11
           distribution: temurin
       - name: Set up Gradle

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -304,7 +304,7 @@ tasks {
 		if (releaseBuild) {
 			javadocTool.set(project.javaToolchains.javadocToolFor {
 				// create Javadoc with the minimum Java version needed for our desired features (e.g. search)
-				languageVersion.set(JavaLanguageVersion.of(21))
+				languageVersion.set(JavaLanguageVersion.of(23))
 			})
 		}
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-junitVersion=5.10.1
+junitVersion=5.11.2
 
 # Ensure sufficient heap size, especially for Sonar.
 org.gradle.jvmargs=-Xmx8g

--- a/src/test/java/org/junitpioneer/jupiter/resource/ResourcesTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/resource/ResourcesTests.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.platform.commons.JUnitException;
 import org.junitpioneer.testkit.ExecutionResults;
 
 @DisplayName("Resources extension")
@@ -76,7 +77,10 @@ class ResourcesTests {
 
 				assertThat(results)
 						.hasSingleFailedTest()
-						.withExceptionInstanceOf(EXPECTED_THROW_ON_RF_CLOSE_EXCEPTION.getClass())
+						.withExceptionInstanceOf(JUnitException.class)
+						.hasMessage("Failed to close extension context")
+						.cause()
+						.isInstanceOf(EXPECTED_THROW_ON_RF_CLOSE_EXCEPTION.getClass())
 						.hasMessage(EXPECTED_THROW_ON_RF_CLOSE_EXCEPTION.getMessage());
 			}
 
@@ -135,7 +139,10 @@ class ResourcesTests {
 
 					assertThat(results)
 							.hasSingleFailedTest()
-							.withExceptionInstanceOf(EXPECTED_THROW_ON_R_CLOSE_EXCEPTION.getClass())
+							.withExceptionInstanceOf(JUnitException.class)
+							.hasMessage("Failed to close extension context")
+							.cause()
+							.isInstanceOf(EXPECTED_THROW_ON_R_CLOSE_EXCEPTION.getClass())
 							.hasMessage(EXPECTED_THROW_ON_R_CLOSE_EXCEPTION.getMessage());
 				}
 
@@ -629,7 +636,10 @@ class ResourcesTests {
 
 				assertThat(results)
 						.hasSingleFailedContainer()
-						.withExceptionInstanceOf(EXPECTED_THROW_ON_RF_CLOSE_EXCEPTION.getClass())
+						.withExceptionInstanceOf(JUnitException.class)
+						.hasMessage("Failed to close extension context")
+						.cause()
+						.isInstanceOf(EXPECTED_THROW_ON_RF_CLOSE_EXCEPTION.getClass())
 						.hasMessage(EXPECTED_THROW_ON_RF_CLOSE_EXCEPTION.getMessage());
 			}
 
@@ -688,7 +698,10 @@ class ResourcesTests {
 
 					assertThat(results)
 							.hasSingleFailedContainer()
-							.withExceptionInstanceOf(EXPECTED_THROW_ON_R_CLOSE_EXCEPTION.getClass())
+							.withExceptionInstanceOf(JUnitException.class)
+							.hasMessage("Failed to close extension context")
+							.cause()
+							.isInstanceOf(EXPECTED_THROW_ON_R_CLOSE_EXCEPTION.getClass())
 							.hasMessage(EXPECTED_THROW_ON_R_CLOSE_EXCEPTION.getMessage());
 				}
 


### PR DESCRIPTION
In contrast to what is partly written in #818, I did _not_ upgrade the JUnit version in `gradle.properties`, as ["Pioneer aims to use the lowest JUnit 5 version that supports Pioneer’s feature set"](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#updating-junit-5).

Proposed commit message:

```
Update JUnit (Pioneer) and Java (CI) (#818 / #826)

This PR updates the JUnit dependency for Pioneer from 5.10.2 to
5.11.2. It also updates the latest included Java version for CI from 21 to
23.

Since the engine behavior changed with JUnit 5.11.0 (see
https://github.com/junit-team/junit5/commit/9af6ca4ba66e5bc3ba4a93b47333816853dd34f4#diff-58dca140b6249c0d7f76a8056994eb6762b71bd2f79cc28106e5391d16d23245), some assertions are updated as well.

Closes: #818
PR: #826
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code (general)
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#assertions) (which are based on AssertJ)

Code (new package)
* [ ] The new package is exported in `module-info.java`
* [ ] The new package is also present in the tests
* [ ] The new package is opened for reflection to JUnit 5 in `module-info.java`
* [ ] The new package is listed in the contribution guide

Contributing
* [x] A prepared commit message exists
* [ ] The list of contributions inside `README.adoc` mentions the new contribution (real name optional) 
