### PR TITLE
Support Named for cartesian products (#842)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -120,6 +120,10 @@ Thank you for your efforts! ?
 
 The least we can do is to thank them and list some of their accomplishments here (in lexicographic order).
 
+==== 2025
+
+* https://github.com/schosin[Ken Schosinsky] added support for `Named` to `@CartesianTestExtension` (#842 / #848)
+
 ==== 2024
 
 * https://github.com/FanJups[Fanon Jupkwo (FanJups)] added a new display name generator extending `org.junit.jupiter.api.DisplayNameGenerator.Standard` to support CamelCase, underscores, and numbers: https://junit-pioneer.org/docs/replace-camelcase-and-underscore-and-number/[ReplaceCamelCaseAndUnderscoreAndNumber] (#793 / #819)

--- a/docs/cartesian-product.adoc
+++ b/docs/cartesian-product.adoc
@@ -211,6 +211,8 @@ This method must return `ArgumentSets`.
 `ArgumentSets` is a helper class, specifically for creating sets for `@CartesianTest`.
 To create the test data, instantiate with the static factory method `argumentsForFirstParameter`, then call the `addValuesForNextParameter` method once per additional parameter in the order in which they appear in the test method.
 In each call, pass in all values for the corresponding parameter.
+By default the display name for arguments will use `toString()` for conversion.
+An argument can be wrapped in `org.junit.jupiter.api.Named` to provide a custom display name.
 For convenience, all methods return with your `ArgumentSets` instance, so you can chain `add...` calls.
 If you want to create an initially-empty `ArgumentSets`, call the static factory method `create()`.
 
@@ -223,7 +225,7 @@ include::{demo}[tag=cartesian_argument_sets]
 
 The test `testMethod` is executed exactly twelve times.
 The first parameter can have any of the two values `"Alpha"` or `"Omega"`.
-The second parameter can have any of the three values `Runnable.class`, `Cloneable.class` or `Predicate.class`.
+The second parameter can have any of the three values `Runnable.class`, `Cloneable.class` or `Predicate.class`, and uses `org.junit.jupiter.api.Named` to replace the long display name of `Class#toString()`.
 The third parameter can have any of the two values `TimeUnit.DAYS` or `TimeUnit.HOURS`.
 `@CartesianTest` tests for all input combinations, that's `2 × 3 × 2`, so twelve tests in total.
 
@@ -232,18 +234,18 @@ To demonstrate with a table:
 |===
 | # of test  | value of `string` | value of `clazz` | value of `unit`
 
-| 1st test   | "Alpha"           | Runnable.class   | TimeUnit.DAYS
-| 2nd test   | "Alpha"           | Runnable.class   | TimeUnit.HOURS
-| 3rd test   | "Alpha"           | Cloneable.class  | TimeUnit.DAYS
-| 4th test   | "Alpha"           | Cloneable.class  | TimeUnit.HOURS
-| 5th test   | "Alpha"           | Predicate.class  | TimeUnit.DAYS
-| 6th test   | "Alpha"           | Predicate.class  | TimeUnit.HOURS
-| 7th test   | "Omega"           | Runnable.class   | TimeUnit.DAYS
-| 8th test   | "Omega"           | Runnable.class   | TimeUnit.HOURS
-| 9th test   | "Omega"           | Cloneable.class  | TimeUnit.DAYS
-| 10th test  | "Omega"           | Cloneable.class  | TimeUnit.HOURS
-| 11th test  | "Omega"           | Predicate.class  | TimeUnit.DAYS
-| 12th test  | "Omega"           | Predicate.class  | TimeUnit.HOURS
+| 1st test   | "Alpha"           | Runnable         | TimeUnit.DAYS
+| 2nd test   | "Alpha"           | Runnable         | TimeUnit.HOURS
+| 3rd test   | "Alpha"           | Cloneable        | TimeUnit.DAYS
+| 4th test   | "Alpha"           | Cloneable        | TimeUnit.HOURS
+| 5th test   | "Alpha"           | Predicate        | TimeUnit.DAYS
+| 6th test   | "Alpha"           | Predicate        | TimeUnit.HOURS
+| 7th test   | "Omega"           | Runnable         | TimeUnit.DAYS
+| 8th test   | "Omega"           | Runnable         | TimeUnit.HOURS
+| 9th test   | "Omega"           | Cloneable        | TimeUnit.DAYS
+| 10th test  | "Omega"           | Cloneable        | TimeUnit.HOURS
+| 11th test  | "Omega"           | Predicate        | TimeUnit.DAYS
+| 12th test  | "Omega"           | Predicate        | TimeUnit.HOURS
 |===
 
 You can reuse the same argument provider method multiple times.

--- a/src/demo/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/cartesian/CartesianTestExtensionDemo.java
@@ -30,6 +30,7 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
@@ -153,7 +154,9 @@ public class CartesianTestExtensionDemo {
 				.argumentsForFirstParameter(
 						"Alpha", "Omega")
 				.argumentsForNextParameter(
-						Runnable.class, Cloneable.class, Predicate.class)
+						Named.of("Runnable", Runnable.class),
+						Named.of("Cloneable", Cloneable.class),
+						Named.of("Predicate", Predicate.class))
 				.argumentsForNextParameter(
 						TimeUnit.DAYS, TimeUnit.HOURS);
 	}

--- a/src/main/java/org/junitpioneer/internal/TestNameFormatter.java
+++ b/src/main/java/org/junitpioneer/internal/TestNameFormatter.java
@@ -16,6 +16,7 @@ import java.text.MessageFormat;
 import java.util.Arrays;
 import java.util.stream.IntStream;
 
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 
 /**
@@ -81,7 +82,12 @@ public final class TestNameFormatter {
 	private Object[] makeReadable(Object[] arguments) {
 		Object[] result = Arrays.copyOf(arguments, arguments.length, Object[].class);
 		for (int i = 0; i < result.length; i++) {
-			result[i] = PioneerUtils.nullSafeToString(arguments[i]);
+			Object argument = arguments[i];
+			if (argument instanceof Named<?>) {
+				result[i] = ((Named<?>) argument).getName();
+			} else {
+				result[i] = PioneerUtils.nullSafeToString(arguments[i]);
+			}
 		}
 		return result;
 	}

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianProductResolver.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianProductResolver.java
@@ -14,6 +14,7 @@ import static org.junitpioneer.internal.PioneerUtils.wrap;
 
 import java.util.List;
 
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolver;
@@ -38,6 +39,10 @@ class CartesianProductResolver implements ParameterResolver {
 			return false;
 
 		Object parameter = parameters.get(parameterContext.getIndex());
+		// unpack JUnit Named
+		if (parameter instanceof Named<?>) {
+			parameter = ((Named<?>) parameter).getPayload();
+		}
 		Class<?> parameterType = parameterContext.getParameter().getType();
 		// need to go from primitives to wrapper class or `isAssignableFrom` returns false for primitive parameters
 		Class<?> parameterClass = wrap(parameterType);
@@ -52,7 +57,12 @@ class CartesianProductResolver implements ParameterResolver {
 
 	@Override
 	public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext) {
-		return parameters.get(parameterContext.getIndex());
+		Object parameter = parameters.get(parameterContext.getIndex());
+		if (parameter instanceof Named<?>) {
+			return ((Named<?>) parameter).getPayload();
+		}
+
+		return parameter;
 	}
 
 }

--- a/src/test/java/org/junitpioneer/jupiter/cartesian/CartesianTestFactoryTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/cartesian/CartesianTestFactoryTests.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -109,6 +110,21 @@ public class CartesianTestFactoryTests {
 
 			assertThat(results).hasNumberOfSucceededTests(4);
 			assertThat(results).hasNumberOfReportEntries(4).withValues("AC", "AD", "BC", "BD");
+		}
+
+		@Test
+		@DisplayName("unpacks Named arguments")
+		void unpacksNamedParameters() {
+			ExecutionResults results = PioneerTestKit
+					.executeTestMethodWithParameterTypes(CorrectFactoryTestCases.class, "unpacksNamed", Class.class,
+						Class.class);
+
+			assertThat(results).hasNumberOfSucceededTests(4);
+			results
+					.dynamicallyRegisteredEvents()
+					.assertThatEvents()
+					.extracting(event -> event.getTestDescriptor().getDisplayName())
+					.containsExactly("[1] S, I", "[2] S, D", "[3] C, I", "[4] C, D");
 		}
 
 	}
@@ -313,6 +329,11 @@ public class CartesianTestFactoryTests {
 		void worksWithNull(String s1, String s2) {
 		}
 
+		@CartesianTest
+		@CartesianTest.MethodFactory("withNamed")
+		void unpacksNamed(Class<?> charsequence, Class<?> number) {
+		}
+
 		static ArgumentSets parentheses() {
 			return ArgumentSets.argumentsForFirstParameter("A", "B").argumentsForNextParameter("C", "D");
 		}
@@ -323,6 +344,12 @@ public class CartesianTestFactoryTests {
 
 		static ArgumentSets withNull() {
 			return ArgumentSets.argumentsForFirstParameter("A", "B").argumentsForNextParameter((Object) null);
+		}
+
+		static ArgumentSets withNamed() {
+			return ArgumentSets
+					.argumentsForFirstParameter(Named.of("S", String.class), Named.of("C", CharSequence.class))
+					.argumentsForNextParameter(Named.of("I", Integer.class), Named.of("D", Double.class));
 		}
 
 		static class Inner {


### PR DESCRIPTION
This commit adds support for org.junit.jupiter.api.Named for CartesianArgumentsProvider, using the name for the display name of the tests for the text and unpacking the payload.

Closes: #842

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for handling and displaying JUnit Named arguments in Cartesian tests, ensuring named parameters are correctly unwrapped and shown in test results.

* **Bug Fixes**
  * Improved parameter handling in Cartesian tests to work seamlessly with Named argument wrappers.

* **Tests**
  * Introduced new tests to verify correct unpacking and display of Named parameters in Cartesian test factories.

* **Documentation**
  * Updated examples to clarify usage of Named arguments for shorter display names in Cartesian tests.
  * Added contributor acknowledgment for enhancements related to Named support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->