### PR TITLE
Allow reproducible dates for @DisabledUntil

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -119,6 +119,10 @@ Thank you for your efforts! ?
 
 The least we can do is to thank them and list some of their accomplishments here (in lexicographic order).
 
+==== 2026
+
+* https://github.com/Anikesh348[Anikesh348] added a reproducible execution date to the https://junit-pioneer.org/docs/disabled-until/[`@DisabledUntil` extension] (#688 / #882)
+
 ==== 2025
 
 * https://github.com/schosin[Ken Schosinsky] added support for `Named` to `@CartesianTestExtension` (#842 / #848)

--- a/docs/disabled-until.adoc
+++ b/docs/disabled-until.adoc
@@ -17,6 +17,7 @@ The test will be automatically executed again once the date supplied by the `dat
 ====
 Applying `@DisabledUntil` can make the test suite non-reproducible.
 If a failing test is disabled during a build that then passes, rerunning that build after the "until" date would fail.
+A fixed execution date can be configured to make reruns reproducible, as described below.
 A report entry is issued for every test that is disabled until a certain date.
 ====
 
@@ -47,6 +48,13 @@ include::{demo}[tag=disable_until_at_class_level]
 ----
 
 The `@DisabledUntil` annotation can only be used once per class or method.
+
+== Reproducible Builds
+
+By default, `@DisabledUntil` compares its `date` to the current date.
+To make a build reproducible, set the `org.junitpioneer.jupiter.disableduntil.executiondate` https://junit.org/junit5/docs/current/user-guide/#running-tests-config-params[configuration parameter] to the build's execution date in ISO 8601 format.
+For example, pass `-Dorg.junitpioneer.jupiter.disableduntil.executiondate=2026-08-27` when running the tests.
+An invalid configured date causes an `ExtensionConfigurationException`.
 
 == Before and After
 

--- a/src/main/java/org/junitpioneer/jupiter/DisabledUntil.java
+++ b/src/main/java/org/junitpioneer/jupiter/DisabledUntil.java
@@ -30,7 +30,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *
  * <p><strong>WARNING:</strong> Applying {@code @DisabledUntil} can make the test suite non-reproducible. If a failing
  * test is disabled during a build that then passes, rerunning that build after the "until" date would fail. A report
- * entry is issued for every test that is disabled until a certain date.</p>
+ * entry is issued for every test that is disabled until a certain date. Set the
+ * {@code org.junitpioneer.jupiter.disableduntil.executiondate} configuration parameter to the build's execution date
+ * as an ISO 8601 string to make reruns reproducible.</p>
  *
  * @since 1.6.0
  * @see org.junit.jupiter.api.Disabled

--- a/src/main/java/org/junitpioneer/jupiter/DisabledUntilExtension.java
+++ b/src/main/java/org/junitpioneer/jupiter/DisabledUntilExtension.java
@@ -32,6 +32,8 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  */
 class DisabledUntilExtension implements ExecutionCondition {
 
+	static final String EXECUTION_DATE_CONFIGURATION_PARAMETER = "org.junitpioneer.jupiter.disableduntil.executiondate";
+
 	private static final DateTimeFormatter ISO_8601 = DateTimeFormatter.ISO_DATE;
 
 	@Override
@@ -57,22 +59,37 @@ class DisabledUntilExtension implements ExecutionCondition {
 		}
 	}
 
+	private LocalDate parseExecutionDate(String dateString) {
+		try {
+			return LocalDate.parse(dateString, ISO_8601);
+		}
+		catch (DateTimeParseException ex) {
+			throw new ExtensionConfigurationException(
+				"The configuration parameter `" + EXECUTION_DATE_CONFIGURATION_PARAMETER + "` with value '" + dateString
+						+ "' is not a valid ISO-8601 date.",
+				ex);
+		}
+	}
+
 	private ConditionEvaluationResult evaluateUntilDate(ExtensionContext context, LocalDate untilDate) {
-		LocalDate today = LocalDate.now();
-		boolean disabled = today.isBefore(untilDate);
+		LocalDate executionDate = context
+				.getConfigurationParameter(EXECUTION_DATE_CONFIGURATION_PARAMETER)
+				.map(this::parseExecutionDate)
+				.orElseGet(LocalDate::now);
+		boolean disabled = executionDate.isBefore(untilDate);
 
 		if (disabled) {
 			String reportEntry = format(
 				"This test is disabled until %s. If executing it on this commit would fail, the build can't be reproduced after that date.",
 				untilDate.format(ISO_8601));
 			context.publishReportEntry("DisabledUntil", reportEntry);
-			String message = format("The `date` %s is after the current date %s", untilDate.format(ISO_8601),
-				today.format(ISO_8601));
+			String message = format("The `date` %s is after the execution date %s", untilDate.format(ISO_8601),
+				executionDate.format(ISO_8601));
 			return disabled(message);
 		} else {
 			String message = format(
-				"The `date` %s is before or on the current date %s, so `@DisabledUntil` no longer disabled test \"%s\". Please remove the annotation.",
-				untilDate.format(ISO_8601), today.format(ISO_8601), context.getUniqueId());
+				"The `date` %s is before or on the execution date %s, so `@DisabledUntil` no longer disabled test \"%s\". Please remove the annotation.",
+				untilDate.format(ISO_8601), executionDate.format(ISO_8601), context.getUniqueId());
 			context.publishReportEntry(DisabledUntilExtension.class.getSimpleName(), message);
 			return enabled(message);
 		}

--- a/src/test/java/org/junitpioneer/jupiter/DisabledUntilExtensionTests.java
+++ b/src/test/java/org/junitpioneer/jupiter/DisabledUntilExtensionTests.java
@@ -10,10 +10,12 @@
 
 package org.junitpioneer.jupiter;
 
+import static org.junitpioneer.jupiter.DisabledUntilExtension.EXECUTION_DATE_CONFIGURATION_PARAMETER;
 import static org.junitpioneer.testkit.assertion.PioneerAssert.assertThat;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Map;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -68,6 +70,34 @@ class DisabledUntilExtensionTests {
 		assertThat(results).hasNumberOfStartedTests(0);
 		assertThat(results).hasSingleSkippedTest();
 		assertThat(results).hasSingleReportEntry().firstValue().contains("2199-01-01", "reproduce");
+	}
+
+	@Test
+	@DisplayName("Should use configured execution date instead of current date")
+	void shouldUseConfiguredExecutionDate() {
+		final ExecutionResults results = PioneerTestKit
+				.executeTestMethodWithParameterTypesAndConfigurationParameters(
+					Map.of(EXECUTION_DATE_CONFIGURATION_PARAMETER, "1990-01-01"), DisabledUntilTestCases.class,
+					"testIsAnnotatedWithDateInThePast");
+		assertThat(results).hasNumberOfStartedTests(0);
+		assertThat(results).hasSingleSkippedTest();
+		assertThat(results).hasSingleReportEntry().firstValue().contains("1993-01-01", "reproduce");
+	}
+
+	@Test
+	@DisplayName("Should fail test with unparsable configured execution date")
+	void shouldFailTestWithUnparsableConfiguredExecutionDate() {
+		final ExecutionResults results = PioneerTestKit
+				.executeTestMethodWithParameterTypesAndConfigurationParameters(
+					Map.of(EXECUTION_DATE_CONFIGURATION_PARAMETER, "xxxx-yy-zz"), DisabledUntilTestCases.class,
+					"testIsAnnotatedWithDateInTheFuture");
+		assertThat(results).hasSingleStartedTest();
+		assertThat(results)
+				.hasSingleFailedTest()
+				.withException()
+				.hasMessageContaining(EXECUTION_DATE_CONFIGURATION_PARAMETER, "xxxx-yy-zz");
+		assertThat(results).hasNumberOfSkippedTests(0);
+		assertThat(results).hasNoReportEntries();
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

- Add an optional `org.junitpioneer.jupiter.disableduntil.executiondate` configuration parameter so `@DisabledUntil` can evaluate against a reproducible build date.
- Validate configured dates and document the parameter in the feature guide and Javadoc.

## Verification

- `./gradlew -g .gradle-user-home --no-daemon --max-workers=1 test --tests org.junitpioneer.jupiter.DisabledUntilExtensionTests` (7 tests passed with test parallelism disabled locally for this resource-constrained host; the repository setting was restored)
- `./gradlew -g .gradle-user-home --no-daemon --max-workers=1 -Duser.home="$PWD/.formatter-home" spotlessCheck`
- `git diff --check`

## Limitations

I did not run the full build because this is a narrow extension change. The project's default parallel test mode exceeded this host's native-thread limit, so I ran the focused suite sequentially instead.

Closes #688.

Proposed commit message:

```
Add reproducible DisabledUntil dates (#688 / #882)

Builds that use @DisabledUntil can become non-reproducible when they
are rerun after an annotation's date. Allowing callers to configure
the execution date keeps the condition result stable across reruns.

Closes: #688
```

---
**PR checklist**

The following checklist shall help the PR's author, the reviewers and maintainers to ensure the quality of this project.
It is based on our contributors guidelines, especially the ["writing code" section](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#writing-code).
It shall help to check for completion of the listed points.
If a point does not apply to the given PR's changes, the corresponding entry can be simply marked as done. 

Documentation (general)
* [ ] There is documentation (Javadoc and site documentation; added or updated)
* [ ] There is implementation information to describe _why_ a non-obvious source code / solution got implemented
* [ ] Site documentation has its own `.adoc` file in the `docs` folder, e.g. `docs/report-entries.adoc`
* [ ] Site documentation in `.adoc` file references demo in `src/demo/java` instead of containing code blocks as text
* [ ] Only one sentence per line (especially in `.adoc` files)
* [ ] Javadoc uses formal style, while sites documentation may use informal style

Documentation (new extension)
* [ ] The `docs/docs-nav.yml` navigation has an entry for the new extension
* [ ] The `package-info.java` contains information about the new extension

Code (general)
* [ ] Code adheres to code style, naming conventions etc.
* [ ] Successful tests cover all changes
* [ ] There are checks which validate correct / false usage / configuration of a functionality and there are tests to verify those checks
* [ ] Tests use [AssertJ](https://assertj.github.io/doc/) or our own [PioneerAssert](https://github.com/junit-pioneer/junit-pioneer/blob/main/CONTRIBUTING.adoc#assertions) (which are based on AssertJ)

Code (new package)
* [ ] The new package is exported in `module-info.java`
* [ ] The new package is also present in the tests
* [ ] The new package is opened for reflection to JUnit 5 in `module-info.java`
* [ ] The new package is listed in the contribution guide

Contributing
* [ ] A prepared commit message exists
* [ ] The list of contributions inside `README.adoc` mentions the new contribution (real name optional) 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional fixed execution-date setting for `@DisabledUntil`.
  * Supports ISO 8601 dates to make test reruns reproducible.
  * Invalid dates now produce a clear configuration error.
  * Without a configured date, behavior continues to use the current date.

* **Documentation**
  * Updated `@DisabledUntil` documentation with configuration details and reproducible-build guidance.
  * Added a new contributor recognition entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->