### PR TITLE
Fix JSON extension error (#855 / #861)

### DIFF
--- a/src/main/java/org/junitpioneer/jupiter/json/AbstractJsonArgumentsProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/json/AbstractJsonArgumentsProvider.java
@@ -16,6 +16,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -101,6 +102,7 @@ abstract class AbstractJsonArgumentsProvider<A extends Annotation>
 							.map(value -> value.value(parameter.getParameterizedType()))
 							.orElse(null);
 				})
+				.filter(Objects::nonNull)
 				.toArray();
 		// @formatter:on
 		return Arguments.of(arguments);

--- a/src/test/java/org/junitpioneer/jupiter/json/JsonClasspathSourceArgumentsProviderTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/json/JsonClasspathSourceArgumentsProviderTests.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.platform.commons.PreconditionViolationException;
 import org.junit.platform.engine.TestDescriptor;
@@ -53,9 +54,12 @@ class JsonClasspathSourceArgumentsProviderTests {
 					mapping(TestDescriptor::getDisplayName, toList())));
 
 		assertThat(displayNames)
-				.containsOnlyKeys("singleObject", "singleObjectAttribute", "deconstructObjectsFromArray",
-					"customDataLocation", "deconstructObjectsFromMultipleFiles",
+				.containsOnlyKeys("singleObjectAttributeAndCompetingResolver", "singleObject", "singleObjectAttribute",
+					"deconstructObjectsFromArray", "customDataLocation", "deconstructObjectsFromMultipleFiles",
 					"deconstructObjectsFromMultipleFilesIntoComplexType");
+
+		assertThat(displayNames.get("singleObjectAttributeAndCompetingResolver"))
+				.containsExactly("[1] \"Luke\"", "[2] \"Yoda\"");
 
 		assertThat(displayNames.get("singleObject"))
 				.containsExactly("[1] Jedi {name='Luke', height=172}", "[2] Jedi {name='Yoda', height=66}");
@@ -116,6 +120,13 @@ class JsonClasspathSourceArgumentsProviderTests {
 
 	@Nested
 	class JsonClasspathSourceTests {
+
+		@ParameterizedTest
+		@JsonClasspathSource(JEDIS)
+		void singleObjectAttributeAndCompetingResolver(@Property("name") String name, TestInfo testInfo) {
+			assertThat(testInfo).isNotNull();
+			assertThat(name).isIn("Luke", "Yoda");
+		}
 
 		@ParameterizedTest
 		@JsonClasspathSource(JEDIS)


### PR DESCRIPTION
Proposed commit message:

```
Fix JSON extension error (#855 / #861)

Fix JSON-based extensions being "greedy" and competing
with other ParameterResolver implementations.

Closes: #855
PR: #861
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code (general)
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#assertions) (which are based on AssertJ)

Code (new package)
* [ ] The new package is exported in `module-info.java`
* [ ] The new package is also present in the tests
* [ ] The new package is opened for reflection to JUnit 5 in `module-info.java`
* [ ] The new package is listed in the contribution guide

Contributing
* [ ] A prepared commit message exists
* [ ] The list of contributions inside `README.adoc` mentions the new contribution (real name optional) 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Null values are now filtered from argument extraction in JSON parameter handling.

* **Tests**
  * Added test coverage for competing resolvers with parameter injection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->