### PR TITLE
test(#875): Reproduce Environment variables not restored after ParameterizedTest

### DIFF
--- a/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/EnvironmentVariableExtensionTests.java
@@ -46,6 +46,8 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junitpioneer.testkit.ExecutionResults;
 
 @DisplayName("EnvironmentVariable extension")
@@ -64,13 +66,23 @@ class EnvironmentVariableExtensionTests {
 
 	@AfterAll
 	static void globalTearDown() {
+		// First check if all environment variables have been restored to their original values
+		assertThat(systemEnvironmentVariable("set envvar A")).isEqualTo("old A");
+		assertThat(systemEnvironmentVariable("set envvar B")).isEqualTo("old B");
+		assertThat(systemEnvironmentVariable("set envvar C")).isEqualTo("old C");
+		assertThat(systemEnvironmentVariable("clear envvar D")).isNull();
+		assertThat(systemEnvironmentVariable("clear envvar E")).isNull();
+		assertThat(systemEnvironmentVariable("clear envvar F")).isNull();
+
+		// Cleanup
 		EnvironmentVariableUtils.clear("set envvar A");
 		EnvironmentVariableUtils.clear("set envvar B");
 		EnvironmentVariableUtils.clear("set envvar C");
 
-		assertThat(systemEnvironmentVariable("clear envvar D")).isNull();
-		assertThat(systemEnvironmentVariable("clear envvar E")).isNull();
-		assertThat(systemEnvironmentVariable("clear envvar F")).isNull();
+		assertThat(systemEnvironmentVariable("set envvar A")).isNull();
+		assertThat(systemEnvironmentVariable("set envvar B")).isNull();
+		assertThat(systemEnvironmentVariable("set envvar C")).isNull();
+
 	}
 
 	private static String systemEnvironmentVariable(String variable) {
@@ -765,6 +777,92 @@ class EnvironmentVariableExtensionTests {
 	@SetEnvironmentVariable(key = "clear envvar E", value = "new E")
 	@RestoreEnvironmentVariables
 	static class InheritanceClearSetRestoreBaseTest {
+	}
+
+	@Nested
+	@Issue("875")
+	@DisplayName("environment is restored after ParameterizedTest")
+	class RestoreAfterParameterizedTest {
+
+		// This reproduces the environment variables not being reset when set as part of a ParameterizedTest.
+		// These test all set only their 'own' environment variable and check ALL environment variables.
+		// This will show in the test output which of the variables was not reset and thus give a clear
+		// indication which test actually did not work correctly.
+		// So the effect is that the BAD test does not fail, all the tests that are run AFTER this BAD test will fail.
+		// How many depends on the (random) order the tests are executed in. In any case the finish check will fail.
+
+		private static final String ENV_NORMAL_TEST = "Normal Test ENV Variable";
+		private static final String ENV_PARAM_TEST = "ParameterizedTest ENV Variable";
+		private static final String ENV_PARAM_WITH_RESTORE_TEST = "ParameterizedTest With Restore ENV Variable";
+		private static final String ENV_ORIG_VALUE = "Original Value";
+		private static final String ENV_CHANGED_VALUE = "Changed Value";
+
+		private static void check(String envName, String envValue) {
+			if (envValue == null) {
+				assertThat(systemEnvironmentVariable(envName))
+						.as("Environment variable \"" + envName + "\" should be NULL.")
+						.isNull();
+			} else {
+				assertThat(systemEnvironmentVariable(envName))
+						.as("Environment variable \"" + envName + "\" should be \"" + envValue + "\".")
+						.isEqualTo(envValue);
+			}
+		}
+
+		@BeforeAll
+		public static void setup() {
+			EnvironmentVariableUtils.set(ENV_NORMAL_TEST, ENV_ORIG_VALUE);
+			EnvironmentVariableUtils.set(ENV_PARAM_TEST, ENV_ORIG_VALUE);
+			EnvironmentVariableUtils.set(ENV_PARAM_WITH_RESTORE_TEST, ENV_ORIG_VALUE);
+			check(ENV_NORMAL_TEST, ENV_ORIG_VALUE);
+			check(ENV_PARAM_TEST, ENV_ORIG_VALUE);
+			check(ENV_PARAM_WITH_RESTORE_TEST, ENV_ORIG_VALUE);
+		}
+
+		@AfterAll
+		public static void finish() {
+			check(ENV_NORMAL_TEST, ENV_ORIG_VALUE);
+			check(ENV_PARAM_TEST, ENV_ORIG_VALUE);
+			check(ENV_PARAM_WITH_RESTORE_TEST, ENV_ORIG_VALUE);
+
+			EnvironmentVariableUtils.clear(ENV_NORMAL_TEST);
+			EnvironmentVariableUtils.clear(ENV_PARAM_TEST);
+			EnvironmentVariableUtils.clear(ENV_PARAM_WITH_RESTORE_TEST);
+
+			check(ENV_NORMAL_TEST, null);
+			check(ENV_PARAM_TEST, null);
+			check(ENV_PARAM_WITH_RESTORE_TEST, null);
+		}
+
+		@Test
+		@SetEnvironmentVariable(key = ENV_NORMAL_TEST, value = ENV_CHANGED_VALUE)
+		void testNormal() {
+			check(ENV_NORMAL_TEST, ENV_CHANGED_VALUE);
+			check(ENV_PARAM_TEST, ENV_ORIG_VALUE);
+			check(ENV_PARAM_WITH_RESTORE_TEST, ENV_ORIG_VALUE);
+		}
+
+		@ParameterizedTest(name = "ParameterizedTest WITHOUT RestoreEnvironmentVariables ({0})")
+		@ValueSource(ints = { 1 })
+		@SetEnvironmentVariable(key = ENV_PARAM_TEST, value = ENV_CHANGED_VALUE)
+		void testParamWithoutRestore(int dummy) {
+			assertThat(dummy).isEqualTo(1);
+			check(ENV_NORMAL_TEST, ENV_ORIG_VALUE);
+			check(ENV_PARAM_TEST, ENV_CHANGED_VALUE);
+			check(ENV_PARAM_WITH_RESTORE_TEST, ENV_ORIG_VALUE);
+		}
+
+		@ParameterizedTest(name = "ParameterizedTest WITH RestoreEnvironmentVariables ({0})")
+		@ValueSource(ints = { 1 })
+		@SetEnvironmentVariable(key = ENV_PARAM_WITH_RESTORE_TEST, value = ENV_CHANGED_VALUE)
+		@RestoreEnvironmentVariables
+		void testParamWithRestore(int dummy) {
+			assertThat(dummy).isEqualTo(1);
+			check(ENV_NORMAL_TEST, ENV_ORIG_VALUE);
+			check(ENV_PARAM_TEST, ENV_ORIG_VALUE);
+			check(ENV_PARAM_WITH_RESTORE_TEST, ENV_CHANGED_VALUE);
+		}
+
 	}
 
 }


### PR DESCRIPTION
# This is just a few tests to reproduce #875 
## Because this does not yet fix the issue this currently will always fail the build.

Proposed commit message:

```
${action} (${issues} / ${pull-request}) [max 70 characters]

${body} [max 70 characters per line]

${references}: ${issues}
PR: ${pull-request}
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code (general)
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#assertions) (which are based on AssertJ)

Code (new package)
* [ ] The new package is exported in `module-info.java`
* [ ] The new package is also present in the tests
* [ ] The new package is opened for reflection to JUnit 5 in `module-info.java`
* [ ] The new package is listed in the contribution guide

Contributing
* [ ] A prepared commit message exists
* [ ] The list of contributions inside `README.adoc` mentions the new contribution (real name optional) 
