### PR TITLE
Use Jackson 3

### DIFF
--- a/.infra/checkstyle/import-control.xml
+++ b/.infra/checkstyle/import-control.xml
@@ -4,15 +4,15 @@
 <import-control pkg="org.junitpioneer">
 
 	<allow pkg=".*" regex="true" />
-	<disallow pkg="com.fasterxml.jackson.*" regex="true"/>
+	<disallow pkg="tools.jackson.*" regex="true"/>
 	<disallow pkg="org.junit.jupiter.api.Assertions.*" regex="true"/>
 
 	<subpackage name="jupiter.json">
 		<file name="JacksonNode.java">
-			<allow pkg="com.fasterxml.jackson.*" regex="true" />
+			<allow pkg="tools.jackson.*" regex="true" />
 		</file>
 		<file name="JacksonJsonConverter.java">
-			<allow pkg="com.fasterxml.jackson.*" regex="true" />
+			<allow pkg="tools.jackson.*" regex="true" />
 		</file>
 	</subpackage>
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,7 +50,7 @@ repositories {
 }
 
 val junitVersion : String by project
-val jacksonVersion: String = "2.18.0"
+val jacksonVersion: String = "3.1.2"
 val assertjVersion: String = "3.27.7"
 val jimfsVersion: String = "1.3.0"
 
@@ -60,7 +60,7 @@ dependencies {
 	implementation(group = "org.junit.jupiter", name = "junit-jupiter-api")
 	implementation(group = "org.junit.jupiter", name = "junit-jupiter-params")
 	implementation(group = "org.junit.platform", name = "junit-platform-launcher")
-	"jacksonImplementation"(group = "com.fasterxml.jackson.core", name = "jackson-databind", version = jacksonVersion)
+	"jacksonImplementation"(group = "tools.jackson.core", name = "jackson-databind", version = jacksonVersion)
 
 	testImplementation(group = "org.junit.jupiter", name = "junit-jupiter-engine")
 	testImplementation(group = "org.junit.platform", name = "junit-platform-testkit")
@@ -266,7 +266,7 @@ tasks {
 				dependencies {
 					implementation(project(project.path))
 					implementation("com.google.jimfs:jimfs:$jimfsVersion")
-					implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
+					implementation("tools.jackson.core:jackson-databind:$jacksonVersion")
 					implementation("org.assertj:assertj-core:$assertjVersion")
 				}
 

--- a/docs/json-argument-source.adoc
+++ b/docs/json-argument-source.adoc
@@ -159,7 +159,7 @@ At the same time, it's not parsing JSON itself and relies on third-party librari
 For this extension that means that projects who want to use it need to pull in a JSON parser themselves.
 This is the list of supported parsers:
 
-* https://search.maven.org/artifact/com.fasterxml.jackson.core/jackson-databind[Jackson]
+* https://search.maven.org/artifact/tools.jackson.core/jackson-databind[Jackson]
 
 If you need support for another parser, please https://github.com/junit-pioneer/junit-pioneer/issues/new/choose[open an issue].
 If your project does not already depend on a supported JSON parser, you can add it as follows.
@@ -182,7 +182,7 @@ Alternatively, the dependency can be added directly:
 
 [source,kotlin]
 ----
-testImplementation("com.fasterxml.jackson.core:jackson-databind:$CURRENT_VERSION")
+testImplementation("tools.jackson.core:jackson-databind:$CURRENT_VERSION")
 ----
 
 === Maven
@@ -192,7 +192,7 @@ In Maven, add the parser as a test dependency:
 [source,xml]
 ----
 <dependency>
-    <groupId>com.fasterxml.jackson.core</groupId>
+    <groupId>tools.jackson.core</groupId>
     <artifactId>jackson-databind</artifactId>
     <version>$CURRENT_VERSION</version>
     <scope>test</scope>
@@ -253,7 +253,7 @@ If your test code runs as a module, the JSON parser must make it into the module
 That means (1) it must be on the module path and (2) it must be resolved.
 
 The steps above ensure that your build tool knows about the parser and should accomplish (1), but if no other module depends on the parser (directly or indirectly), (2) requires additional work.
-In that case, you need to manually resolve the module by applying the command line option `--add-modules=com.fasterxml.jackson.databind` to the Java process that executes the tests.
+In that case, you need to manually resolve the module by applying the command line option `--add-modules=tools.jackson.databind` to the Java process that executes the tests.
 
 == Thread-Safety
 

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -15,8 +15,8 @@ module org.junitpioneer {
 	requires org.junit.jupiter.params;
 	requires org.junit.platform.launcher;
 
-	requires static com.fasterxml.jackson.core;
-	requires static com.fasterxml.jackson.databind;
+	requires static tools.jackson.core;
+	requires static tools.jackson.databind;
 
 	exports org.junitpioneer.vintage;
 	exports org.junitpioneer.jupiter;
@@ -32,7 +32,7 @@ module org.junitpioneer {
 	opens org.junitpioneer.jupiter.issue to org.junit.platform.commons;
 	opens org.junitpioneer.jupiter.params to org.junit.platform.commons;
 	opens org.junitpioneer.jupiter.resource to org.junit.platform.commons;
-	opens org.junitpioneer.jupiter.json to org.junit.platform.commons, com.fasterxml.jackson.databind;
+	opens org.junitpioneer.jupiter.json to org.junit.platform.commons, tools.jackson.databind;
 	opens org.junitpioneer.jupiter.converter to org.junit.platform.commons;
 	opens org.junitpioneer.jupiter.displaynamegenerator to org.junit.platform.commons;
 

--- a/src/main/java/org/junitpioneer/jupiter/json/DefaultObjectMapperProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/json/DefaultObjectMapperProvider.java
@@ -10,7 +10,7 @@
 
 package org.junitpioneer.jupiter.json;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 public class DefaultObjectMapperProvider implements ObjectMapperProvider {
 

--- a/src/main/java/org/junitpioneer/jupiter/json/JacksonJsonConverter.java
+++ b/src/main/java/org/junitpioneer/jupiter/json/JacksonJsonConverter.java
@@ -17,6 +17,7 @@ import java.io.InputStream;
 import java.util.Map;
 import java.util.ServiceLoader;
 
+import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junitpioneer.internal.PioneerPreconditions;
 
 import tools.jackson.databind.JsonNode;
@@ -49,14 +50,22 @@ class JacksonJsonConverter implements JsonConverter {
 
 	@Override
 	public Node toNode(InputStream stream) {
-		JsonNode jsonNode = objectMapper.readTree(stream);
-		return new JacksonNode(objectMapper, jsonNode);
+		try {
+			JsonNode jsonNode = objectMapper.readTree(stream);
+			return new JacksonNode(objectMapper, jsonNode);
+		} catch (Exception e) {
+			throw new ParameterResolutionException("Could not convert JSON to Node.", e);
+		}
 	}
 
 	@Override
 	public Node toNode(String value, boolean lenient) {
-		JsonNode jsonNode = getObjectMapper(lenient).readTree(value);
-		return new JacksonNode(getObjectMapper(false), jsonNode);
+		try {
+			JsonNode jsonNode = getObjectMapper(lenient).readTree(value);
+			return new JacksonNode(getObjectMapper(false), jsonNode);
+		} catch (Exception e) {
+			throw new ParameterResolutionException("Could not convert JSON to Node.", e);
+		}
 	}
 
 	private ObjectMapper getObjectMapper(boolean lenient) {

--- a/src/main/java/org/junitpioneer/jupiter/json/JacksonJsonConverter.java
+++ b/src/main/java/org/junitpioneer/jupiter/json/JacksonJsonConverter.java
@@ -53,7 +53,8 @@ class JacksonJsonConverter implements JsonConverter {
 		try {
 			JsonNode jsonNode = objectMapper.readTree(stream);
 			return new JacksonNode(objectMapper, jsonNode);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			throw new ParameterResolutionException("Could not convert JSON to Node.", e);
 		}
 	}
@@ -63,7 +64,8 @@ class JacksonJsonConverter implements JsonConverter {
 		try {
 			JsonNode jsonNode = getObjectMapper(lenient).readTree(value);
 			return new JacksonNode(getObjectMapper(false), jsonNode);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			throw new ParameterResolutionException("Could not convert JSON to Node.", e);
 		}
 	}

--- a/src/main/java/org/junitpioneer/jupiter/json/JacksonJsonConverter.java
+++ b/src/main/java/org/junitpioneer/jupiter/json/JacksonJsonConverter.java
@@ -13,16 +13,14 @@ package org.junitpioneer.jupiter.json;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 
-import java.io.IOException;
 import java.io.InputStream;
-import java.io.UncheckedIOException;
 import java.util.Map;
 import java.util.ServiceLoader;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import org.junitpioneer.internal.PioneerPreconditions;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * A {@link JsonConverter} using Jackson 2 {@link ObjectMapper} to perform the conversion
@@ -51,24 +49,14 @@ class JacksonJsonConverter implements JsonConverter {
 
 	@Override
 	public Node toNode(InputStream stream) {
-		try {
-			JsonNode jsonNode = objectMapper.readTree(stream);
-			return new JacksonNode(objectMapper, jsonNode);
-		}
-		catch (IOException e) {
-			throw new UncheckedIOException("Failed to read stream", e);
-		}
+		JsonNode jsonNode = objectMapper.readTree(stream);
+		return new JacksonNode(objectMapper, jsonNode);
 	}
 
 	@Override
 	public Node toNode(String value, boolean lenient) {
-		try {
-			JsonNode jsonNode = getObjectMapper(lenient).readTree(value);
-			return new JacksonNode(getObjectMapper(false), jsonNode);
-		}
-		catch (IOException e) {
-			throw new UncheckedIOException("Failed to read value", e);
-		}
+		JsonNode jsonNode = getObjectMapper(lenient).readTree(value);
+		return new JacksonNode(getObjectMapper(false), jsonNode);
 	}
 
 	private ObjectMapper getObjectMapper(boolean lenient) {

--- a/src/main/java/org/junitpioneer/jupiter/json/JacksonJsonConverter.java
+++ b/src/main/java/org/junitpioneer/jupiter/json/JacksonJsonConverter.java
@@ -23,7 +23,7 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
 /**
- * A {@link JsonConverter} using Jackson 2 {@link ObjectMapper} to perform the conversion
+ * A {@link JsonConverter} using Jackson 3 {@link ObjectMapper} to perform the conversion
  */
 class JacksonJsonConverter implements JsonConverter {
 

--- a/src/main/java/org/junitpioneer/jupiter/json/JacksonNode.java
+++ b/src/main/java/org/junitpioneer/jupiter/json/JacksonNode.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import org.junit.jupiter.api.extension.ParameterResolutionException;
+
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -46,7 +47,8 @@ class JacksonNode implements Node {
 	public <T> T toType(Type type) {
 		try {
 			return objectMapper.treeToValue(node, objectMapper.constructType(type));
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			throw new ParameterResolutionException("Could not resolve type " + type, e);
 		}
 	}

--- a/src/main/java/org/junitpioneer/jupiter/json/JacksonNode.java
+++ b/src/main/java/org/junitpioneer/jupiter/json/JacksonNode.java
@@ -19,7 +19,7 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
 /**
- * A {@link Node} implementation for Jackson 2.
+ * A {@link Node} implementation for Jackson 3.
  */
 class JacksonNode implements Node {
 

--- a/src/main/java/org/junitpioneer/jupiter/json/JacksonNode.java
+++ b/src/main/java/org/junitpioneer/jupiter/json/JacksonNode.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import org.junit.jupiter.api.extension.ParameterResolutionException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
 
@@ -43,7 +44,11 @@ class JacksonNode implements Node {
 
 	@Override
 	public <T> T toType(Type type) {
-		return objectMapper.treeToValue(node, objectMapper.constructType(type));
+		try {
+			return objectMapper.treeToValue(node, objectMapper.constructType(type));
+		} catch (Exception e) {
+			throw new ParameterResolutionException("Could not resolve type " + type, e);
+		}
 	}
 
 	@Override

--- a/src/main/java/org/junitpioneer/jupiter/json/JacksonNode.java
+++ b/src/main/java/org/junitpioneer/jupiter/json/JacksonNode.java
@@ -10,15 +10,13 @@
 
 package org.junitpioneer.jupiter.json;
 
-import java.io.UncheckedIOException;
 import java.lang.reflect.Type;
 import java.util.Optional;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * A {@link Node} implementation for Jackson 2.
@@ -45,12 +43,7 @@ class JacksonNode implements Node {
 
 	@Override
 	public <T> T toType(Type type) {
-		try {
-			return objectMapper.treeToValue(node, objectMapper.constructType(type));
-		}
-		catch (JsonProcessingException e) {
-			throw new UncheckedIOException("Failed to convert to type " + type, e);
-		}
+		return objectMapper.treeToValue(node, objectMapper.constructType(type));
 	}
 
 	@Override
@@ -64,8 +57,8 @@ class JacksonNode implements Node {
 
 	@Override
 	public Object value(Type typeHint) {
-		if (node.isTextual()) {
-			return node.textValue();
+		if (node.isString()) {
+			return node.stringValue();
 		} else if (node.isInt()) {
 			return node.intValue();
 		} else if (node.isLong()) {

--- a/src/main/java/org/junitpioneer/jupiter/json/JsonClasspathSourceArgumentsProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/json/JsonClasspathSourceArgumentsProvider.java
@@ -10,8 +10,6 @@
 
 package org.junitpioneer.jupiter.json;
 
-import static java.util.stream.Collectors.toUnmodifiableList;
-
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.stream.Stream;
@@ -31,7 +29,7 @@ class JsonClasspathSourceArgumentsProvider extends AbstractJsonSourceBasedArgume
 				.stream(jsonSource.value())
 				.map(JsonClasspathSourceArgumentsProvider::classpathResource);
 
-		accept(resources.collect(toUnmodifiableList()), jsonSource.data());
+		accept(resources.toList(), jsonSource.data());
 	}
 
 	private static Source classpathResource(String resource) {

--- a/src/main/java/org/junitpioneer/jupiter/json/JsonConverterProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/json/JsonConverterProvider.java
@@ -16,7 +16,7 @@ class JsonConverterProvider {
 
 	static boolean isJacksonObjectMapperClassPresent() {
 		try {
-			JsonConverterProvider.class.getClassLoader().loadClass("com.fasterxml.jackson.databind.ObjectMapper");
+			JsonConverterProvider.class.getClassLoader().loadClass("tools.jackson.databind.ObjectMapper");
 			return true;
 		}
 		catch (Exception e) {

--- a/src/main/java/org/junitpioneer/jupiter/json/ObjectMapperProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/json/ObjectMapperProvider.java
@@ -10,16 +10,14 @@
 
 package org.junitpioneer.jupiter.json;
 
-import com.fasterxml.jackson.core.JsonFactory;
-import com.fasterxml.jackson.core.json.JsonReadFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.core.json.JsonReadFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
- * Service interface for providing a custom {@link com.fasterxml.jackson.databind.ObjectMapper} instance at runtime.
+ * Service interface for providing a custom {@link tools.jackson.databind.ObjectMapper} instance at runtime.
  * The default implementation doesn't register any additional Jackson modules.
- *
- * @see com.fasterxml.jackson.databind.Module
  */
 public interface ObjectMapperProvider {
 
@@ -30,20 +28,20 @@ public interface ObjectMapperProvider {
 		if (mapper instanceof JsonMapper) {
 			return ((JsonMapper) mapper)
 					.rebuild()
-					.enable(JsonReadFeature.ALLOW_UNQUOTED_FIELD_NAMES)
+					.enable(JsonReadFeature.ALLOW_UNQUOTED_PROPERTY_NAMES)
 					.enable(JsonReadFeature.ALLOW_JAVA_COMMENTS)
 					.enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
 					.enable(JsonReadFeature.ALLOW_TRAILING_COMMA)
 					.build();
 		}
-		return get()
-				.copyWith(JsonFactory
-						.builder()
-						.enable(JsonReadFeature.ALLOW_UNQUOTED_FIELD_NAMES)
-						.enable(JsonReadFeature.ALLOW_JAVA_COMMENTS)
-						.enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
-						.enable(JsonReadFeature.ALLOW_TRAILING_COMMA)
-						.build());
+		var factory = ((JsonFactory) mapper.tokenStreamFactory())
+				.rebuild()
+				.enable(JsonReadFeature.ALLOW_UNQUOTED_PROPERTY_NAMES)
+				.enable(JsonReadFeature.ALLOW_JAVA_COMMENTS)
+				.enable(JsonReadFeature.ALLOW_SINGLE_QUOTES)
+				.enable(JsonReadFeature.ALLOW_TRAILING_COMMA)
+				.build();
+		return JsonMapper.builder(factory).addModules(mapper.registeredModules()).build();
 	}
 
 	String id();

--- a/src/test/java/module-info.java
+++ b/src/test/java/module-info.java
@@ -15,8 +15,8 @@ module org.junitpioneer {
 	requires org.junit.jupiter.params;
 	requires org.junit.platform.launcher;
 
-	requires static com.fasterxml.jackson.core;
-	requires static com.fasterxml.jackson.databind;
+	requires static tools.jackson.core;
+	requires static tools.jackson.databind;
 
 	exports org.junitpioneer.vintage;
 	exports org.junitpioneer.jupiter;
@@ -32,7 +32,7 @@ module org.junitpioneer {
 	opens org.junitpioneer.jupiter.issue to org.junit.platform.commons;
 	opens org.junitpioneer.jupiter.params to org.junit.platform.commons;
 	opens org.junitpioneer.jupiter.resource to org.junit.platform.commons;
-	opens org.junitpioneer.jupiter.json to org.junit.platform.commons, com.fasterxml.jackson.databind;
+	opens org.junitpioneer.jupiter.json to org.junit.platform.commons, tools.jackson.databind;
 	opens org.junitpioneer.jupiter.converter to org.junit.platform.commons;
 	opens org.junitpioneer.jupiter.displaynamegenerator to org.junit.platform.commons;
 

--- a/src/test/java/org/junitpioneer/jupiter/json/ArrayNodeToListTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/json/ArrayNodeToListTests.java
@@ -12,7 +12,6 @@ package org.junitpioneer.jupiter.json;
 
 import static org.junitpioneer.testkit.assertion.PioneerAssert.assertThat;
 
-import java.io.UncheckedIOException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Predicate;
@@ -89,10 +88,7 @@ public class ArrayNodeToListTests {
 				.executeTestMethodWithParameterTypes(ArrayNodeToListTests.BadConfigurationTestCase.class,
 					"conversionException", List.class);
 
-		assertThat(results)
-				.hasSingleFailedContainer()
-				.withExceptionInstanceOf(UncheckedIOException.class)
-				.hasMessageContaining("Failed to convert to type");
+		assertThat(results).hasSingleFailedContainer();
 	}
 
 	@ParameterizedTest

--- a/src/test/java/org/junitpioneer/jupiter/json/ArrayNodeToListTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/json/ArrayNodeToListTests.java
@@ -89,7 +89,8 @@ public class ArrayNodeToListTests {
 				.executeTestMethodWithParameterTypes(ArrayNodeToListTests.BadConfigurationTestCase.class,
 					"conversionException", List.class);
 
-		assertThat(results).hasSingleFailedContainer()
+		assertThat(results)
+				.hasSingleFailedContainer()
 				.withExceptionInstanceOf(ParameterResolutionException.class)
 				.hasMessageContaining("Could not resolve type");
 	}

--- a/src/test/java/org/junitpioneer/jupiter/json/ArrayNodeToListTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/json/ArrayNodeToListTests.java
@@ -19,6 +19,7 @@ import java.util.function.Predicate;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junitpioneer.jupiter.ReportEntry;
 import org.junitpioneer.testkit.ExecutionResults;
@@ -82,13 +83,15 @@ public class ArrayNodeToListTests {
 	}
 
 	@Test
-	@DisplayName("throws a ParameterResolutionException if it can not convert complex objects")
+	@DisplayName("throws a ParameterResolutionException if it can not convert to datatype")
 	void throwsForMalformedComplexObjects() {
 		ExecutionResults results = PioneerTestKit
 				.executeTestMethodWithParameterTypes(ArrayNodeToListTests.BadConfigurationTestCase.class,
 					"conversionException", List.class);
 
-		assertThat(results).hasSingleFailedContainer();
+		assertThat(results).hasSingleFailedContainer()
+				.withExceptionInstanceOf(ParameterResolutionException.class)
+				.hasMessageContaining("Could not resolve type");
 	}
 
 	@ParameterizedTest

--- a/src/test/java/org/junitpioneer/jupiter/json/ObjectMapperProviderTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/json/ObjectMapperProviderTests.java
@@ -16,9 +16,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
@@ -27,6 +24,9 @@ import org.junit.platform.commons.PreconditionViolationException;
 import org.junitpioneer.testkit.ExecutionResults;
 import org.junitpioneer.testkit.PioneerTestKit;
 import org.junitpioneer.testkit.assertion.PioneerAssert;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 @DisplayName("ObjectMapperProvider interface")
 public class ObjectMapperProviderTests {


### PR DESCRIPTION
Proposed commit message:

```
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code (general)
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#assertions) (which are based on AssertJ)

Code (new package)
* [ ] The new package is exported in `module-info.java`
* [ ] The new package is also present in the tests
* [ ] The new package is opened for reflection to JUnit 5 in `module-info.java`
* [ ] The new package is listed in the contribution guide

Contributing
* [ ] A prepared commit message exists
* [ ] The list of contributions inside `README.adoc` mentions the new contribution (real name optional) 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced lenient JSON parsing to support unquoted property names, Java comments, single quotes, and trailing commas.
  * Added support for lenient parsing with standard object mappers while preserving their configuration.

* **Bug Fixes**
  * Improved JSON conversion error handling with clearer parameter-resolution failures.

* **Chores**
  * Updated Jackson integration to use Jackson 3.1.2 artifacts.

* **Documentation**
  * Updated JSON argument source documentation to reflect the current Jackson dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->