### PR TITLE
feat: Allow using Source based values in Environment variables.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -119,6 +119,10 @@ Thank you for your efforts! ?
 
 The least we can do is to thank them and list some of their accomplishments here (in lexicographic order).
 
+==== 2026
+
+* https://github.com/nielsbasjes[Niels Basjes] added support for setting Environment variables and System properties from any JUnit `Source` using `@SetEnvironmentVariableFromSource` and `@SetSystemPropertyFromSource` (#381/#872).
+
 ==== 2025
 
 * https://github.com/schosin[Ken Schosinsky] added support for `Named` to `@CartesianTestExtension` (#842 / #848)

--- a/docs/environment-variables.adoc
+++ b/docs/environment-variables.adoc
@@ -9,6 +9,9 @@ Both annotations work on the test method and class level, are repeatable, combin
 After the annotated method has been executed, the variables mentioned in the annotation will be restored to their original value or the value of the higher-level container, or will be cleared if they didn't have one before.
 Other environment variables that are changed during the test, are *not* restored (unless the `@RestoreEnvironmentVariables` is used).
 
+[NOTE]
+Check the `@SetEnvironmentVariableFromSource` if a dynamically determined value is needed.
+
 [WARNING]
 ====
 Java considers environment variables to be immutable, which is why this extension uses reflection to change them.
@@ -52,10 +55,29 @@ Method-level configurations are visible in both `@BeforeEach` setup methods and 
 Since v1.7.0, a class-level configuration means that the specified environment variables are cleared/set before and reset after each individual test in the annotated class.
 ====
 
+== `@SetEnvironmentVariableFromSource`
+The `@SetEnvironmentVariableFromSource` does the same thing as the `@SetEnvironmentVariable` annotation with the only difference being that the actual value is being provided by a JUnit `Source`.
+
+This enables running the same test with a set of possible values for the environment variable and also allows putting a dynamically determined value into the environment variable. This can, for example, be done by writing a method which provides the value and using the `@MethodSource` annotation, or by setting a value in a `@BeforeAll` and using the `@FieldSource`.
+
+To use this:
+
+1. The test must be annotated with `@ParameterizedTest` and some kind of `Source` must be provided.
+2. For each environment variable you need to be set from the `Source` a method parameter must be created. In all of those cases the passed argument and the value of the environment variable should be the same and you can test for that.
+3. Use `@SetEnvironmentVariableFromSource` to specify the name of the environment variable that needs to be set and the index of the argument that contains the value to be used. This uses the same index that you would use when setting the name of a test.
+
+[source,java,indent=0]
+----
+include::{demo}[tag=environment_method_from_source_test]
+----
+
 == `@RestoreEnvironmentVariables`
 `@RestoreEnvironmentVariables` can be used to restore changes to environment variables made directly in code.
-While `@ClearEnvironmentVariable` and `@SetEnvironmentVariable` set or clear specific variables and values, they don't allow values to be calculated or parameterized, thus there are times you may want to directly set them in your test code.
-`@RestoreEnvironmentVariables` can be placed on test methods or test classes and will completely restore all environment variables to their original state after a test or test class is complete.
+
+[NOTE]
+In general changing environment variables in your code is discouraged because this can be achieved with `@SetEnvironmentVariableFromSource` in a simpler and more reliable way.
+
+In the exceptional cases where you still need to set or clear specific variables and values in your test code the use of `@RestoreEnvironmentVariables` is recommended. `@RestoreEnvironmentVariables` can be placed on test methods or test classes and will completely restore all environment variables to their original state after a test or test class is complete.
 
 In this example, `@RestoreEnvironmentVariables` is used on a test method, ensuring any changes made in that method are restored:
 
@@ -89,15 +111,22 @@ Some other test class, running later:
 include::{demo}[tag=environment_class_restore_isolated_class]
 ----
 
-== Using `@ClearEnvironmentVariable`, `@SetEnvironmentVariable`, and `@RestoreEnvironmentVariables` together
-All three annotations can be combined, which could be used when some environment values are parameterized (i.e. need to be set in code) and others are not.
+== Using `@ClearEnvironmentVariable`, `@SetEnvironmentVariable`, `@SetEnvironmentVariableFromSource`, and `@RestoreEnvironmentVariables` together
+All four annotations can be combined, which could be used when some environment values are parameterized (possibly need to be set in code) and others are not.
 For instance, imagine testing an image generation utility that takes configuration from environment variables.
 Basic configuration can be specified using `Set` and `Clear` and the image size parameterized:
 
 [source,java,indent=0]
 ----
+include::{demo}[tag=environment_method_combine_all_test_source]
+----
+
+If you really need to set the variables from your code it can look like this:
+[source,java,indent=0]
+----
 include::{demo}[tag=environment_method_combine_all_test]
 ----
+
 
 [NOTE]
 ====

--- a/src/demo/java/org/junitpioneer/jupiter/EnvironmentVariablesExtensionDemo.java
+++ b/src/demo/java/org/junitpioneer/jupiter/EnvironmentVariablesExtensionDemo.java
@@ -83,6 +83,18 @@ public class EnvironmentVariablesExtensionDemo {
 	}
 	// end::environment_method_restore_test[]
 
+	// tag::environment_method_from_source_test[]
+	@ParameterizedTest(name = "Setting MyEnvVariable to {0}")
+	@ValueSource(strings = { "foo", "bar" })
+	@SetEnvironmentVariableFromSource(key = "MyEnvVariable", argument = 0)
+	@SetEnvironmentVariable(key = "MyOtherEnvVariable", value = "Something")
+	@RestoreEnvironmentVariables
+	void parameterizedFromSourceTest(String value) {
+		assertThat(System.getenv("MyEnvVariable")).isEqualTo(value);
+		assertThat(System.getenv("MyOtherEnvVariable")).isEqualTo("Something");
+	}
+	// end::environment_method_from_source_test[]
+
 	@Nested
 	@TestClassOrder(ClassOrderer.OrderAnnotation.class)
 	class EnvironmentVariableRestoreExample {
@@ -154,6 +166,19 @@ public class EnvironmentVariablesExtensionDemo {
 		// Test your image generation utility with the current environment variables
 	}
 	// end::environment_method_combine_all_test[]
+
+	// tag::environment_method_combine_all_test_source[]
+	@ParameterizedTest(name = "Testing Image Size = {0}")
+	@IntRangeSource(from = 0, to = 10000, step = 500)
+	@SetEnvironmentVariable(key = "DISABLE_CACHE", value = "TRUE")
+	@SetEnvironmentVariableFromSource(key = "IMAGE_SIZE", argument = 0)
+	@ClearEnvironmentVariable(key = "COPYWRITE_OVERLAY_TEXT")
+	void imageGenerationTestFromSource(int imageSize) {
+		assertThat(System.getenv("IMAGE_SIZE")).isEqualTo(String.valueOf(imageSize));
+
+		// Test your image generation utility with the current environment variables
+	}
+	// end::environment_method_combine_all_test_source[]
 
 	public static void setEnvVar(String name, String value) {
 		EnvironmentVariableUtils.set(name, value);

--- a/src/main/java/org/junitpioneer/jupiter/AbstractEntryBasedExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/AbstractEntryBasedExtension.java
@@ -15,6 +15,7 @@ import static java.util.stream.Collectors.toMap;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Collection;
@@ -23,11 +24,13 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -36,6 +39,8 @@ import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
 import org.junit.platform.commons.support.AnnotationSupport;
 import org.junitpioneer.internal.PioneerAnnotationUtils;
 import org.junitpioneer.internal.PioneerUtils;
@@ -48,10 +53,11 @@ import org.junitpioneer.internal.PioneerUtils;
  * @param <V> The entry value type.
  * @param <C> The clear annotation type.
  * @param <S> The set annotation type.
+ * @param <SS> The set annotation type that retrieves the value from the source.
  * @param <R> The restore annotation type.
  */
-abstract class AbstractEntryBasedExtension<K, V, C extends Annotation, S extends Annotation, R extends Annotation>
-		implements BeforeEachCallback, AfterEachCallback, BeforeAllCallback, AfterAllCallback {
+abstract class AbstractEntryBasedExtension<K, V, C extends Annotation, S extends Annotation, SS extends Annotation, R extends Annotation>
+		implements BeforeEachCallback, AfterEachCallback, BeforeAllCallback, AfterAllCallback, InvocationInterceptor {
 
 	/**
 	 * Key to indicate storage is for an incremental backup object.
@@ -62,6 +68,11 @@ abstract class AbstractEntryBasedExtension<K, V, C extends Annotation, S extends
 	 * Key to indicate storage is for a complete backup object.
 	 */
 	private static final String COMPLETE_KEY = "full";
+
+	/**
+	 * The key in the Store used to persist the "From Source" information.
+	 */
+	private static final String SOURCE_BASED_VALUES_KEY = "FromSourceIndexes";
 
 	@Override
 	public void beforeAll(ExtensionContext context) {
@@ -96,28 +107,37 @@ abstract class AbstractEntryBasedExtension<K, V, C extends Annotation, S extends
 		currentContext.getElement().ifPresent(element -> {
 			Set<K> entriesToClear;
 			Map<K, V> entriesToSet;
-
+			Map<K, Integer> entriesToSetFromSource;
+			Set<K> allKeysToSet;
 			try {
 				entriesToClear = findEntriesToClear(element);
 				entriesToSet = findEntriesToSet(element);
-				preventClearAndSetSameEntries(entriesToClear, entriesToSet.keySet());
+				entriesToSetFromSource = findEntriesToSetFromSource(element);
+				allKeysToSet = new HashSet<>(entriesToSet.keySet());
+				allKeysToSet.addAll(entriesToSetFromSource.keySet());
+				preventClearAndSetSameEntries(entriesToClear, allKeysToSet);
 			}
 			catch (IllegalStateException ex) {
 				throw new ExtensionConfigurationException("Don't clear/set the same entry more than once.", ex);
 			}
 
-			if (entriesToClear.isEmpty() && entriesToSet.isEmpty())
+			if (entriesToClear.isEmpty() && entriesToSet.isEmpty() && entriesToSetFromSource.isEmpty()) {
 				return;
+			}
 
 			reportWarning(currentContext);
 
 			// Only backup original values if we didn't already do bulk storage of the original state
 			if (doIncrementalBackup) {
-				storeOriginalIncrementalEntries(originalContext, entriesToClear, entriesToSet.keySet());
+				storeOriginalIncrementalEntries(originalContext, entriesToClear, allKeysToSet);
 			}
 
 			clearEntries(entriesToClear);
 			setEntries(entriesToSet);
+
+			// Store the entries that need to be set from the source in a place that they can be actually set
+			// during the interceptTestTemplateMethod
+			getStore(currentContext).put(SOURCE_BASED_VALUES_KEY, entriesToSetFromSource);
 		});
 	}
 
@@ -129,6 +149,48 @@ abstract class AbstractEntryBasedExtension<K, V, C extends Annotation, S extends
 
 	private Map<K, V> findEntriesToSet(AnnotatedElement element) {
 		return findAnnotations(element, getSetAnnotationType()).collect(toMap(setKeyMapper(), setValueMapper()));
+	}
+
+	private Map<K, Integer> findEntriesToSetFromSource(AnnotatedElement element) {
+		return findAnnotations(element, getSetFromSourceAnnotationType())
+				.collect(toMap(setFromSourceKeyMapper(), setFromSourceArgumentIndexMapper()));
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void interceptTestTemplateMethod(@NonNull Invocation<Void> invocation,
+			@NonNull ReflectiveInvocationContext<Method> invocationContext, @NonNull ExtensionContext extensionContext)
+			throws Throwable {
+		Map<K, Integer> entriesToSetFromSource = (Map<K, Integer>) getStore(extensionContext)
+				.get(SOURCE_BASED_VALUES_KEY);
+		if (entriesToSetFromSource != null && !entriesToSetFromSource.isEmpty()) {
+			Map<K, V> entriesToSet = new HashMap<>();
+			List<Object> arguments = invocationContext.getArguments();
+			for (Entry<K, Integer> entryToSetFromSource : entriesToSetFromSource.entrySet()) {
+				K key = entryToSetFromSource.getKey();
+				Integer argumentIndex = entryToSetFromSource.getValue();
+
+				if (argumentIndex < 0) {
+					throw new IllegalArgumentException(
+						"The specified index " + argumentIndex + " is illegal (must be 0 or larger).");
+				}
+				if (argumentIndex >= arguments.size()) {
+					throw new IllegalArgumentException("The specified index " + argumentIndex + " for " + key
+							+ " is greater than the maximum arguments index (" + (arguments.size() - 1)
+							+ ") for the current test method.");
+				}
+				Object argumentValue = arguments.get(argumentIndex);
+				if (argumentValue == null) {
+					throw new IllegalArgumentException("The specified index " + argumentIndex + " for " + key
+							+ " resolves to null; null values are not supported.");
+				}
+				V value = castArgumentToValueType().apply(argumentValue);
+				entriesToSet.put(key, value);
+			}
+			setEntries(entriesToSet);
+		}
+
+		invocation.proceed();
 	}
 
 	private <A extends Annotation> Stream<A> findAnnotations(AnnotatedElement element, Class<A> clazz) {
@@ -146,8 +208,13 @@ abstract class AbstractEntryBasedExtension<K, V, C extends Annotation, S extends
 	}
 
 	@SuppressWarnings("unchecked")
+	private Class<SS> getSetFromSourceAnnotationType() {
+		return (Class<SS>) getActualTypeArgumentAt(4);
+	}
+
+	@SuppressWarnings("unchecked")
 	private Class<R> getRestoreAnnotationType() {
-		return (Class<R>) getActualTypeArgumentAt(4);
+		return (Class<R>) getActualTypeArgumentAt(5);
 	}
 
 	private Type getActualTypeArgumentAt(int index) {
@@ -281,6 +348,21 @@ abstract class AbstractEntryBasedExtension<K, V, C extends Annotation, S extends
 	 * @return Mapper function to get the value from a set annotation.
 	 */
 	protected abstract Function<S, V> setValueMapper();
+
+	/**
+	 * @return Mapper function to get the key from a set annotation that uses a Source.
+	 */
+	protected abstract Function<SS, K> setFromSourceKeyMapper();
+
+	/**
+	 * @return Mapper function to get the index of the argument of the argument that contains the value from a set annotation that uses a Source.
+	 */
+	protected abstract Function<SS, Integer> setFromSourceArgumentIndexMapper();
+
+	/**
+	 * @return Cast/Convert the provided Object to the required Value type V.
+	 */
+	protected abstract Function<Object, V> castArgumentToValueType();
 
 	/**
 	 * Removes the entry indicated by the specified key.

--- a/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/EnvironmentVariableExtension.java
@@ -22,7 +22,7 @@ import java.util.function.Function;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 class EnvironmentVariableExtension extends
-		AbstractEntryBasedExtension<String, String, ClearEnvironmentVariable, SetEnvironmentVariable, RestoreEnvironmentVariables> {
+		AbstractEntryBasedExtension<String, String, ClearEnvironmentVariable, SetEnvironmentVariable, SetEnvironmentVariableFromSource, RestoreEnvironmentVariables> {
 
 	// package visible to make accessible for tests
 	static final AtomicBoolean REPORTED_WARNING = new AtomicBoolean(false);
@@ -44,6 +44,21 @@ class EnvironmentVariableExtension extends
 	@Override
 	protected Function<SetEnvironmentVariable, String> setValueMapper() {
 		return SetEnvironmentVariable::value;
+	}
+
+	@Override
+	protected Function<SetEnvironmentVariableFromSource, String> setFromSourceKeyMapper() {
+		return SetEnvironmentVariableFromSource::key;
+	}
+
+	@Override
+	protected Function<SetEnvironmentVariableFromSource, Integer> setFromSourceArgumentIndexMapper() {
+		return SetEnvironmentVariableFromSource::argument;
+	}
+
+	@Override
+	protected Function<Object, String> castArgumentToValueType() {
+		return Object::toString;
 	}
 
 	@Override

--- a/src/main/java/org/junitpioneer/jupiter/SetEnvironmentVariableFromSource.java
+++ b/src/main/java/org/junitpioneer/jupiter/SetEnvironmentVariableFromSource.java
@@ -20,18 +20,14 @@ import java.lang.annotation.Target;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
- * {@code @SetEnvironmentVariable} is a JUnit Jupiter extension to set the value of
- * an environment variable for a test execution.
+ * {@code @SetEnvironmentVariableFromSource} is a JUnit Jupiter extension to set the value of
+ * an environment variable for a test execution based on the provided Source.
  *
- * <p>The key and value of the environment variable to be set must be specified via
- * {@link #key()} and {@link #value()}. After the annotated method has been executed,
+ * <p>The key and argument index of the environment variable to be set must be specified via
+ * {@link #key()} and {@link #argument()}. After the annotated method has been executed,
  * the original value or the value of the higher-level container is restored.</p>
  *
- * <p>{@code SetEnvironmentVariable} can be used on the method and on the class level.
- * It is repeatable and inherited from higher-level containers. If a class is
- * annotated, the configured property will be set before every test inside that
- * class. Any method-level configurations will override the class-level
- * configurations.</p>
+ * <p>{@code SetEnvironmentVariableFromSource} is repeatable and can be used on the method level only.</p>
  *
  * <p>WARNING: Java considers environment variables to be immutable, so this extension
  * uses reflection to change them. This requires that the {@link SecurityManager}
@@ -43,21 +39,21 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *
  * <p>During
  * <a href="https://junit.org/junit5/docs/current/user-guide/#writing-tests-parallel-execution" target="_top">parallel test execution</a>,
- * all tests annotated with {@link ClearEnvironmentVariable}, {@link SetEnvironmentVariable}, {@link ReadsEnvironmentVariable}, and {@link WritesEnvironmentVariable}
+ * all tests annotated with {@link ClearEnvironmentVariable}, {@link SetEnvironmentVariable}, {@link SetEnvironmentVariableFromSource}, {@link ReadsEnvironmentVariable}, and {@link WritesEnvironmentVariable}
  * are scheduled in a way that guarantees correctness under mutation of shared global state.</p>
  *
  * <p>For more details and examples, see
  * <a href="https://junit-pioneer.org/docs/environment-variables/" target="_top">the documentation on <code>@ClearEnvironmentVariable</code> and <code>@SetEnvironmentVariable</code></a>.</p>
  *
- * @since 0.6
+ * @since 2.4.0
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.METHOD, ElementType.TYPE })
+@Target(ElementType.METHOD)
 @Inherited
-@Repeatable(SetEnvironmentVariable.SetEnvironmentVariables.class)
+@Repeatable(SetEnvironmentVariableFromSource.SetEnvironmentVariablesFromSource.class)
 @WritesEnvironmentVariable
 @ExtendWith(EnvironmentVariableExtension.class)
-public @interface SetEnvironmentVariable {
+public @interface SetEnvironmentVariableFromSource {
 
 	/**
 	 * The key of the environment variable to be set.
@@ -65,21 +61,24 @@ public @interface SetEnvironmentVariable {
 	String key();
 
 	/**
-	 * The value of the environment variable to be set.
+	 * The argument index number of the {@code @ParameterizedTest} from which the value must be retrieved.
+	 * The first argument has index 0, the second argument index 1, etc.
+	 * Note that the default '.toString()' will be used to obtain the actual value put in the environment
+	 * variable.
 	 */
-	String value();
+	int argument();
 
 	/**
-	 * Containing annotation of repeatable {@code @SetEnvironmentVariable}.
+	 * Containing annotation of repeatable {@code @SetEnvironmentVariableFromSource}.
 	 */
 	@Retention(RetentionPolicy.RUNTIME)
-	@Target({ ElementType.METHOD, ElementType.TYPE })
+	@Target(ElementType.METHOD)
 	@Inherited
 	@WritesEnvironmentVariable
 	@ExtendWith(EnvironmentVariableExtension.class)
-	@interface SetEnvironmentVariables {
+	@interface SetEnvironmentVariablesFromSource {
 
-		SetEnvironmentVariable[] value();
+		SetEnvironmentVariableFromSource[] value();
 
 	}
 

--- a/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
@@ -17,6 +17,7 @@ import static org.junitpioneer.jupiter.EnvironmentVariableExtension.WARNING_KEY;
 import static org.junitpioneer.jupiter.EnvironmentVariableExtension.WARNING_VALUE;
 import static org.junitpioneer.testkit.PioneerTestKit.executeTestClass;
 import static org.junitpioneer.testkit.PioneerTestKit.executeTestMethod;
+import static org.junitpioneer.testkit.PioneerTestKit.executeTestMethodWithParameterTypes;
 import static org.junitpioneer.testkit.assertion.PioneerAssert.assertThat;
 
 import java.lang.annotation.ElementType;
@@ -27,6 +28,7 @@ import java.lang.annotation.Target;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Stream;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
@@ -46,6 +48,10 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junitpioneer.testkit.ExecutionResults;
 
 @DisplayName("EnvironmentVariable extension")
@@ -140,6 +146,73 @@ class EnvironmentVariableExtensionTests {
 
 			assertThat(systemEnvironmentVariable("clear envvar D")).isEqualTo("new D");
 			assertThat(systemEnvironmentVariable("clear envvar E")).isNull();
+			assertThat(systemEnvironmentVariable("clear envvar F")).isNull();
+		}
+
+	}
+
+	@Nested
+	@DisplayName("used with SetEnvironmentVariableFromSource")
+	class SetEnvironmentVariableFromSourceTests {
+
+		@ParameterizedTest
+		@DisplayName("should set environment variable to value {0}")
+		@ValueSource(strings = { "new A fromSource" })
+		@SetEnvironmentVariableFromSource(key = "set envvar A", argument = 0)
+		@SetEnvironmentVariable(key = "set envvar B", value = "new B")
+		@RestoreEnvironmentVariables // Needed because of https://github.com/junit-pioneer/junit-pioneer/issues/875
+		void shouldSetEnvironmentVariableToValueFromSource(String setEnvvarA) {
+			assertThat(setEnvvarA).isEqualTo("new A fromSource");
+
+			assertThat(systemEnvironmentVariable("set envvar A")).isEqualTo("new A fromSource");
+			assertThat(systemEnvironmentVariable("set envvar B")).isEqualTo("new B");
+			assertThat(systemEnvironmentVariable("set envvar C")).isEqualTo("old C");
+
+			assertThat(systemEnvironmentVariable("clear envvar D")).isNull();
+			assertThat(systemEnvironmentVariable("clear envvar E")).isNull();
+			assertThat(systemEnvironmentVariable("clear envvar F")).isNull();
+		}
+
+		private static Stream<Arguments> shouldBeRepeatable() {
+			return Stream.of(Arguments.of("new A fromSource", "new D fromSource"));
+		}
+
+		@ParameterizedTest
+		@DisplayName("should be repeatable")
+		@MethodSource("shouldBeRepeatable")
+		@SetEnvironmentVariableFromSource(key = "set envvar A", argument = 0)
+		@SetEnvironmentVariable(key = "set envvar B", value = "new B")
+		@SetEnvironmentVariable(key = "set envvar C", value = "new C")
+		@SetEnvironmentVariableFromSource(key = "clear envvar D", argument = 1)
+		@RestoreEnvironmentVariables // Needed because of https://github.com/junit-pioneer/junit-pioneer/issues/875
+		void shouldBeRepeatable(String setEnvvarA, String clearEnvvarD) {
+			assertThat(setEnvvarA).isEqualTo("new A fromSource");
+			assertThat(clearEnvvarD).isEqualTo("new D fromSource");
+
+			assertThat(systemEnvironmentVariable("set envvar A")).isEqualTo("new A fromSource");
+			assertThat(systemEnvironmentVariable("set envvar B")).isEqualTo("new B");
+			assertThat(systemEnvironmentVariable("set envvar C")).isEqualTo("new C");
+
+			assertThat(systemEnvironmentVariable("clear envvar D")).isEqualTo("new D fromSource");
+			assertThat(systemEnvironmentVariable("clear envvar E")).isNull();
+			assertThat(systemEnvironmentVariable("clear envvar F")).isNull();
+		}
+
+		@ParameterizedTest
+		@DisplayName("should be combinable")
+		@ValueSource(strings = { "new E fromSource" })
+		@ClearEnvironmentVariable(key = "set envvar B")
+		@SetEnvironmentVariableFromSource(key = "clear envvar E", argument = 0)
+		@RestoreEnvironmentVariables // Needed because of https://github.com/junit-pioneer/junit-pioneer/issues/875
+		void clearAndSetEnvironmentVariableShouldBeCombinable(String fromSource0) {
+			assertThat(fromSource0).isEqualTo("new E fromSource");
+
+			assertThat(systemEnvironmentVariable("set envvar A")).isEqualTo("old A");
+			assertThat(systemEnvironmentVariable("set envvar B")).isNull();
+			assertThat(systemEnvironmentVariable("set envvar C")).isEqualTo("old C");
+
+			assertThat(systemEnvironmentVariable("clear envvar D")).isNull();
+			assertThat(systemEnvironmentVariable("clear envvar E")).isEqualTo("new E fromSource");
 			assertThat(systemEnvironmentVariable("clear envvar F")).isNull();
 		}
 
@@ -567,6 +640,36 @@ class EnvironmentVariableExtensionTests {
 			assertThat(results).hasSingleFailedTest().withExceptionInstanceOf(ExtensionConfigurationException.class);
 		}
 
+		@Test
+		@DisplayName("should fail when SetEnvironmentVariableFromSource argument is negative")
+		@RestoreEnvironmentVariables // Needed because of https://github.com/junit-pioneer/junit-pioneer/issues/875
+		void shouldFailWhenSetEnvironmentVariableFromSourceArgumentIsNegative() {
+			ExecutionResults results = executeTestMethodWithParameterTypes(
+				MethodLevelInitializationFailureTestCases.class,
+				"shouldFailWhenSetEnvironmentVariableFromSourceArgumentIsNegative", String.class);
+			assertThat(results).hasSingleFailedTest().withExceptionInstanceOf(IllegalArgumentException.class);
+		}
+
+		@Test
+		@DisplayName("should fail when SetEnvironmentVariableFromSource argument is too large")
+		@RestoreEnvironmentVariables // Needed because of https://github.com/junit-pioneer/junit-pioneer/issues/875
+		void shouldFailWhenSetEnvironmentVariableFromSourceArgumentIsTooLarge() {
+			ExecutionResults results = executeTestMethodWithParameterTypes(
+				MethodLevelInitializationFailureTestCases.class,
+				"shouldFailWhenSetEnvironmentVariableFromSourceArgumentIsTooLarge", String.class);
+			assertThat(results).hasSingleFailedTest().withExceptionInstanceOf(IllegalArgumentException.class);
+		}
+
+		@Test
+		@DisplayName("should fail when SetEnvironmentVariableFromSource value is NULL")
+		@RestoreEnvironmentVariables // Needed because of https://github.com/junit-pioneer/junit-pioneer/issues/875
+		void shouldFailWhenSetEnvironmentVariableFromSourceValueIsNull() {
+			ExecutionResults results = executeTestMethodWithParameterTypes(
+				MethodLevelInitializationFailureTestCases.class,
+				"shouldFailWhenSetEnvironmentVariableFromSourceValueIsNull", String.class);
+			assertThat(results).hasSingleFailedTest().withExceptionInstanceOf(IllegalArgumentException.class);
+		}
+
 	}
 
 	@Nested
@@ -648,6 +751,31 @@ class EnvironmentVariableExtensionTests {
 		@SetEnvironmentVariable(key = "set envvar A", value = "new A")
 		@SetEnvironmentVariable(key = "set envvar A", value = "new B")
 		void shouldFailWhenSetSameEnvironmentVariableTwice() {
+		}
+
+		@ParameterizedTest
+		@ValueSource(strings = "dummy")
+		@SetEnvironmentVariableFromSource(key = "set envvar A", argument = -1)
+		@RestoreEnvironmentVariables // Needed because of https://github.com/junit-pioneer/junit-pioneer/issues/875
+		void shouldFailWhenSetEnvironmentVariableFromSourceArgumentIsNegative(String dummy) {
+		}
+
+		@ParameterizedTest
+		@ValueSource(strings = "dummy")
+		@SetEnvironmentVariableFromSource(key = "set envvar A", argument = 1)
+		@RestoreEnvironmentVariables // Needed because of https://github.com/junit-pioneer/junit-pioneer/issues/875
+		void shouldFailWhenSetEnvironmentVariableFromSourceArgumentIsTooLarge(String dummy) {
+		}
+
+		private static Stream<String> nullStringSource() {
+			return Stream.of((String) null);
+		}
+
+		@ParameterizedTest
+		@MethodSource("nullStringSource")
+		@SetEnvironmentVariableFromSource(key = "set envvar A", argument = 0)
+		@RestoreEnvironmentVariables // Needed because of https://github.com/junit-pioneer/junit-pioneer/issues/875
+		void shouldFailWhenSetEnvironmentVariableFromSourceValueIsNull(String dummy) {
 		}
 
 	}


### PR DESCRIPTION
Proposed commit message:

```
Set Environment variables from a Junit Source (#381 / #872)

Adds new annotation `@SetEnvironmentVariableFromSource` take the 
actual value from the provided Junit Source. 
This enables setting them dynamically just before the test.

Issue: #381 
PR: #872
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [x] There is documentation (Javadoc and site documentation; added or updated)
* [x] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [x] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [x] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [x] Only one sentence per line (especially in `.adoc` files)
* [x] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code (general)
* [x] Code adheres to code style, naming conventions etc.
* [x] Successful tests cover all changes
* [x] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [x] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#assertions) (which are based on AssertJ)

Code (new package)
* [ ] The new package is exported in `module-info.java`
* [ ] The new package is also present in the tests
* [ ] The new package is opened for reflection to JUnit 5 in `module-info.java`
* [ ] The new package is listed in the contribution guide

Contributing
* [x] A prepared commit message exists
* [x] The list of contributions inside `README.adoc` mentions the new contribution (real name optional) 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `@SetEnvironmentVariableFromSource` annotation, enabling environment variables to be set dynamically from parameterized test source values.

* **Documentation**
  * Added comprehensive documentation and examples demonstrating usage patterns for the new annotation with various test configurations.
  * Updated contributor information in README.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/junit-pioneer/junit-pioneer/pull/872?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->