### PR TITLE
Jitter for RetryingTest

### DIFF
--- a/docs/retrying-test.adoc
+++ b/docs/retrying-test.adoc
@@ -117,14 +117,16 @@ After failure, the test `suspendBetweenRetries` will wait for 100ms before retry
 include::{demo}[tag=jitter]
 ----
 
-Use `maxJitterMs` to specify additional suspending.
+Use `maxJitterMs` to add a random delay (between 0 and the specified value in milliseconds) on top of `suspendForMs` between retries.
+This helps avoid thundering-herd problems when multiple retrying tests access the same external resource simultaneously.
 
 [source,java,indent=0]
 ----
 include::{demo}[tag=jitter_seed]
 ----
 
-Use `jitterSeed` to specify seed for jitter's generator might be specified manually.
+Use `jitterSeed` to make the jitter reproducible by providing a fixed seed for the random number generator.
+This is useful for testing or debugging jitter behavior.
 
 === Configuring on which Exceptions to Retry
 

--- a/docs/retrying-test.adoc
+++ b/docs/retrying-test.adoc
@@ -117,15 +117,14 @@ After failure, the test `suspendBetweenRetries` will wait for 100ms before retry
 include::{demo}[tag=jitter]
 ----
 
-The test `requiresTwoSuccesses` must run at least two times without raising an exception.
-However, it will not run more than four times.
+Use `maxJitterMs` to specify additional suspending.
 
 [source,java,indent=0]
 ----
 include::{demo}[tag=jitter_seed]
 ----
 
-The seed for jitter's generator might be specified manually.
+Use `jitterSeed` to specify seed for jitter's generator might be specified manually.
 
 === Configuring on which Exceptions to Retry
 

--- a/docs/retrying-test.adoc
+++ b/docs/retrying-test.adoc
@@ -125,16 +125,7 @@ However, it will not run more than four times.
 include::{demo}[tag=jitter_seed]
 ----
 
-=== Suspending between each Retry
-
-[source,java,indent=0]
-----
-include::{demo}[tag=suspending_between_each_retry]
-----
-
-Use `suspendForMs` to specify the number of milliseconds to wait between each retry.
-
-After failure, the test `suspendBetweenRetries` will wait for 100ms before retrying.
+The seed for jitter's generator might be specified manually.
 
 === Configuring on which Exceptions to Retry
 

--- a/docs/retrying-test.adoc
+++ b/docs/retrying-test.adoc
@@ -110,6 +110,32 @@ Use `suspendForMs` to specify the number of milliseconds to wait between each re
 
 After failure, the test `suspendBetweenRetries` will wait for 100ms before retrying.
 
+=== Configuring the Jitter
+
+[source,java,indent=0]
+----
+include::{demo}[tag=jitter]
+----
+
+The test `requiresTwoSuccesses` must run at least two times without raising an exception.
+However, it will not run more than four times.
+
+[source,java,indent=0]
+----
+include::{demo}[tag=jitter_seed]
+----
+
+=== Suspending between each Retry
+
+[source,java,indent=0]
+----
+include::{demo}[tag=suspending_between_each_retry]
+----
+
+Use `suspendForMs` to specify the number of milliseconds to wait between each retry.
+
+After failure, the test `suspendBetweenRetries` will wait for 100ms before retrying.
+
 === Configuring on which Exceptions to Retry
 
 Use `onExceptions` to only retry on the mentioned exception(s):

--- a/src/demo/java/org/junitpioneer/jupiter/RetryingTestExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/RetryingTestExtensionDemo.java
@@ -42,6 +42,20 @@ public class RetryingTestExtensionDemo {
 	}
 	// end::retrying_aborted[]
 
+	// tag::jitter[]
+	@RetryingTest(maxAttempts = 3, maxJitterMs = 500)
+	void jitter() {
+        // randomly jitted value is added to sleep interval
+	}
+	// end::jitter[]
+
+	// tag::jitter_seed[]
+	@RetryingTest(maxAttempts = 3, maxJitterMs = 500, jitterSeed = 123)
+	void jitterSeed() {
+        // jitter might be initialized with the seed.
+	}
+	// end::jitter_seed[]
+
 	// tag::retrying_configure_numbers_of_success[]
 	@RetryingTest(maxAttempts = 4, minSuccess = 2)
 	void requiresTwoSuccesses() {

--- a/src/demo/java/org/junitpioneer/jupiter/RetryingTestExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/RetryingTestExtensionDemo.java
@@ -45,14 +45,14 @@ public class RetryingTestExtensionDemo {
 	// tag::jitter[]
 	@RetryingTest(maxAttempts = 3, maxJitterMs = 500)
 	void jitter() {
-        // randomly jitted value is added to sleep interval
+		// randomly jitted value is added to sleep interval
 	}
 	// end::jitter[]
 
 	// tag::jitter_seed[]
 	@RetryingTest(maxAttempts = 3, maxJitterMs = 500, jitterSeed = 123)
 	void jitterSeed() {
-        // jitter might be initialized with the seed.
+		// jitter might be initialized with the seed.
 	}
 	// end::jitter_seed[]
 

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTest.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTest.java
@@ -155,8 +155,8 @@ public @interface RetryingTest {
 	/**
 	 * Specifies the maximum jitter (in milliseconds) added between executions.
 	 *
-+	 * <p>A random value between 0 (inclusive) and this value (exclusive) is added
-+	 * to {@link #suspendForMs()} to calculate the total sleep time between retries.</p>
+	+	 * <p>A random value between 0 (inclusive) and this value (exclusive) is added
+	+	 * to {@link #suspendForMs()} to calculate the total sleep time between retries.</p>
 	 *
 	 * <p>Value must be greater than or equal to 0.</p>
 	 */

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTest.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTest.java
@@ -17,6 +17,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.Random;
+
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
@@ -160,16 +161,16 @@ public @interface RetryingTest {
 	 *
 	 * <p>Value must be greater than or equal to 0.</p>
 	 */
-    int maxJitterMs() default 0;
+	int maxJitterMs() default 0;
 
 	/**
 	 * Specifies a jitter seed. This allows the retries to be reproducible.
 	 *
 	 * <p>This value will be used to create an instance of {@link java.util.Random}</p>
-     *
+	 *
 	 * <p>0 value is default and used as the marker to use seed {@link System#currentTimeMillis()}</p>
 	 */
-    int jitterSeed() default 0;
+	int jitterSeed() default 0;
 
 	/**
 	 * Specifies on which exceptions a failed test is retried.

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTest.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTest.java
@@ -155,8 +155,8 @@ public @interface RetryingTest {
 	/**
 	 * Specifies the maximum jitter (in milliseconds) added between executions.
 	 *
-	+	 * <p>A random value between 0 (inclusive) and this value (exclusive) is added
-	+	 * to {@link #suspendForMs()} to calculate the total sleep time between retries.</p>
+	 * <p>A random value between 0 (inclusive) and this value (exclusive) is added
+	 * to {@link #suspendForMs()} to calculate the total sleep time between retries.</p>
 	 *
 	 * <p>Value must be greater than or equal to 0.</p>
 	 */

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTest.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTest.java
@@ -153,10 +153,10 @@ public @interface RetryingTest {
 	int suspendForMs() default 0;
 
 	/**
-	 * Specifies a jitter (in milliseconds) between executions.
+	 * Specifies the maximum jitter (in milliseconds) added between executions.
 	 *
-	 * <p>This value is being added to the {@link #suspendForMs()} to calculate sleep time</p>
-	 * <p>The addition generates randomly with maximum value equal to the specified one</p>
++	 * <p>A random value between 0 (inclusive) and this value (exclusive) is added
++	 * to {@link #suspendForMs()} to calculate the total sleep time between retries.</p>
 	 *
 	 * <p>Value must be greater than or equal to 0.</p>
 	 */

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTest.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTest.java
@@ -16,7 +16,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
+import java.util.Random;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
@@ -151,6 +151,25 @@ public @interface RetryingTest {
 	 * <p>Value must be greater than or equal to 0.</p>
 	 */
 	int suspendForMs() default 0;
+
+	/**
+	 * Specifies a jitter (in milliseconds) between executions.
+	 *
+	 * <p>This value is being added to the {@link #suspendForMs()} to calculate sleep time</p>
+	 * <p>The addition generates randomly with maximum value equal to the specified one</p>
+	 *
+	 * <p>Value must be greater than or equal to 0.</p>
+	 */
+    int maxJitterMs() default 0;
+
+	/**
+	 * Specifies a jitter seed. This allows the retries to be reproducible.
+	 *
+	 * <p>This value will be used to create an instance of {@link java.util.Random}</p>
+     *
+	 * <p>0 value is default and used as the marker to use seed {@link System#currentTimeMillis()}</p>
+	 */
+    int jitterSeed() default 0;
 
 	/**
 	 * Specifies on which exceptions a failed test is retried.

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTest.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTest.java
@@ -16,7 +16,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.util.Random;
 
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
@@ -14,16 +14,15 @@ import static java.lang.String.format;
 import static java.util.Spliterator.ORDERED;
 import static java.util.Spliterators.spliteratorUnknownSize;
 import static java.util.stream.StreamSupport.stream;
-
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
@@ -77,6 +76,8 @@ class RetryingTestExtension implements TestTemplateInvocationContextProvider, Te
 		private final int maxRetries;
 		private final int minSuccess;
 		private final int suspendForMs;
+        private final Random jitterRandom;
+		private final int maxJitterMs;
 		private final Class<? extends Throwable>[] expectedExceptions;
 		private final List<TestAbortedException> seenExceptions;
 		private final TestNameFormatter formatter;
@@ -86,11 +87,15 @@ class RetryingTestExtension implements TestTemplateInvocationContextProvider, Te
 		private boolean seenFailedAssumption;
 		private boolean seenUnexpectedException;
 
-		private FailedTestRetrier(int maxRetries, int minSuccess, int suspendForMs,
+		private FailedTestRetrier(int maxRetries, int minSuccess, int suspendForMs, int maxJitterMs, int jitterSeed,
 				Class<? extends Throwable>[] expectedExceptions, TestNameFormatter formatter) {
 			this.maxRetries = maxRetries;
 			this.minSuccess = minSuccess;
 			this.suspendForMs = suspendForMs;
+            this.maxJitterMs = maxJitterMs;
+            // TODO: Shouldn't this value be logged so the user could reproduce the tests?
+            // What is the best way to show the seed?
+            this.jitterRandom = new Random(jitterSeed == 0 ? System.currentTimeMillis() : jitterSeed);
 			this.expectedExceptions = expectedExceptions;
 			this.seenExceptions = new ArrayList<>();
 			this.retriesSoFar = 0;
@@ -134,8 +139,12 @@ class RetryingTestExtension implements TestTemplateInvocationContextProvider, Te
 				throw new ExtensionConfigurationException(
 					"@RetryingTest requires that `suspendForMs` be greater than or equal to 0.");
 			}
+            if (retryingTest.maxJitterMs() < 0) {
+				throw new ExtensionConfigurationException(
+					"@RetryingTest requires that `maxJitterMs` be greater than or equal to 0.");
+			}
 
-			return new FailedTestRetrier(maxAttempts, minSuccess, retryingTest.suspendForMs(),
+			return new FailedTestRetrier(maxAttempts, minSuccess, retryingTest.suspendForMs(), retryingTest.maxJitterMs(), retryingTest.jitterSeed(),
 				retryingTest.onExceptions(), formatter);
 		}
 
@@ -158,8 +167,8 @@ class RetryingTestExtension implements TestTemplateInvocationContextProvider, Te
 				// and include the test execution number, to make it easier to correlate the
 				// failure with a specific execution
 				var testAbortedException = new TestAbortedException(
-					format("%s%nTest execution #%d (of up to %d) failed ~> will retry in %d ms...",
-						exception.getMessage(), retriesSoFar, maxRetries, suspendForMs),
+					format("%s%nTest execution #%d (of up to %d) failed ~> will retry in %d ms with max jitter %d ms...",
+						exception.getMessage(), retriesSoFar, maxRetries, suspendForMs, maxJitterMs),
 					exception);
 				seenExceptions.add(testAbortedException);
 				throw testAbortedException;
@@ -222,13 +231,21 @@ class RetryingTestExtension implements TestTemplateInvocationContextProvider, Te
 				throw new NoSuchElementException();
 
 			if (!isFirstExecution()) {
-				suspendFor(suspendForMs);
+				suspendFor(suspendForMs + calcuateJitter());
 			}
 
 			retriesSoFar++;
 
 			return new RetryingTestInvocationContext(formatter);
 		}
+
+        private int calcuateJitter() {
+            int jitter = 0;
+            if (maxJitterMs != 0) {
+                jitter = jitterRandom.nextInt(maxJitterMs);
+            }
+            return jitter;
+        }
 
 	}
 

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
@@ -14,6 +14,7 @@ import static java.lang.String.format;
 import static java.util.Spliterator.ORDERED;
 import static java.util.Spliterators.spliteratorUnknownSize;
 import static java.util.stream.StreamSupport.stream;
+
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -23,6 +24,7 @@ import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
+
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
@@ -76,7 +78,7 @@ class RetryingTestExtension implements TestTemplateInvocationContextProvider, Te
 		private final int maxRetries;
 		private final int minSuccess;
 		private final int suspendForMs;
-        private final Random jitterRandom;
+		private final Random jitterRandom;
 		private final int maxJitterMs;
 		private final Class<? extends Throwable>[] expectedExceptions;
 		private final List<TestAbortedException> seenExceptions;
@@ -92,10 +94,10 @@ class RetryingTestExtension implements TestTemplateInvocationContextProvider, Te
 			this.maxRetries = maxRetries;
 			this.minSuccess = minSuccess;
 			this.suspendForMs = suspendForMs;
-            this.maxJitterMs = maxJitterMs;
-            // TODO: Shouldn't this value be logged so the user could reproduce the tests?
-            // What is the best way to show the seed?
-            this.jitterRandom = new Random(jitterSeed == 0 ? System.currentTimeMillis() : jitterSeed);
+			this.maxJitterMs = maxJitterMs;
+			// TODO: Shouldn't this value be logged so the user could reproduce the tests?
+			// What is the best way to show the seed?
+			this.jitterRandom = new Random(jitterSeed == 0 ? System.currentTimeMillis() : jitterSeed);
 			this.expectedExceptions = expectedExceptions;
 			this.seenExceptions = new ArrayList<>();
 			this.retriesSoFar = 0;
@@ -139,13 +141,13 @@ class RetryingTestExtension implements TestTemplateInvocationContextProvider, Te
 				throw new ExtensionConfigurationException(
 					"@RetryingTest requires that `suspendForMs` be greater than or equal to 0.");
 			}
-            if (retryingTest.maxJitterMs() < 0) {
+			if (retryingTest.maxJitterMs() < 0) {
 				throw new ExtensionConfigurationException(
 					"@RetryingTest requires that `maxJitterMs` be greater than or equal to 0.");
 			}
 
-			return new FailedTestRetrier(maxAttempts, minSuccess, retryingTest.suspendForMs(), retryingTest.maxJitterMs(), retryingTest.jitterSeed(),
-				retryingTest.onExceptions(), formatter);
+			return new FailedTestRetrier(maxAttempts, minSuccess, retryingTest.suspendForMs(),
+				retryingTest.maxJitterMs(), retryingTest.jitterSeed(), retryingTest.onExceptions(), formatter);
 		}
 
 		<E extends Throwable> void failed(E exception) throws E {
@@ -166,10 +168,9 @@ class RetryingTestExtension implements TestTemplateInvocationContextProvider, Te
 				// put the original exception's message first, so tools can parse it correctly
 				// and include the test execution number, to make it easier to correlate the
 				// failure with a specific execution
-				var testAbortedException = new TestAbortedException(
-					format("%s%nTest execution #%d (of up to %d) failed ~> will retry in %d ms with max jitter %d ms...",
-						exception.getMessage(), retriesSoFar, maxRetries, suspendForMs, maxJitterMs),
-					exception);
+				var testAbortedException = new TestAbortedException(format(
+					"%s%nTest execution #%d (of up to %d) failed ~> will retry in %d ms with max jitter %d ms...",
+					exception.getMessage(), retriesSoFar, maxRetries, suspendForMs, maxJitterMs), exception);
 				seenExceptions.add(testAbortedException);
 				throw testAbortedException;
 			} else {
@@ -239,13 +240,13 @@ class RetryingTestExtension implements TestTemplateInvocationContextProvider, Te
 			return new RetryingTestInvocationContext(formatter);
 		}
 
-        private int calcuateJitter() {
-            int jitter = 0;
-            if (maxJitterMs != 0) {
-                jitter = jitterRandom.nextInt(maxJitterMs);
-            }
-            return jitter;
-        }
+		private int calcuateJitter() {
+			int jitter = 0;
+			if (maxJitterMs != 0) {
+				jitter = jitterRandom.nextInt(maxJitterMs);
+			}
+			return jitter;
+		}
 
 	}
 

--- a/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/RetryingTestExtension.java
@@ -232,7 +232,7 @@ class RetryingTestExtension implements TestTemplateInvocationContextProvider, Te
 				throw new NoSuchElementException();
 
 			if (!isFirstExecution()) {
-				suspendFor(suspendForMs + calcuateJitter());
+				suspendFor(suspendForMs + calculateJitter());
 			}
 
 			retriesSoFar++;
@@ -240,7 +240,7 @@ class RetryingTestExtension implements TestTemplateInvocationContextProvider, Te
 			return new RetryingTestInvocationContext(formatter);
 		}
 
-		private int calcuateJitter() {
+		private int calculateJitter() {
 			int jitter = 0;
 			if (maxJitterMs != 0) {
 				jitter = jitterRandom.nextInt(maxJitterMs);

--- a/src/test/java/org/junitpioneer/jupiter/RetryingTestExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/RetryingTestExtensionTests.java
@@ -552,13 +552,13 @@ class RetryingTestExtensionTests {
 			// Do nothing
 		}
 
-		@RetryingTest(maxAttempts = 3, suspendForMs = SUSPEND_FOR)
-		void failThreeTimesWithSuspend() {
+		@RetryingTest(maxAttempts = 3)
+		void failThreeTimesWithoutSuspend() {
 			throw new IllegalArgumentException();
 		}
 
 		@RetryingTest(maxAttempts = 3, suspendForMs = SUSPEND_FOR)
-		void failThreeTimesWithoutSuspend() {
+		void failThreeTimesWithSuspend() {
 			throw new IllegalArgumentException();
 		}
 

--- a/src/test/java/org/junitpioneer/jupiter/RetryingTestExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/RetryingTestExtensionTests.java
@@ -38,7 +38,7 @@ import org.opentest4j.TestAbortedException;
 class RetryingTestExtensionTests {
 
 	private static final int SUSPEND_FOR = 10;
-    private static final int JIT_FOR = 100;
+	private static final int JIT_FOR = 100;
 
 	@Test
 	void invalidConfigurationWithTest() {
@@ -273,7 +273,7 @@ class RetryingTestExtensionTests {
 		assertThat(results).hasNumberOfDynamicallyRegisteredTests(0);
 	}
 
-    @Test
+	@Test
 	void jitterForLessThanZero_fails() {
 		ExecutionResults results = PioneerTestKit
 				.executeTestMethod(RetryingTestTestCases.class, "jitterForLessThanZero");
@@ -304,7 +304,7 @@ class RetryingTestExtensionTests {
 		assertFailedTest(results, 3);
 	}
 
-    @Test
+	@Test
 	void failThreeTimesWithSuspendAndJitter() {
 		ExecutionResults results = PioneerTestKit
 				.executeTestMethod(RetryingTestTestCases.class, "failThreeTimesWithSuspendAndJitter");
@@ -319,7 +319,7 @@ class RetryingTestExtensionTests {
 		assertFailedTest(results, 4);
 	}
 
-    @Test
+	@Test
 	void failThreeTimesWithSuspendAndJitterWithSeed() {
 		ExecutionResults results = PioneerTestKit
 				.executeTestMethod(RetryingTestTestCases.class, "failThreeTimesWithSuspendAndJitterWithSeed");
@@ -391,7 +391,7 @@ class RetryingTestExtensionTests {
 	@TestInstance(PER_CLASS)
 	static class RetryingTestTestCases {
 
-        private int executionCount;
+		private int executionCount;
 
 		@Test
 		@RetryingTest(3)
@@ -571,6 +571,7 @@ class RetryingTestExtensionTests {
 		void failThreeTimesWithSuspendAndJitterWithSeed() {
 			throw new IllegalArgumentException();
 		}
+
 	}
 
 	@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })

--- a/src/test/java/org/junitpioneer/jupiter/RetryingTestExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/RetryingTestExtensionTests.java
@@ -38,6 +38,7 @@ import org.opentest4j.TestAbortedException;
 class RetryingTestExtensionTests {
 
 	private static final int SUSPEND_FOR = 10;
+    private static final int JIT_FOR = 100;
 
 	@Test
 	void invalidConfigurationWithTest() {
@@ -139,7 +140,7 @@ class RetryingTestExtensionTests {
 				.hasNumberOfAbortedTests(2)
 				.hasNumberOfFailedTests(1);
 
-		assertFailedTest(results);
+		assertFailedTest(results, 3);
 	}
 
 	@Test
@@ -193,7 +194,7 @@ class RetryingTestExtensionTests {
 				.hasNumberOfFailedTests(1)
 				.hasNumberOfSucceededTests(1);
 
-		assertFailedTest(results);
+		assertFailedTest(results, 3);
 
 	}
 
@@ -207,7 +208,7 @@ class RetryingTestExtensionTests {
 				.hasNumberOfFailedTests(1)
 				.hasNumberOfSucceededTests(0);
 
-		assertFailedTest(results);
+		assertFailedTest(results, 3);
 	}
 
 	@Test
@@ -272,6 +273,14 @@ class RetryingTestExtensionTests {
 		assertThat(results).hasNumberOfDynamicallyRegisteredTests(0);
 	}
 
+    @Test
+	void jitterForLessThanZero_fails() {
+		ExecutionResults results = PioneerTestKit
+				.executeTestMethod(RetryingTestTestCases.class, "jitterForLessThanZero");
+
+		assertThat(results).hasNumberOfDynamicallyRegisteredTests(0);
+	}
+
 	@Test
 	void suspendForLessThanZero_fails() {
 		ExecutionResults results = PioneerTestKit
@@ -292,7 +301,37 @@ class RetryingTestExtensionTests {
 				.hasNumberOfSucceededTests(0);
 
 		assertSuspendedFor(results, SUSPEND_FOR);
-		assertFailedTest(results);
+		assertFailedTest(results, 3);
+	}
+
+    @Test
+	void failThreeTimesWithSuspendAndJitter() {
+		ExecutionResults results = PioneerTestKit
+				.executeTestMethod(RetryingTestTestCases.class, "failThreeTimesWithSuspendAndJitter");
+
+		assertThat(results)
+				.hasNumberOfDynamicallyRegisteredTests(4)
+				.hasNumberOfAbortedTests(3)
+				.hasNumberOfFailedTests(1)
+				.hasNumberOfSucceededTests(0);
+
+		assertSuspendedFor(results, SUSPEND_FOR);
+		assertFailedTest(results, 4);
+	}
+
+    @Test
+	void failThreeTimesWithSuspendAndJitterWithSeed() {
+		ExecutionResults results = PioneerTestKit
+				.executeTestMethod(RetryingTestTestCases.class, "failThreeTimesWithSuspendAndJitterWithSeed");
+
+		assertThat(results)
+				.hasNumberOfDynamicallyRegisteredTests(5)
+				.hasNumberOfAbortedTests(4)
+				.hasNumberOfFailedTests(1)
+				.hasNumberOfSucceededTests(0);
+
+		assertSuspendedFor(results, SUSPEND_FOR);
+		assertFailedTest(results, 5);
 	}
 
 	@Test
@@ -307,7 +346,7 @@ class RetryingTestExtensionTests {
 				.hasNumberOfSucceededTests(0);
 
 		assertSuspendedFor(results, 0);
-		assertFailedTest(results);
+		assertFailedTest(results, 3);
 	}
 
 	private void assertSuspendedFor(ExecutionResults results, long greaterThanOrEqualTo) {
@@ -330,12 +369,12 @@ class RetryingTestExtensionTests {
 		}
 	}
 
-	private void assertFailedTest(ExecutionResults results) {
+	private void assertFailedTest(ExecutionResults results, int count) {
 		assertThat(results)
 				.hasSingleFailedTest()
 				.withExceptionInstanceOf(MultipleFailuresError.class)
 				.extracting(MultipleFailuresError::getFailures, InstanceOfAssertFactories.list(Throwable.class))
-				.hasSize(3)
+				.hasSize(count)
 				.hasOnlyElementsOfType(TestAbortedException.class)
 				.extracting(Throwable::getCause)
 				.hasOnlyElementsOfType(IllegalArgumentException.class);
@@ -352,7 +391,7 @@ class RetryingTestExtensionTests {
 	@TestInstance(PER_CLASS)
 	static class RetryingTestTestCases {
 
-		private int executionCount;
+        private int executionCount;
 
 		@Test
 		@RetryingTest(3)
@@ -508,16 +547,30 @@ class RetryingTestExtensionTests {
 			// Do nothing
 		}
 
+		@RetryingTest(maxAttempts = 3, maxJitterMs = -1)
+		void jitterForLessThanZero() {
+			// Do nothing
+		}
+
 		@RetryingTest(maxAttempts = 3, suspendForMs = SUSPEND_FOR)
 		void failThreeTimesWithSuspend() {
 			throw new IllegalArgumentException();
 		}
 
-		@RetryingTest(maxAttempts = 3)
+		@RetryingTest(maxAttempts = 3, suspendForMs = SUSPEND_FOR)
 		void failThreeTimesWithoutSuspend() {
 			throw new IllegalArgumentException();
 		}
 
+		@RetryingTest(maxAttempts = 4, suspendForMs = SUSPEND_FOR, maxJitterMs = JIT_FOR)
+		void failThreeTimesWithSuspendAndJitter() {
+			throw new IllegalArgumentException();
+		}
+
+		@RetryingTest(maxAttempts = 5, suspendForMs = SUSPEND_FOR, maxJitterMs = JIT_FOR, jitterSeed = 666)
+		void failThreeTimesWithSuspendAndJitterWithSeed() {
+			throw new IllegalArgumentException();
+		}
 	}
 
 	@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })


### PR DESCRIPTION
Proposed commit message:

```
Add (#783) maxJitterMs and jitterSeed attributes to @RetryingTest

Implement random jitter calculation in RetryingTestExtension, 
validate non‑negative jitter values, update retry messages to 
include jitter information, and extend tests to cover jitter 
behavior and related edge cases.
```

I'm concerned about the test coverage. The logic around randomness is easy, but hard to test. I didn't find any existing code to rely on. I'd be glad to write more tests if you think they are required and have idea on the good way to do so in the project.

Closes: https://github.com/junit-pioneer/junit-pioneer/issues/783

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [x] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [-] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [x] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [x] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [-] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [-] The `package-info.java` contains information about the new extension

Code (general)
* [x] Code adheres to code style, naming conventions etc.
* [-] Successful tests cover all changes **(?)**
* [x] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#assertions) (which are based on AssertJ)

Code (new package)
* [-] The new package is exported in `module-info.java`
* [-] The new package is also present in the tests
* [-] The new package is opened for reflection to JUnit 5 in `module-info.java`
* [-] The new package is listed in the contribution guide

Contributing
* [x] A prepared commit message exists
* [x] The list of contributions inside `README.adoc` mentions the new contribution (real name optional) 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added jitter to retry behavior with configurable maximum jitter and optional seed for reproducible delays.

* **Documentation**
  * Added "Configuring the Jitter" section with runnable demos showing jitter and seeded-jitter usage.

* **Tests**
  * Expanded tests and assertions covering jitter, seeded jitter, suspension timing, and retry scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->