### PR TITLE
Fix deprecated Jackson feature registration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,8 @@ val releaseBuild : Boolean = project.version != "unspecified"
 
 val targetJavaVersion = JavaVersion.VERSION_17
 
+val jacksonSourceSet = sourceSets.create("jackson")
+
 java {
 	if (experimentalBuild) {
 		toolchain {
@@ -41,7 +43,18 @@ java {
 	withJavadocJar()
 	withSourcesJar()
 	registerFeature("jackson") {
-		usingSourceSet(sourceSets["main"])
+		usingSourceSet(jacksonSourceSet)
+	}
+}
+
+configurations {
+	named("jacksonApiElements") {
+		outgoing.artifacts.clear()
+		outgoing.artifact(tasks.named("jar"))
+	}
+	named("jacksonRuntimeElements") {
+		outgoing.artifacts.clear()
+		outgoing.artifact(tasks.named("jar"))
 	}
 }
 
@@ -60,10 +73,12 @@ dependencies {
 	implementation(group = "org.junit.jupiter", name = "junit-jupiter-api")
 	implementation(group = "org.junit.jupiter", name = "junit-jupiter-params")
 	implementation(group = "org.junit.platform", name = "junit-platform-launcher")
+	compileOnly(group = "com.fasterxml.jackson.core", name = "jackson-databind", version = jacksonVersion)
 	"jacksonImplementation"(group = "com.fasterxml.jackson.core", name = "jackson-databind", version = jacksonVersion)
 
 	testImplementation(group = "org.junit.jupiter", name = "junit-jupiter-engine")
 	testImplementation(group = "org.junit.platform", name = "junit-platform-testkit")
+	testImplementation(group = "com.fasterxml.jackson.core", name = "jackson-databind", version = jacksonVersion)
 
 	testImplementation(group = "org.assertj", name = "assertj-core", version = assertjVersion)
 	testImplementation(group = "org.mockito", name = "mockito-core", version = "5.23.0")


### PR DESCRIPTION

Closes #825.

This PR addresses the Gradle deprecation warning caused by
registering the "jackson" feature using the main source set.

Before this change, the jackson feature used sourceSets["main"].
Gradle reports that this behavior is deprecated and incompatible
with Gradle 9.

This change creates a separate jackson source set and uses it for
the jackson feature registration. The jacksonApiElements and
jacksonRuntimeElements variants are kept aligned with the previous
behavior by publishing the main junit-pioneer.jar artifact.

Validation performed locally:

- .\gradlew.bat build --warning-mode all --console=plain
  - BUILD SUCCESSFUL
  - the old jackson main-source-set warning no longer appears

- .\gradlew.bat outgoingVariants --console=plain
  - BUILD SUCCESSFUL
  - jacksonApiElements still exists
  - jacksonRuntimeElements still exists
  - capability remains org.junit-pioneer:junit-pioneer-jackson
  - artifact remains build\libs\junit-pioneer.jar

- .\gradlew.bat test --console=plain
  - BUILD SUCCESSFUL

Unrelated warnings remain, including JaCoCo warnings under Java 24
and other existing deprecation notices. They are not changed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved packaging for the Jackson feature so it now ships as its own bundled component.
  * Updated dependency handling to better support Jackson during development and testing.
  * Refined published outputs to ensure the correct library artifact is delivered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->