### PR TITLE
Fix version in deprecated tag

### DIFF
--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocale.java
@@ -67,7 +67,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *
  * @deprecated The extension was provided to the JUnit framework.
  */
-@Deprecated(forRemoval = true, since = "6.0")
+@Deprecated(forRemoval = true, since = "3.0")
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE })
 @Inherited

--- a/src/main/java/org/junitpioneer/jupiter/DefaultLocaleExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultLocaleExtension.java
@@ -25,7 +25,7 @@ import org.junitpioneer.jupiter.LocaleProvider.NullLocaleProvider;
 /**
  * @deprecated The extension was provided to the JUnit framework.
  */
-@Deprecated(forRemoval = true, since = "6.0")
+@Deprecated(forRemoval = true, since = "3.0")
 class DefaultLocaleExtension implements BeforeEachCallback, AfterEachCallback {
 
 	private static final Namespace NAMESPACE = Namespace.create(DefaultLocaleExtension.class);

--- a/src/main/java/org/junitpioneer/jupiter/DefaultTimeZone.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultTimeZone.java
@@ -49,7 +49,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *
  * @deprecated The extension was provided to the JUnit framework.
  */
-@Deprecated(forRemoval = true, since = "6.0")
+@Deprecated(forRemoval = true, since = "3.0")
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE })
 @Inherited

--- a/src/main/java/org/junitpioneer/jupiter/DefaultTimeZoneExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/DefaultTimeZoneExtension.java
@@ -26,7 +26,7 @@ import org.junitpioneer.jupiter.TimeZoneProvider.NullTimeZoneProvider;
 /*
  * @deprecated The extension was provided to the JUnit framework.
  */
-@Deprecated(forRemoval = true, since = "6.0")
+@Deprecated(forRemoval = true, since = "3.0")
 class DefaultTimeZoneExtension implements BeforeEachCallback, AfterEachCallback {
 
 	private static final Namespace NAMESPACE = Namespace.create(DefaultTimeZoneExtension.class);

--- a/src/main/java/org/junitpioneer/jupiter/LocaleProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/LocaleProvider.java
@@ -16,13 +16,13 @@ import java.util.function.Supplier;
 /**
  * @deprecated The extension was provided to the JUnit framework.
  */
-@Deprecated(forRemoval = true, since = "6.0")
+@Deprecated(forRemoval = true, since = "3.0")
 public interface LocaleProvider extends Supplier<Locale> {
 
 	/*
 	* @deprecated The extension was provided to the JUnit framework.
 	 */
-	@Deprecated(forRemoval = true, since = "6.0")
+	@Deprecated(forRemoval = true, since = "3.0")
 	interface NullLocaleProvider extends LocaleProvider {
 	}
 

--- a/src/main/java/org/junitpioneer/jupiter/ReadsDefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReadsDefaultLocale.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.parallel.Resources;
  *
  * @deprecated The extension was provided to the JUnit framework.
  */
-@Deprecated(forRemoval = true, since = "6.0")
+@Deprecated(forRemoval = true, since = "3.0")
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE, ElementType.TYPE })
 @Inherited

--- a/src/main/java/org/junitpioneer/jupiter/ReadsDefaultTimeZone.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReadsDefaultTimeZone.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.parallel.Resources;
  *
  * @deprecated The extension was provided to the JUnit framework.
  */
-@Deprecated(forRemoval = true, since = "6.0")
+@Deprecated(forRemoval = true, since = "3.0")
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE, ElementType.TYPE })
 @Inherited

--- a/src/main/java/org/junitpioneer/jupiter/TimeZoneProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/TimeZoneProvider.java
@@ -16,7 +16,7 @@ import java.util.function.Supplier;
 /**
  * @deprecated The extension was provided to the JUnit framework.
  */
-@Deprecated(forRemoval = true, since = "6.0")
+@Deprecated(forRemoval = true, since = "3.0")
 public interface TimeZoneProvider extends Supplier<TimeZone> {
 
 	interface NullTimeZoneProvider extends TimeZoneProvider {

--- a/src/main/java/org/junitpioneer/jupiter/WritesDefaultLocale.java
+++ b/src/main/java/org/junitpioneer/jupiter/WritesDefaultLocale.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.parallel.Resources;
  *
  * @deprecated The extension was provided to the JUnit framework.
  */
-@Deprecated(forRemoval = true, since = "6.0")
+@Deprecated(forRemoval = true, since = "3.0")
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE, ElementType.TYPE })
 @Inherited

--- a/src/main/java/org/junitpioneer/jupiter/WritesDefaultTimeZone.java
+++ b/src/main/java/org/junitpioneer/jupiter/WritesDefaultTimeZone.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.parallel.Resources;
  *
  * @deprecated The extension was provided to the JUnit framework.
  */
-@Deprecated(forRemoval = true, since = "6.0")
+@Deprecated(forRemoval = true, since = "3.0")
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE, ElementType.TYPE })
 @Inherited

--- a/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultLocaleTests.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junitpioneer.internal.PioneerUtils;
 import org.junitpioneer.testkit.ExecutionResults;
 
-@Deprecated(forRemoval = true, since = "6.0")
+@Deprecated(forRemoval = true, since = "3.0")
 
 @DisplayName("DefaultLocale extension")
 class DefaultLocaleTests {

--- a/src/test/java/org/junitpioneer/jupiter/DefaultTimeZoneTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DefaultTimeZoneTests.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junitpioneer.testkit.ExecutionResults;
 
-@Deprecated(forRemoval = true, since = "6.0")
+@Deprecated(forRemoval = true, since = "3.0")
 
 @DisplayName("DefaultTimeZone extension")
 class DefaultTimeZoneTests {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deprecation timeline: locale and timezone-related APIs are now marked for removal in version 3.0 instead of version 6.0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->