### PR TITLE
Add pre-commit hook for formatting (#588)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,10 @@
+#!/bin/sh
+stagedFiles=$(git diff --staged --name-only)
+echo "Running spotlessApply. Formatting code..."
+./gradlew spotlessApply
+
+for file in $stagedFiles; do
+  if test -f "$file"; then
+    git add $file
+  fi
+done

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -156,6 +156,18 @@ It usually makes sense to store them in a static final field.
 
 How to write the code itself.
 
+==== Formatting
+
+This project uses https://github.com/diffplug/spotless[Spotless] to apply and verify code formatting.
+As builds break if the formatting is off, you should run it before committing.
+You can execute it manually by `./gradlew spotlessApply`.
+But you can also automate this by enabling a pre-commit hook:
+
+```bash
+git config --local core.hooksPath .githooks/
+```
+
+
 ==== `Optional`
 https://nipafx.dev/intention-revealing-code-java-8-optional/[There shall be no `null` - use `Optional` instead]:
 

--- a/README.adoc
+++ b/README.adoc
@@ -125,6 +125,7 @@ The least we can do is to thank them and list some of their accomplishments here
 * https://github.com/FanJups[Fanon Jupkwo (FanJups)] added a new display name generator extending `org.junit.jupiter.api.DisplayNameGenerator.Standard` to support CamelCase, underscores, and numbers: https://junit-pioneer.org/docs/replace-camelcase-and-underscore-and-number/[ReplaceCamelCaseAndUnderscoreAndNumber] (#793 / #819)
 * https://github.com/TWiStErRob[Papp Róbert (TWiStErRob)] updated Gradle and GitHub Actions tooling to latest. (#803 / #804 / #805)
 * https://github.com/boris-faniuk-n26[Boris Faniuk] contributed to `@RetryingTest` extension (#821)
+* https://github.com/ccudennec-otto[Christopher Cudennec] contributed to `CONTRIBUTING.adoc` and added the pre-commit hook for code formatting (#588)
 
 ==== 2023
 


### PR DESCRIPTION
Add the hook and documentation how to use it to CONTRIBUTING.adoc

Closes: #588
---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [x] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code (general)
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#assertions) (which are based on AssertJ)

Code (new package)
* [ ] The new package is exported in `module-info.java`
* [ ] The new package is also present in the tests
* [ ] The new package is opened for reflection to JUnit 5 in `module-info.java`
* [ ] The new package is listed in the contribution guide

Contributing
* [x] A prepared commit message exists
* [x] The list of contributions inside `README.adoc` mentions the new contribution (real name optional) 
