### PR TITLE
Create member-name wrangling utility (#434)

### DIFF
--- a/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianFactoryArgumentsProvider.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/CartesianFactoryArgumentsProvider.java
@@ -15,6 +15,7 @@ import static org.junit.platform.commons.support.ReflectionSupport.invokeMethod;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.Optional;
 
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtensionConfigurationException;
@@ -65,10 +66,12 @@ class CartesianFactoryArgumentsProvider
 	}
 
 	private static Class<?> findExplicitOrImplicitClass(Method testMethod, String methodFactoryName) {
-		if (!methodFactoryName.contains("#"))
+		Optional<String> optionalClassName = MemberNameUtils.extractClassName(methodFactoryName);
+		if (optionalClassName.isEmpty()) {
 			return testMethod.getDeclaringClass();
+		}
 
-		String className = methodFactoryName.substring(0, methodFactoryName.indexOf('#'));
+		String className = optionalClassName.get();
 		Try<Class<?>> tryToLoadClass = ReflectionSupport.tryToLoadClass(className);
 		// step (outwards) through all enclosing classes, trying to load the factory class by appending
 		// its name to the enclosing class' name (if a previous load didn't already succeed

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/MemberNameUtils.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/MemberNameUtils.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junitpioneer.jupiter.cartesian;
+
+import java.util.Optional;
+
+/** Package private class to handle string splitting/manipulation in
+ * CartesianFactoryArgumentsProvider.java
+ * */
+class MemberNameUtils {
+
+	// utility class no-arg constructor
+	private MemberNameUtils() {
+	}
+
+	/** Extracts the method name from a String Reference. Examples are as follows:
+	 *
+	 * <p>Examples:
+	 *   <ul>
+	 * <li>"myMethod" => "myMethod"</li>
+	 * <li>"MyClass#myMethod" => "myMethod"</li>
+	 * <li>"MyClass#myMethod(int val)" => "myMethod" [regardless of parameters]</li>
+	 *   </ul>
+	 * </p>
+	 *
+	 * @param memberName  The String reference
+	 * @return {@link String} The extracted method name
+	 * @throws IllegalArgumentException  memberName cannot be null or empty
+	 * */
+	public static String extractMethodName(String memberName) {
+		if (memberName == null || memberName.isBlank()) { // do not use isEmpty()
+			throw new IllegalArgumentException("memberName reference cannot be null or empty");
+		}
+
+		String name = memberName;
+		if (name.contains("(")) {
+			name = name.substring(0, name.indexOf('('));
+		}
+
+		if (name.contains("#")) {
+			name = name.substring(name.indexOf('#') + 1);
+		}
+
+		// check if the string is empty
+		String trimmedName = name.trim();
+		if (trimmedName.isEmpty()) {
+			throw new IllegalArgumentException("memberName cannot be empty");
+		}
+
+		return trimmedName;
+	}
+
+	/** Extracts class name from String reference if present.
+	 *
+	 * @param memberName  The String reference
+	 * @return an {@code Optional<String>} The extracted class name, or empty if absent
+	 * @throws IllegalArgumentException  If memberName is null or not present
+	 * */
+	public static Optional<String> extractClassName(String memberName) {
+		if (memberName == null || !memberName.contains("#")) {
+			return Optional.empty();
+		}
+
+		String className = memberName.substring(0, memberName.indexOf('#')).trim();
+		return className.isEmpty() ? Optional.empty() : Optional.of(className);
+	}
+
+}

--- a/src/main/java/org/junitpioneer/jupiter/cartesian/MemberNameUtils.java
+++ b/src/main/java/org/junitpioneer/jupiter/cartesian/MemberNameUtils.java
@@ -61,8 +61,8 @@ class MemberNameUtils {
 	/** Extracts class name from String reference if present.
 	 *
 	 * @param memberName  The String reference
-	 * @return an {@code Optional<String>} The extracted class name, or empty if absent
-	 * @throws IllegalArgumentException  If memberName is null or not present
+	 * @return an {@code Optional<String>} containing the extracted class name. The extracted class name,
+	 * or empty if {@code memberName} is {@code null}, blank, or contains no class reference.
 	 * */
 	public static Optional<String> extractClassName(String memberName) {
 		if (memberName == null || !memberName.contains("#")) {

--- a/src/test/java/org/junitpioneer/jupiter/cartesian/MemberNameUtilsTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/cartesian/MemberNameUtilsTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * All rights reserved. This program and the accompanying materials are
+ * made available under the terms of the Eclipse Public License v2.0 which
+ * accompanies this distribution and is available at
+ *
+ * http://www.eclipse.org/legal/epl-v20.html
+ */
+
+package org.junitpioneer.jupiter.cartesian;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class MemberNameUtilsTests {
+
+	@ParameterizedTest(name = "[{index}] {arguments}")
+	@DisplayName("Should correctly extract method names from various String formats")
+	@CsvSource(useHeadersInDisplayName = true, delimiter = '|', value = { "input| expected", "myMethod| myMethod",
+			"MyClass#myMethod| myMethod", "MyClass#myMethod(int)| myMethod",
+			"MyClass#myMethod(int\\, String)| myMethod" })
+	void shouldExtractMethodName(String input, String expected) {
+		assertThat(MemberNameUtils.extractMethodName(input)).isEqualTo(expected);
+	}
+
+	@ParameterizedTest
+	@DisplayName("Should throw IllegalArgumentException when method reference name is null or empty.")
+	@NullAndEmptySource
+	@ValueSource(strings = { " ", "", "#", "MyClass#" })
+	void shouldThrowExceptionForInvalidMethodNameInput(String input) {
+		assertThatThrownBy(() -> MemberNameUtils.extractMethodName(input)).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@ParameterizedTest
+	@DisplayName("Should correctly extract class names when '#' separator exists")
+	@CsvSource(value = { "MyClass#myMethod, MyClass", "com.example.MyClass#myMethod, com.example.MyClass",
+			"com.example.MyClass#myMethod(int), com.example.MyClass" })
+	void shouldExtractClassName(String input, String expected) {
+		assertThat(MemberNameUtils.extractClassName(input)).contains(expected);
+	}
+
+	@ParameterizedTest
+	@DisplayName("Should return empty optional when no class name is provided")
+	@NullAndEmptySource
+	@ValueSource(strings = { "myMethod", "myMethod(int)", "#myMethod" })
+	void shouldReturnEmptyOptionalWhenThereIsNoClasName(String input) {
+		assertThat(MemberNameUtils.extractClassName(input)).isEmpty();
+	}
+
+}


### PR DESCRIPTION
Create member-name wrangling utility (#434 / #<PR-ID>)

CartesianFactoryArgumentsProvider requires parsing member names from
String references (such as class names and method signatures) to
discover and resolve test sources accurately.

This utility class centralizes member name parsing logic, handling:
 - class name extraction
 - method name extraction
 - validation for null and blank input strings

Closes: #434
PR: #<PR-ID>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved member-reference parsing for method names, including parameterized references and class prefixes.
  * Added support for extracting optional class names from references.
  * References without an explicit class now resolve against the test method’s declaring class.
  * Invalid, blank, or incomplete references are handled consistently.

* **Tests**
  * Added coverage for valid and invalid references, missing class names, blank inputs, and class-resolution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->