### PR TITLE
Mark SystemPropertyExtension as Deprecated

### DIFF
--- a/docs/system-properties.adoc
+++ b/docs/system-properties.adoc
@@ -5,6 +5,14 @@
 
 == `@ClearSystemProperty` and `@SetSystemProperty`
 The `@ClearSystemProperty` and `@SetSystemProperty` annotations can be used to clear and set, respectively, the values of system properties for a test execution.
+
+[WARNING]
+====
+These extensions were contributed to the JUnit Framework and are available since JUnit version 6.1.0.
+Therefore, they are marked as deprecated for removal and not maintained in JUnit Pioneer anymore.
+Expect their removal in Pioneer with a future release.
+====
+
 Both annotations work on the test method and class level, are repeatable, combinable, and inherited from higher-level containers.
 After the annotated method has been executed, the properties mentioned in the annotation will be restored to their original value or the value of the higher-level container, or will be cleared if they didn't have one before.
 Other system properties that are changed during the test, are *not* restored (unless the `@RestoreSystemProperties` is used).

--- a/src/main/java/org/junitpioneer/jupiter/ClearSystemProperty.java
+++ b/src/main/java/org/junitpioneer/jupiter/ClearSystemProperty.java
@@ -41,7 +41,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * <a href="https://junit-pioneer.org/docs/system-properties/" target="_top">the documentation on <code>@ClearSystemProperty and @SetSystemProperty</code></a>.</p>
  *
  * @since 0.5
+ *
+ * @deprecated The extension was provided to the JUnit framework.
  */
+@Deprecated(forRemoval = true, since = "3.0")
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE })
 @Inherited

--- a/src/main/java/org/junitpioneer/jupiter/ReadsSystemProperty.java
+++ b/src/main/java/org/junitpioneer/jupiter/ReadsSystemProperty.java
@@ -32,7 +32,10 @@ import org.junit.jupiter.api.parallel.Resources;
  * <a href="https://junit-pioneer.org/docs/system-properties/" target="_top">the documentation on <code>@ClearSystemProperty</code> and <code>@SetSystemProperty</code></a>.</p>
  *
  * @since 0.9
+ *
+ * @deprecated The extension was provided to the JUnit framework.
  */
+@Deprecated(forRemoval = true, since = "3.0")
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE, ElementType.TYPE })
 @Inherited

--- a/src/main/java/org/junitpioneer/jupiter/RestoreSystemProperties.java
+++ b/src/main/java/org/junitpioneer/jupiter/RestoreSystemProperties.java
@@ -61,7 +61,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * all its potential (non-standard) richness.</p>
  *
  * @since 2.0.0
+ *
+ * @deprecated The extension was provided to the JUnit framework.
  */
+@Deprecated(forRemoval = true, since = "3.0")
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE })
 @Inherited

--- a/src/main/java/org/junitpioneer/jupiter/SetSystemProperty.java
+++ b/src/main/java/org/junitpioneer/jupiter/SetSystemProperty.java
@@ -44,7 +44,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * <a href="https://junit-pioneer.org/docs/system-properties/" target="_top">the documentation on <code>@ClearSystemProperty</code> and <code>@SetSystemProperty</code></a>.</p>
  *
  * @since 0.5
+ *
+ * @deprecated The extension was provided to the JUnit framework.
  */
+@Deprecated(forRemoval = true, since = "3.0")
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE })
 @Inherited

--- a/src/main/java/org/junitpioneer/jupiter/SystemPropertyExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/SystemPropertyExtension.java
@@ -13,6 +13,10 @@ package org.junitpioneer.jupiter;
 import java.util.Properties;
 import java.util.function.Function;
 
+/*
+* @deprecated The extension was provided to the JUnit framework.
+*/
+@Deprecated(forRemoval = true, since = "3.0")
 class SystemPropertyExtension extends
 		AbstractEntryBasedExtension<String, String, ClearSystemProperty, SetSystemProperty, RestoreSystemProperties> {
 

--- a/src/main/java/org/junitpioneer/jupiter/WritesSystemProperty.java
+++ b/src/main/java/org/junitpioneer/jupiter/WritesSystemProperty.java
@@ -32,7 +32,10 @@ import org.junit.jupiter.api.parallel.Resources;
  * <a href="https://junit-pioneer.org/docs/system-properties/" target="_top">the documentation on <code>@ClearSystemProperty</code> and <code>@SetSystemProperty</code></a>.</p>
  *
  * @since 0.9
+ *
+ * @deprecated The extension was provided to the JUnit framework.
  */
+@Deprecated(forRemoval = true, since = "3.0")
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.PACKAGE, ElementType.TYPE })
 @Inherited

--- a/src/test/java/org/junitpioneer/jupiter/RestoreSystemPropertiesTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/RestoreSystemPropertiesTests.java
@@ -44,6 +44,7 @@ import org.junit.platform.commons.support.ReflectionSupport;
  * <p>{@link VerifySysPropsExtension} is registered as an extension <em>before</em> {@code RestoreSystemProperties}. It
  * stores the initial system properties and verifies them at the end.
  */
+@Deprecated(forRemoval = true, since = "3.0")
 @DisplayName("RestoreSystemProperties Annotation")
 @ExtendWith(RestoreSystemPropertiesTests.VerifySysPropsExtension.class) // 1st: Order is important here
 @RestoreSystemProperties // 2nd

--- a/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/SystemPropertyExtensionTests.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junitpioneer.testkit.ExecutionResults;
 
+@Deprecated(forRemoval = true, since = "3.0")
 @DisplayName("SystemProperty extension")
 class SystemPropertyExtensionTests {
 


### PR DESCRIPTION
The extension was contributed to JUnit.

closes #856


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deprecation notice for system property extensions, indicating they were contributed to the JUnit Framework since version 6.1.0.

* **Deprecated**
  * Marked system property extensions as deprecated for removal in a future version, including related annotations and classes. Users should migrate to the JUnit Framework equivalents.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->